### PR TITLE
维修子机目标问题修复

### DIFF
--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -142,16 +142,14 @@ DEFINE_HOOK(0x6B79BF, SpawnManagerClass_AI_CheckRepairDone, 0x5)
 	enum { ResetTarget = 0x6B79C4, KeepTarget = 0x6B79D3 };
 	GET(SpawnManagerClass*, pThis, ESI);
 
+	if (!pThis->Target)
+		return ResetTarget;
+
 	if (pThis->Owner->CombatDamage(-1) < 0)
 	{
 		auto pTarget = abstract_cast<TechnoClass*>(pThis->Target);
 
 		if (pTarget && pTarget->GetHealthPercentage() >= RulesClass::Instance->unknown_double_16F8)
-			return ResetTarget;
-	}
-	else
-	{
-		if (!pThis->Target)
 			return ResetTarget;
 	}
 

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -137,6 +137,27 @@ DEFINE_HOOK(0x6B7282, SpawnManagerClass_AI_PromoteSpawns, 0x5)
 	return 0;
 }
 
+DEFINE_HOOK(0x6B79BF, SpawnManagerClass_AI_CheckRepairDone, 0x5)
+{
+	enum { ResetTarget = 0x6B79C4, KeepTarget = 0x6B79D3 };
+	GET(SpawnManagerClass*, pThis, ESI);
+
+	if (pThis->Owner->CombatDamage(-1) < 0)
+	{
+		auto pTarget = abstract_cast<TechnoClass*>(pThis->Target);
+
+		if (pTarget && pTarget->GetHealthPercentage() > RulesClass::Instance->unknown_double_16F8)
+			return ResetTarget;
+	}
+	else
+	{
+		if (!pThis->Target)
+			return ResetTarget;
+	}
+
+	return KeepTarget;
+}
+
 #pragma endregion
 
 #pragma region WakeAnims

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -146,7 +146,7 @@ DEFINE_HOOK(0x6B79BF, SpawnManagerClass_AI_CheckRepairDone, 0x5)
 	{
 		auto pTarget = abstract_cast<TechnoClass*>(pThis->Target);
 
-		if (pTarget && pTarget->GetHealthPercentage() > RulesClass::Instance->unknown_double_16F8)
+		if (pTarget && pTarget->GetHealthPercentage() >= RulesClass::Instance->unknown_double_16F8)
 			return ResetTarget;
 	}
 	else


### PR DESCRIPTION
原本游戏中，用子机对目标进行维修的单位在修理完毕后不会自动重设维修目标，这使得子机会一直盘旋在目标周围。
现在我们修复了这个问题。
无ini，强制开启。
