### PR TITLE
弹头仅伤害目标本身

### DIFF
--- a/src/Ext/Bullet/Hooks.DetonateLogics.cpp
+++ b/src/Ext/Bullet/Hooks.DetonateLogics.cpp
@@ -78,24 +78,13 @@ DEFINE_HOOK(0x469A75, BulletClass_Logics_DamageHouse, 0x7)
 
 			auto pObject = abstract_cast<ObjectClass*>(pTarget);
 
-			auto dist = 0;
+			auto dist = coord->DistanceFrom(pObject->GetCoords());
 			auto pBuilding = abstract_cast<BuildingClass*>(pObject);
 
 			if (pBuilding)
 			{
-				auto const buildingCell = pBuilding->GetMapCoords();
-
-				for (auto pFoundation = pBuilding->GetFoundationData(false); *pFoundation != CellStruct { 0x7FFF, 0x7FFF }; ++pFoundation)
-				{
-					CellStruct currentCell = buildingCell + *pFoundation;
-					auto pCurrentCell = MapClass::Instance.GetCellAt(currentCell);
-					auto currentDist = coord->DistanceFrom(pCurrentCell->GetCoords());
-					dist = currentDist < dist ? currentDist : dist;
-				}
-			}
-			else
-			{
-				dist = coord->DistanceFrom(pObject->GetCoords());
+				auto pBuildingType = pBuilding->Type;
+				dist -= ((pBuildingType->GetFoundationHeight(0) + pBuildingType->GetFoundationWidth()) << 6);
 			}
 
 			if (dist > pWHExt->NoCellSpread_SnapDistance.Get())

--- a/src/Ext/Bullet/Hooks.DetonateLogics.cpp
+++ b/src/Ext/Bullet/Hooks.DetonateLogics.cpp
@@ -42,11 +42,101 @@ DEFINE_HOOK(0x4692BD, BulletClass_Logics_ApplyMindControl, 0x6)
 
 DEFINE_HOOK(0x469A75, BulletClass_Logics_DamageHouse, 0x7)
 {
+	enum { SkipDamageArea = 0x469A88 };
+
 	GET(BulletClass*, pThis, ESI);
 	GET(HouseClass*, pHouse, ECX);
+	GET(int, damage, EDX);
+	GET_BASE(CoordStruct*, coord, 0x8);
 
 	if (!pHouse)
-		R->ECX(BulletExt::ExtMap.Find(pThis)->FirerHouse);
+	{
+		pHouse = BulletExt::ExtMap.Find(pThis)->FirerHouse;
+		R->ECX(pHouse);
+	}
+
+	auto pWH = pThis->WH;
+	auto pWHExt = WarheadTypeExt::ExtMap.Find(pWH);
+
+	if (pWHExt->NoCellSpread)
+	{
+		DamageAreaResult result = DamageAreaResult::Missed;
+
+		do
+		{
+			if (damage == 0)
+			{
+				break;
+			}
+
+			auto pTarget = pThis->Target;
+
+			if (!pTarget || pTarget->WhatAmI() == AbstractType::Cell)
+			{
+				break;
+			}
+
+			auto pObject = abstract_cast<ObjectClass*>(pTarget);
+
+			auto dist = 0;
+			auto pBuilding = abstract_cast<BuildingClass*>(pObject);
+
+			if (pBuilding)
+			{
+				auto const buildingCell = pBuilding->GetMapCoords();
+
+				for (auto pFoundation = pBuilding->GetFoundationData(false); *pFoundation != CellStruct { 0x7FFF, 0x7FFF }; ++pFoundation)
+				{
+					CellStruct currentCell = buildingCell + *pFoundation;
+					auto pCurrentCell = MapClass::Instance.GetCellAt(currentCell);
+					auto currentDist = coord->DistanceFrom(pCurrentCell->GetCoords());
+					dist = currentDist < dist ? currentDist : dist;
+				}
+			}
+			else
+			{
+				dist = coord->DistanceFrom(pObject->GetCoords());
+			}
+
+			if (dist > pWHExt->NoCellSpread_SnapDistance.Get())
+			{
+				break;
+			}
+
+			auto pTechno = abstract_cast<TechnoClass*>(pObject);
+
+			if (!pTechno)
+			{
+				pObject->ReceiveDamage(&damage, 0, pWH, pThis->Owner, false, false, pHouse);
+				result = DamageAreaResult::Hit;
+			}
+			else
+			{
+				if (pTechno->IsAlive
+					&& (!pBuilding || !pBuilding->Type->InvisibleInGame)
+					&& pTechno->Health > 0
+					&& pTechno->IsOnMap
+					&& !pTechno->InLimbo
+					&& !(pTechno == pThis->Owner && pTechno->GetTechnoType()->DamageSelf && pWH != RulesClass::Instance->CrushWarhead))
+				{
+					if (pTechno->IsIronCurtained() && !pTechno->ForceShielded)
+					{
+						result = DamageAreaResult::Nullified;
+					}
+					else
+					{
+						result = DamageAreaResult::Hit;
+					}
+
+					pObject->ReceiveDamage(&damage, 0, pWH, pThis->Owner, false, false, pHouse);
+				}
+			}
+		}
+		while (false);
+
+		R->EAX(result);
+		return SkipDamageArea;
+	}
 
 	return 0;
 }

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -279,6 +279,9 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->CombatAlert_Suppress.Read(exINI, pSection, "CombatAlert.Suppress");
 
+	this->NoCellSpread.Read(exINI, pSection, "NoCellSpread");
+	this->NoCellSpread_SnapDistance.Read(exINI, pSection, "NoCellSpread_SnapDistance");
+
 	// Convert.From & Convert.To
 	TypeConvertGroup::Parse(this->Convert_Pairs, exINI, pSection, AffectedHouse::All);
 
@@ -517,6 +520,8 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->BuildingUndeploy_Leave)
 
 		.Process(this->CombatAlert_Suppress)
+		.Process(this->NoCellSpread)
+		.Process(this->NoCellSpread_SnapDistance)
 
 		// Ares tags
 		.Process(this->AffectsEnemies)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -163,6 +163,9 @@ public:
 
 		Nullable<bool> CombatAlert_Suppress;
 
+		Valueable<bool> NoCellSpread;
+		Valueable<Leptons> NoCellSpread_SnapDistance;
+
 		// Ares tags
 		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
 		Valueable<bool> AffectsEnemies;
@@ -328,6 +331,9 @@ public:
 			, BuildingUndeploy_Leave { false }
 
 			, CombatAlert_Suppress {}
+
+			, NoCellSpread { false }
+			, NoCellSpread_SnapDistance { Leptons(128) }
 
 			, AffectsEnemies { true }
 			, AffectsOwner {}


### PR DESCRIPTION

 2-79. 弹头仅伤害目标本身
在原本游戏中，任何弹头都会进行范围伤害查找，即使CellSpread=0也是如此。CellSpread=0的弹头会伤害格子上的建筑和任何位置与引爆坐标相同的单位。
现在你可以让弹头跳过伤害查找只伤害主目标了。
注意：虽然是弹头上的标签，但也必须经过抛射体引爆阶段才能生效。


[SomeWarhead]
NoCellSpread=false                          ；是否仅伤害目标本身
NoCellSpread.SnapDistance=0.5       ；引爆时距离目标多远算作命中目标从而会对目标造成伤害，单位：格