### PR TITLE
统一雷达颜色

### DIFF
--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -363,6 +363,15 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->InvisoLatencyFix.Read(exINI, GameStrings::General, "InvisoLatencyFix");
 
+	this->UnifiedRadarColor.Read(exINI, GameStrings::AudioVisual, "UnifiedRadarColor");
+	this->UnifiedRadarColor_Self.Read(exINI, GameStrings::AudioVisual, "UnifiedRadarColor.Self");
+	this->UnifiedRadarColor_Ally.Read(exINI, GameStrings::AudioVisual, "UnifiedRadarColor.Ally");
+	this->UnifiedRadarColor_Enemy.Read(exINI, GameStrings::AudioVisual, "UnifiedRadarColor.Enemy");
+	this->UnifiedRadarColor_Neutral.Read(exINI, GameStrings::AudioVisual, "UnifiedRadarColor.Neutral");
+	this->UnifiedRadarColor_Land.Read(exINI, GameStrings::AudioVisual, "UnifiedRadarColor.Land");
+	this->UnifiedRadarColor_Water.Read(exINI, GameStrings::AudioVisual, "UnifiedRadarColor.Water");
+	this->UnifiedRadarColor_Cliff.Read(exINI, GameStrings::AudioVisual, "UnifiedRadarColor.Cliff");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -681,6 +690,14 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->UpdateInLimbo_NormalPassenger)
 		.Process(this->UpdateInLimbo_LimboLaunch)
 		.Process(this->InvisoLatencyFix)
+		.Process(this->UnifiedRadarColor)
+		.Process(this->UnifiedRadarColor_Self)
+		.Process(this->UnifiedRadarColor_Ally)
+		.Process(this->UnifiedRadarColor_Enemy)
+		.Process(this->UnifiedRadarColor_Neutral)
+		.Process(this->UnifiedRadarColor_Land)
+		.Process(this->UnifiedRadarColor_Water)
+		.Process(this->UnifiedRadarColor_Cliff)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -321,6 +321,15 @@ public:
 
 		Valueable<bool> InvisoLatencyFix;
 
+		Valueable<bool> UnifiedRadarColor;
+		Valueable<ColorStruct> UnifiedRadarColor_Self;
+		Valueable<ColorStruct> UnifiedRadarColor_Ally;
+		Valueable<ColorStruct> UnifiedRadarColor_Enemy;
+		Valueable<ColorStruct> UnifiedRadarColor_Neutral;
+		Valueable<ColorStruct> UnifiedRadarColor_Land;
+		Valueable<ColorStruct> UnifiedRadarColor_Water;
+		Valueable<ColorStruct> UnifiedRadarColor_Cliff;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, InfantryGainSelfHealCap {}
@@ -581,6 +590,14 @@ public:
 			, UpdateInLimbo_NormalPassenger { false }
 			, UpdateInLimbo_LimboLaunch { false }
 			, InvisoLatencyFix { false }
+			, UnifiedRadarColor { false }
+			, UnifiedRadarColor_Self { ColorStruct(0,255,0) }
+			, UnifiedRadarColor_Ally { ColorStruct(255,255,0) }
+			, UnifiedRadarColor_Enemy { ColorStruct(255,0,0) }
+			, UnifiedRadarColor_Neutral { ColorStruct(255,255,255) }
+			, UnifiedRadarColor_Land { ColorStruct(255,127,0) }
+			, UnifiedRadarColor_Water { ColorStruct(95,127,207) }
+			, UnifiedRadarColor_Cliff { ColorStruct(63,63,63) }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -1874,6 +1874,69 @@ DEFINE_HOOK(0x655DDD, RadarClass_ProcessPoint_RadarInvisible, 0x6)
 	return isInShrouded && !pTechnoOwner->IsControlledByCurrentPlayer() ? Invisible : GoOtherChecks;
 }
 
+DEFINE_HOOK(0x655F80, RadarClass_ProcessPoint_UnifiedRadarColor, 0x6)
+{
+	enum { SkipGameCode = 0x655FEB };
+
+	GET_STACK(HouseClass*, pOwner, STACK_OFFSET(0x40, 0x4));
+
+	auto pRulesExt = RulesExt::Global();
+
+	if (!pRulesExt->UnifiedRadarColor)
+		return 0;
+
+	int colorCode = 0;
+
+	if (pOwner->Type->MultiplayPassive)
+	{
+		colorCode = Drawing::RGB_To_Int(pRulesExt->UnifiedRadarColor_Neutral);
+	}
+	else if (pOwner->IsControlledByCurrentPlayer())
+	{
+		colorCode = Drawing::RGB_To_Int(pRulesExt->UnifiedRadarColor_Self);
+	}
+	else if (HouseClass::CurrentPlayer->IsAlliedWith(pOwner))
+	{
+		colorCode = Drawing::RGB_To_Int(pRulesExt->UnifiedRadarColor_Ally);
+	}
+	else
+	{
+		colorCode = Drawing::RGB_To_Int(pRulesExt->UnifiedRadarColor_Enemy);
+	}
+
+	R->EBX(colorCode);
+	return SkipGameCode;
+}
+
+DEFINE_HOOK(0x47C329, CellClass_GetRadarColor_UnifiedRadarColor, 0x7)
+{
+	REF_STACK(ColorStruct, rgb1, STACK_OFFSET(0x14, -0x8));
+	REF_STACK(ColorStruct, rgb2, STACK_OFFSET(0x14, -0xC));
+	GET(CellClass*, pThis, ESI);
+
+	auto pRulesExt = RulesExt::Global();
+
+	if (!pRulesExt->UnifiedRadarColor)
+		return 0;
+
+	if (pThis->Tile_Is_Cliff())
+	{
+		rgb1 = pRulesExt->UnifiedRadarColor_Cliff;
+	}
+	else if (pThis->Tile_Is_Water())
+	{
+		rgb1 = pRulesExt->UnifiedRadarColor_Water;
+	}
+	else
+	{
+		rgb1 = pRulesExt->UnifiedRadarColor_Land;
+	}
+
+	rgb2 = rgb1;
+
+	return 0;
+}
+
 #pragma endregion
 
 #pragma region VisualCharacter


### PR DESCRIPTION

 2-76. 统一雷达颜色
现在你可以让小地图按照以下分类进行分配颜色，而非使用每个物件自身的雷达颜色。

[AudioVisual]
UnifiedRadarColor=false                           ；是否使用统一的雷达颜色
UnifiedRadarColor.Self=0,255,0                 ；己方的颜色，RGB（0到255的3维向量）
UnifiedRadarColor.Ally=255,255,0              ；友方的颜色
UnifiedRadarColor.Enemy=255,0,0             ；敌方的颜色
UnifiedRadarColor.Neutral=255,255,255    ；中立方的颜色
UnifiedRadarColor.Land=255,127,0            ；陆地的颜色
UnifiedRadarColor.Water=95,127,207         ；水面的颜色
UnifiedRadarColor.Cliff=63,63,63               ；悬崖的颜色