### PR TITLE
一堆

### DIFF
--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -358,7 +358,9 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->UpdateInLimbo_LimboLaunch.Read(exINI, GameStrings::General, "UpdateInLimbo.Parasite");
 
 	this->InvisoLatencyFix.Read(exINI, GameStrings::General, "InvisoLatencyFix");
-	this->RetaliateIfNoTargetAssigned.Read(exINI, GameStrings::General, "RetaliateIfNoTargetAssigned");
+
+	this->CanAttackMeThreatBonus.Read(exINI, GameStrings::General, "CanAttackMeThreatBonus");
+	this->ExtraTargeting_OnNoTargetAssigned.Read(exINI, GameStrings::General, "ExtraTargeting.OnNoTargetAssigned");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -675,7 +677,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->UpdateInLimbo_NormalPassenger)
 		.Process(this->UpdateInLimbo_LimboLaunch)
 		.Process(this->InvisoLatencyFix)
-		.Process(this->RetaliateIfNoTargetAssigned)
+		.Process(this->CanAttackMeThreatBonus)
+		.Process(this->ExtraTargeting_OnNoTargetAssigned)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -358,6 +358,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->UpdateInLimbo_LimboLaunch.Read(exINI, GameStrings::General, "UpdateInLimbo.Parasite");
 
 	this->InvisoLatencyFix.Read(exINI, GameStrings::General, "InvisoLatencyFix");
+	this->RetaliateIfNoTargetAssigned.Read(exINI, GameStrings::General, "RetaliateIfNoTargetAssigned");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -674,6 +675,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->UpdateInLimbo_NormalPassenger)
 		.Process(this->UpdateInLimbo_LimboLaunch)
 		.Process(this->InvisoLatencyFix)
+		.Process(this->RetaliateIfNoTargetAssigned)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -316,7 +316,8 @@ public:
 		Valueable<bool> UpdateInLimbo_LimboLaunch;
 
 		Valueable<bool> InvisoLatencyFix;
-		Valueable<bool> RetaliateIfNoTargetAssigned;
+		Valueable<double> CanAttackMeThreatBonus;
+		Valueable<bool> ExtraTargeting_OnNoTargetAssigned;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -575,7 +576,9 @@ public:
 			, UpdateInLimbo_NormalPassenger { false }
 			, UpdateInLimbo_LimboLaunch { false }
 			, InvisoLatencyFix { false }
-			, RetaliateIfNoTargetAssigned { false }
+
+			, CanAttackMeThreatBonus { false }
+			, ExtraTargeting_OnNoTargetAssigned { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -316,6 +316,7 @@ public:
 		Valueable<bool> UpdateInLimbo_LimboLaunch;
 
 		Valueable<bool> InvisoLatencyFix;
+		Valueable<bool> RetaliateIfNoTargetAssigned;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -574,6 +575,7 @@ public:
 			, UpdateInLimbo_NormalPassenger { false }
 			, UpdateInLimbo_LimboLaunch { false }
 			, InvisoLatencyFix { false }
+			, RetaliateIfNoTargetAssigned { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -577,7 +577,7 @@ public:
 			, UpdateInLimbo_LimboLaunch { false }
 			, InvisoLatencyFix { false }
 
-			, CanAttackMeThreatBonus { false }
+			, CanAttackMeThreatBonus { 0.0 }
 			, ExtraTargeting_OnNoTargetAssigned { false }
 		{ }
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -709,6 +709,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->AggressiveStance)
 		.Process(this->KeepTargetOnMove)
 		.Process(this->LastSensorsMapCoords)
+		.Process(this->PlayerAssignedLastTarget)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -86,6 +86,7 @@ public:
 		CellStruct LastSensorsMapCoords;
 
 		bool AggressiveStance;                  // Aggressive stance that will auto target buildings
+		AbstractClass* PlayerAssignedLastTarget;
 
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, TypeExtData { nullptr }
@@ -147,6 +148,7 @@ public:
 			, AggressiveStance { false }
 			, KeepTargetOnMove { false }
 			, LastSensorsMapCoords { CellStruct::Empty }
+			, PlayerAssignedLastTarget { }
 		{ }
 
 		void OnEarlyUpdate();

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -576,34 +576,6 @@ DEFINE_HOOK(0x74691D, UnitClass_UpdateDisguise_EMP, 0x6)
 
 #pragma endregion
 
-#pragma region ReturnFire
-
-DEFINE_HOOK(0x702B31, TechnoClass_ReceiveDamage_ReturnFireCheck, 0x7)
-{
-	enum { SkipReturnFire = 0x702B47, NotSkip = 0 };
-
-	GET(TechnoClass* const, pThis, ESI);
-
-	auto const pOwner = pThis->Owner;
-
-	if (!(pOwner->IsHumanPlayer || pOwner->IsInPlayerControl) || !RulesExt::Global()->PlayerReturnFire_Smarter)
-		return NotSkip;
-	else if (pThis->Target)
-		return SkipReturnFire;
-
-	auto const pThisFoot = abstract_cast<FootClass*>(pThis);
-
-	if (!pThisFoot)
-		return NotSkip;
-
-	auto const mission = pThis->CurrentMission;
-	const bool isJJMoving = pThisFoot->GetHeight() > Unsorted::CellHeight && mission == Mission::Move && pThisFoot->Locomotor->Is_Moving_Now();
-
-	return (isJJMoving || (mission == Mission::Move && pThisFoot->GetHeight() <= 0)) ? SkipReturnFire : NotSkip;
-}
-
-#pragma endregion
-
 #pragma region AttackMindControlledDelay
 
 bool __fastcall CanAttackMindControlled(TechnoClass* pControlled, TechnoClass* pRetaliator)

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -1906,13 +1906,14 @@ DEFINE_HOOK(0x703B0B, TechnoClass_VisualCharacter_Normal, 0x5)
 		const auto pThis = VisualCharacterContext::pThis;
 		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
 		const auto pOwner = pThis->Owner;
+		const auto defaultValue = pTypeExt->DefaultVisualCharacter;
 
 		if (pOwner == pWatcher)
-			R->EAX(static_cast<VisualType>(pTypeExt->DefaultVisualCharacterToSelf.Get()));
+			R->EAX(static_cast<VisualType>(pTypeExt->DefaultVisualCharacterToSelf.Get(defaultValue)));
 		else if (pOwner->IsAlliedWith(pWatcher))
-			R->EAX(static_cast<VisualType>(pTypeExt->DefaultVisualCharacterToAlly.Get()));
+			R->EAX(static_cast<VisualType>(pTypeExt->DefaultVisualCharacterToAlly.Get(defaultValue)));
 		else
-			R->EAX(static_cast<VisualType>(pTypeExt->DefaultVisualCharacterToEnemy.Get()));
+			R->EAX(static_cast<VisualType>(pTypeExt->DefaultVisualCharacterToEnemy.Get(defaultValue)));
 	}
 	else
 	{
@@ -1938,13 +1939,14 @@ static inline bool ShouldIgnoreByMouse(ObjectClass* pObject)
 		const auto pTechno = static_cast<TechnoClass*>(pObject);
 		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType());
 		const auto pOwner = pTechno->Owner;
+		const auto defaultValue = pTypeExt->IgnoredByMouse;
 
 		if (pOwner == HouseClass::CurrentPlayer)
-			return pTypeExt->IgnoredByMouse_ToSelf.Get();
+			return pTypeExt->IgnoredByMouse_ToSelf.Get(defaultValue);
 		else if (pOwner->IsAlliedWith(HouseClass::CurrentPlayer))
-			return pTypeExt->IgnoredByMouse_ToAlly.Get();
+			return pTypeExt->IgnoredByMouse_ToAlly.Get(defaultValue);
 
-		return pTypeExt->IgnoredByMouse_ToEnemy.Get();
+		return pTypeExt->IgnoredByMouse_ToEnemy.Get(defaultValue);
 	}
 
 	const auto absType = pObject->WhatAmI();

--- a/src/Ext/Techno/Hooks.TargetEvaluation.cpp
+++ b/src/Ext/Techno/Hooks.TargetEvaluation.cpp
@@ -54,6 +54,106 @@ DEFINE_HOOK(0x4C73B0, EventClass_RespondToEvent_RecordTarget, 0x6)
 	return 0;
 }
 
+bool IsAThreatToMe(TechnoClass* pTechno, AbstractClass* pTarget)
+{
+	auto pTechnoTarget = abstract_cast<TechnoClass*>(pTarget);
+	bool targetThreat = false;
+
+	if (pTechnoTarget)
+	{
+		auto error = pTechnoTarget->GetFireError(pTechno, pTechnoTarget->SelectWeapon(pTechno), false);
+		targetThreat = pTechnoTarget->WhatAmI() == AbstractType::Building ? (error != FireError::ILLEGAL) && (error != FireError::RANGE) : (error != FireError::ILLEGAL);
+	}
+
+	return targetThreat;
+}
+
+bool IsAssignedTarget(TechnoClass* pTechno, AbstractClass* pTarget)
+{
+	auto pExt = TechnoExt::ExtMap.Find(pTechno);
+	return pTarget && pExt->PlayerAssignedLastTarget == pTarget;
+}
+
+DEFINE_HOOK(0x702B31, TechnoClass_ReceiveDamage_ReturnFireCheck, 0x7)
+{
+	enum { SkipReturnFire = 0x702B47 };
+
+	GET(TechnoClass* const, pThis, ESI);
+	GET_STACK(TechnoClass*, pAttacker, STACK_OFFSET(0xC4, 0x10));
+
+	auto const pOwner = pThis->Owner;
+
+	// Vanilla behavior.
+	if (!pOwner->IsControlledByHuman() || !RulesExt::Global()->PlayerReturnFire_Smarter)
+		return 0;
+
+	// Too far. Can't attack.
+	if (!pThis->IsCloseEnoughToAttack(pAttacker))
+		return SkipReturnFire;
+
+	auto pCurrentTarget = pThis->Target;
+
+	// Target is assigned by player. I must kill it first.
+	if (IsAssignedTarget(pThis, pCurrentTarget))
+		return SkipReturnFire;
+
+	// Current target may hurt me. I must kill it first.
+	if (IsAThreatToMe(pThis, pCurrentTarget) && pThis->IsCloseEnoughToAttack(pCurrentTarget))
+		return SkipReturnFire;
+
+	// OK I will attack it, but no override mission.
+	pThis->SetTarget(pAttacker);
+	pThis->QueueMission(Mission::Attack, false);
+	return SkipReturnFire;
+}
+
+DEFINE_HOOK(0x708859, TechnoClass_CanRetaliate_SmarterReturnFire, 0x6)
+{
+	enum { CanRetaliate = 0x708867 };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	auto pTarget = pThis->Target;
+
+	return RulesClass::Instance->PlayerReturnFire
+		&& RulesExt::Global()->PlayerReturnFire_Smarter
+		&& !IsAssignedTarget(pThis, pTarget)
+		&& !(IsAThreatToMe(pThis, pTarget) && pThis->IsCloseEnoughToAttack(pTarget))
+		? CanRetaliate : 0;
+}
+
+DEFINE_HOOK(0x6FA697, TechnoClass_Update_AutoTargetMissionCheck, 0x6)
+{
+	enum { CanTargeting = 0x6FA6AC };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	return pThis->CurrentMission == Mission::Attack && RulesExt::Global()->ExtraTargeting_OnNoTargetAssigned ? CanTargeting : 0;
+}
+
+DEFINE_HOOK(0x7093E9, TechnoClass_CanPassiveAquireNow_MissionCheck, 0x7)
+{
+	enum { CanTargeting = 0x7093F8 };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	auto pTarget = pThis->Target;
+
+	return pThis->CurrentMission == Mission::Attack
+		&& RulesExt::Global()->ExtraTargeting_OnNoTargetAssigned
+		&& !IsAssignedTarget(pThis, pTarget)
+		&& !(IsAThreatToMe(pThis, pTarget) && pThis->IsCloseEnoughToAttack(pTarget))
+		? CanTargeting : 0;
+}
+
+DEFINE_HOOK(0x70CF1D, TechnoClass_ThreatCoefficient_CanAttackMeThreatBonus, 0x6)
+{
+	REF_STACK(double, totalThreat, STACK_OFFSET(0x58, -0x48));
+
+	totalThreat += RulesExt::Global()->CanAttackMeThreatBonus;
+	return 0;
+}
+
 #pragma endregion
 
 #pragma region MapZone

--- a/src/Ext/Techno/Hooks.TargetEvaluation.cpp
+++ b/src/Ext/Techno/Hooks.TargetEvaluation.cpp
@@ -1,6 +1,7 @@
 #include "Body.h"
 
 #include <Ext/BuildingType/Body.h>
+#include <EventClass.h>
 
 // Cursor & target acquisition stuff not directly tied to other features can go here.
 
@@ -37,6 +38,21 @@ FireError __fastcall TechnoClass_TargetSomethingNearby_CanFire_Wrapper(TechnoCla
 }
 
 DEFINE_FUNCTION_JUMP(CALL6, 0x7098E6, TechnoClass_TargetSomethingNearby_CanFire_Wrapper);
+
+DEFINE_HOOK(0x4C73B0, EventClass_RespondToEvent_RecordTarget, 0x6)
+{
+	GET(EventClass*, pThis, ESI);
+	GET(TechnoClass*, pTechno, EDI);
+	GET(Mission, mission, EAX);
+
+	if (mission == Mission::Attack)
+	{
+		auto pExt = TechnoExt::ExtMap.Find(pTechno);
+		pExt->PlayerAssignedLastTarget = pThis->MegaMission.Target;
+	}
+
+	return 0;
+}
 
 #pragma endregion
 

--- a/src/Ext/Techno/Hooks.TargetEvaluation.cpp
+++ b/src/Ext/Techno/Hooks.TargetEvaluation.cpp
@@ -102,8 +102,9 @@ DEFINE_HOOK(0x702B31, TechnoClass_ReceiveDamage_ReturnFireCheck, 0x7)
 		return SkipReturnFire;
 
 	// OK I will attack it, but no override mission.
-	pThis->SetTarget(pAttacker);
-	pThis->QueueMission(Mission::Attack, false);
+	pThis->Target = pAttacker; // 如果使用 Settter，当 pAttacker 为建筑时单位会停下。我不知道这是为什么。
+	// pThis->SetTarget(pAttacker);
+	// pThis->QueueMission(Mission::Attack, false);
 	return SkipReturnFire;
 }
 
@@ -152,6 +153,21 @@ DEFINE_HOOK(0x70CF1D, TechnoClass_ThreatCoefficient_CanAttackMeThreatBonus, 0x6)
 
 	totalThreat += RulesExt::Global()->CanAttackMeThreatBonus;
 	return 0;
+}
+
+DEFINE_HOOK(0x709918, TechnoClass_TargetAndEstimateDamage_CheckTarget, 0x6)
+{
+	enum { CanTargeting = 0x709926 };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	auto pTarget = pThis->Target;
+
+	return pTarget
+		&& RulesExt::Global()->ExtraTargeting_OnNoTargetAssigned
+		&& !IsAssignedTarget(pThis, pTarget)
+		&& !(IsAThreatToMe(pThis, pTarget) && pThis->IsCloseEnoughToAttack(pTarget))
+		? CanTargeting : 0;
 }
 
 #pragma endregion

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -840,6 +840,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->RadarInvisible_ToSelf.Read(exINI, pSection, "RadarInvisible.ToSelf");
 	this->RadarInvisible_ToAlly.Read(exINI, pSection, "RadarInvisible.ToAlly");
 
+	this->IgnoredByMouse.Read(exINI, pSection, "IgnoredByMouse");
 	this->IgnoredByMouse_ToSelf.Read(exINI, pSection, "IgnoredByMouse.ToSelf");
 	this->IgnoredByMouse_ToAlly.Read(exINI, pSection, "IgnoredByMouse.ToAlly");
 	this->IgnoredByMouse_ToEnemy.Read(exINI, pSection, "IgnoredByMouse.ToEnemy");
@@ -968,6 +969,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 			this->AlternateFLHs.push_back(alternateFLH);
 	}
 
+	this->DefaultVisualCharacter.Read(exArtINI, pArtSection, "DefaultVisualCharacter");
 	this->DefaultVisualCharacterToSelf.Read(exArtINI, pArtSection, "DefaultVisualCharacterToSelf");
 	this->DefaultVisualCharacterToAlly.Read(exArtINI, pArtSection, "DefaultVisualCharacterToAlly");
 	this->DefaultVisualCharacterToEnemy.Read(exArtINI, pArtSection, "DefaultVisualCharacterToEnemy");
@@ -1416,10 +1418,12 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->RadarInvisible_ToSelf)
 		.Process(this->RadarInvisible_ToAlly)
 
+		.Process(this->DefaultVisualCharacter)
 		.Process(this->DefaultVisualCharacterToSelf)
 		.Process(this->DefaultVisualCharacterToAlly)
 		.Process(this->DefaultVisualCharacterToEnemy)
 
+		.Process(this->IgnoredByMouse)
 		.Process(this->IgnoredByMouse_ToSelf)
 		.Process(this->IgnoredByMouse_ToAlly)
 		.Process(this->IgnoredByMouse_ToEnemy)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -402,9 +402,10 @@ public:
 		Valueable<bool> RadarInvisible_ToSelf;
 		Valueable<bool> RadarInvisible_ToAlly;
 
-		Valueable<int> DefaultVisualCharacterToSelf;
-		Valueable<int> DefaultVisualCharacterToAlly;
-		Valueable<int> DefaultVisualCharacterToEnemy;
+		Valueable<int> DefaultVisualCharacter;
+		Nullable<int> DefaultVisualCharacterToSelf;
+		Nullable<int> DefaultVisualCharacterToAlly;
+		Nullable<int> DefaultVisualCharacterToEnemy;
 
 		Valueable<bool> Cloneable;
 		ValueableVector<BuildingTypeClass*> ClonedAt;
@@ -439,9 +440,10 @@ public:
 		std::vector<std::vector<CoordStruct>> DeployedWeaponBurstFLHs;
 		std::vector<std::vector<CoordStruct>> EliteDeployedWeaponBurstFLHs;
 
-		Valueable<bool> IgnoredByMouse_ToSelf;
-		Valueable<bool> IgnoredByMouse_ToAlly;
-		Valueable<bool> IgnoredByMouse_ToEnemy;
+		Valueable<bool> IgnoredByMouse;
+		Nullable<bool> IgnoredByMouse_ToSelf;
+		Nullable<bool> IgnoredByMouse_ToAlly;
+		Nullable<bool> IgnoredByMouse_ToEnemy;
 
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
@@ -820,13 +822,15 @@ public:
 			, RadarInvisible_ToSelf { false }
 			, RadarInvisible_ToAlly { false }
 
-			, DefaultVisualCharacterToSelf { 0 }
-			, DefaultVisualCharacterToAlly { 0 }
-			, DefaultVisualCharacterToEnemy { 0 }
+			, DefaultVisualCharacter { 0 }
+			, DefaultVisualCharacterToSelf { }
+			, DefaultVisualCharacterToAlly { }
+			, DefaultVisualCharacterToEnemy { }
 
-			, IgnoredByMouse_ToSelf { false }
-			, IgnoredByMouse_ToAlly { false }
-			, IgnoredByMouse_ToEnemy { false }
+			, IgnoredByMouse { false }
+			, IgnoredByMouse_ToSelf { }
+			, IgnoredByMouse_ToAlly { }
+			, IgnoredByMouse_ToEnemy { }
 
 			, Cloneable { true }
 			, ClonedAt { }


### PR DESCRIPTION
（改进了功能）
原本游戏有一个PlayerReturnFire的flag，但是它会让单位在挨打时无论是否有命令都直接去攻击开火者，非常愚蠢。
现在大幅优化了PlayerReturnFire的逻辑，现在只有开火者位于射程内且具有比当前目标更高优先级时才会进行还击，而且仅将开火者设为目标而不会跑过去打。

[CombatDamage]
PlayerReturnFire.Smarter=no   ; 是否优化PlayerReturnFire的判定

 2-70. 额外索敌时机（增加了第三个标签）
现在你可以让单位在一些额外的事件点进行索敌。

[General]
ExtraTargeting.OnLoseTarget=false                ；当单位处于攻击任务且目标消失时是否额外索敌一次
ExtraTargeting.OnStopCommand=false          ；当单位按下s键时是否额外索敌一次
ExtraTargeting.OnNoTargetAssigned=false     ；当单位攻击的目标不是玩家手动指定的时候是否仍执行周期性索敌

 2-73. 可以攻击索敌者额外仇恨（新功能）
现在你可以让单位在进行仇恨计算时考虑目标是否可能攻击到索敌者，如果可以的话则具有额外仇恨。
仇恨具体算法参考modenc。
对于建筑目标而言，索敌者处于其射程内时才被认为可以攻击到索敌者。

[General]
CanAttackMeThreatBonus=0.0            ；浮点数，目标可以攻击索敌者时具有的额外仇恨

 2-65. 默认透明度（增加了默认值）
在原本游戏中，单位会在隐形时产生透明度变化。
现在你可以让单位在默认情况下也具有透明度。
注意1：这个并非单纯的视觉效果，例如当透明度处于隐藏状态时单位就无法被选中。遇到任何意料之外的情况请反馈。
注意2：本效果只影响默认情况下的透明度，当单位进入隐形等状态时就会使用本来应当处于的透明度。
注意3：透明度是0到5之间的整数。大致来说0到3依次透明度提高，4是被冲击波影响，5是隐形状态完全不可见。具体效果请自行尝试。

在 artmd.ini
[SomeTechno]
DefaultVisualCharacter=0               ；默认透明度
DefaultVisualCharacterToSelf=       ；对自己的默认透明度，覆盖DefaultVisualCharacter
DefaultVisualCharacterToAlly=       ；对友方的默认透明度，覆盖DefaultVisualCharacter
DefaultVisualCharacterToEnemy=  ；对敌人的默认透明度，覆盖DefaultVisualCharacter

 2-66. 鼠标忽略的物件（增加了默认值）
现在你可以让一些物件（ObjectClass）被鼠标忽略。
被忽略的物件在鼠标指针指向它时不会影响指针的行为，指针点击也无法以这些物件为目标。
被忽略的物件可以被框选t选等选中。
注意：这个效果仅影响指针，单位仍然完全正常地处于地图上，索敌弹头等效果都能正常对其产生效果。

[SomeTerrain]
IgnoreByMouse=false                        ；鼠标是否忽略

[SomeOverlay]
IgnoreByMouse=false                        ；鼠标是否忽略

[SomeTechno]
IgnoreByMouse=false                 ；鼠标是否忽略
IgnoreByMouse.ToSelf=              ；己方鼠标是否忽略，覆盖IgnoreByMouse
IgnoreByMouse.ToAlly=              ；友方鼠标是否忽略，覆盖IgnoreByMouse
IgnoreByMouse.ToEnemy=         ；敌方鼠标是否忽略，覆盖IgnoreByMouse
