### PR TITLE
航母在桥上无法开火bug修复

### DIFF
--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -241,6 +241,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->BuildingTypeSelectable.Read(exINI, GameStrings::General, "BuildingTypeSelectable");
 
+	this->SpawnerBridgeFix.Read(exINI, GameStrings::General, "SpawnerBridgeFix");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -447,6 +449,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->CombatLightDetailLevel)
 		.Process(this->LightFlashAlphaImageDetailLevel)
 		.Process(this->BuildingTypeSelectable)
+		.Process(this->SpawnerBridgeFix)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -197,6 +197,8 @@ public:
 		Valueable<bool> BuildingWaypoints;
 		Valueable<bool> BuildingTypeSelectable;
 
+		Valueable<bool> SpawnerBridgeFix;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, InfantryGainSelfHealCap {}
@@ -344,6 +346,7 @@ public:
 			, LightFlashAlphaImageDetailLevel { 0 }
 			, BuildingWaypoints { false }
 			, BuildingTypeSelectable { false }
+			, SpawnerBridgeFix { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -412,6 +412,14 @@ DEFINE_HOOK(0x6FCBE6, TechnoClass_CanFire_BridgeAAFix, 0x6)
 	return 0;
 }
 
+DEFINE_HOOK(0x6FC617, TechnoClass_GetFireError_SpawnerRelatedStupidCheck, 0x8)
+{
+	enum { CheckPass = 0x6FC61F, NotPass = 0x6FCD29 };
+
+	GET(bool, stupidBool, EAX);
+	return (!RulesExt::Global()->SpawnerBridgeFix && stupidBool) ? NotPass : CheckPass;
+}
+
 #pragma endregion
 
 #pragma region TechnoClass_Fire


### PR DESCRIPTION
 2-80. 航母在桥上无法开火bug修复
在原本游戏中，使用子机的空军在桥上方时会被禁止开火。这看上去没有丝毫逻辑的行为现在可以被改变了。
注意：之所以没有强制开启，是因为实在无法理解这个行为以至于怀疑其是否正在避免什么奇葩问题发生。

[General]
SpawnerBridgeFix=false         ；是否修复以上问题