### PR TITLE
维修武器索敌硬编码修复

### DIFF
--- a/src/Ext/Techno/Hooks.TargetEvaluation.cpp
+++ b/src/Ext/Techno/Hooks.TargetEvaluation.cpp
@@ -72,6 +72,16 @@ DEFINE_HOOK(0x6F7E47, TechnoClass_EvaluateObject_MapZone, 0x7)
 	return AllowedObject;
 }
 
+// Fix the hardcode of healing weapon can't acquire in air target.
+DEFINE_HOOK(0x6F9222, TechnoClass_SelectAutoTarget_HealingTargetAir, 0x6)
+{
+	GET(TechnoClass*, pThis, ESI);
+	return pThis->CombatDamage(-1) < 0 ? 0x6F922E : 0;
+}
+
+// Skip the hardcode of healing weapon auto target range.
+DEFINE_JUMP(LJMP, 0x6F9024, 0x6F9042);
+
 #pragma endregion
 
 #pragma region Walls


### PR DESCRIPTION
 2-69. 维修武器索敌硬编码修复
在原版游戏中，维修武器索敌距离强制为512，而且无法获取空中的目标。
现在它们都可以正常工作了。
无ini，强制开启。
注意：索敌距离的改动和wic同款功能可以共存。