### PR TITLE
屏幕外依旧绘制

### DIFF
--- a/src/Ext/Anim/Hooks.cpp
+++ b/src/Ext/Anim/Hooks.cpp
@@ -483,4 +483,23 @@ DEFINE_HOOK(0x425060, AnimClass_Expire_ScorchFlamer, 0x6)
 
 #pragma endregion
 
+DEFINE_HOOK(0x5F4B7A, ObjectClass_DrawIfVisible_OnScreenCheck, 0x5)
+{
+	enum { Draw = 0x5F4B88, NoDraw = 0x5F4B7F };
 
+	GET(AbstractType, absType, EAX);
+	GET(ObjectClass*, pThis, ESI);
+
+	if (absType == AbstractType::ParticleSystem)
+		return Draw;
+
+	if (auto pAnim = abstract_cast<AnimClass*>(pThis))
+	{
+		auto pTypeExt = AnimTypeExt::ExtMap.Find(pAnim->Type);
+
+		if (pTypeExt && pTypeExt->RenderIfOutOfScreen)
+			return Draw;
+	}
+
+	return NoDraw;
+}

--- a/src/Ext/AnimType/Body.cpp
+++ b/src/Ext/AnimType/Body.cpp
@@ -130,6 +130,7 @@ void AnimTypeExt::ExtData::LoadFromINIFile(CCINIClass* pINI)
 	this->LargeFireAnims.Read(exINI, pID, "LargeFireAnims");
 	this->LargeFireChances.Read(exINI, pID, "LargeFireChances");
 	this->LargeFireDistances.Read(exINI, pID, "LargeFireDistances");
+	this->RenderIfOutOfScreen.Read(exINI, pID, "RenderIfOutOfScreen");
 }
 
 template <typename T>
@@ -184,6 +185,7 @@ void AnimTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->LargeFireAnims)
 		.Process(this->LargeFireChances)
 		.Process(this->LargeFireDistances)
+		.Process(this->RenderIfOutOfScreen)
 		;
 }
 

--- a/src/Ext/AnimType/Body.h
+++ b/src/Ext/AnimType/Body.h
@@ -65,6 +65,7 @@ public:
 		ValueableVector<AnimTypeClass*> LargeFireAnims;
 		ValueableVector<double> LargeFireChances;
 		ValueableVector<double> LargeFireDistances;
+		Valueable<bool> RenderIfOutOfScreen;
 
 		ExtData(AnimTypeClass* OwnerObject) : Extension<AnimTypeClass>(OwnerObject)
 			, Palette { CustomPalette::PaletteMode::Temperate }
@@ -114,6 +115,7 @@ public:
 			, LargeFireAnims {}
 			, LargeFireChances {}
 			, LargeFireDistances {}
+			, RenderIfOutOfScreen { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
 2-82. 屏幕外依旧绘制
在原本游戏中，只会绘制屏幕矩形范围及往左右上下再扩大6格这么大范围内的实体。超过这个范围的实体将不会被绘制，即使它们图像的一部分仍然应该可见。
现在你可以改变这一点了。
目前仅对动画生效。对于别的类型如果有确切的需求可以提。

在 artmd.ini 中
[SomeAnim]
RenderIfOutOfScreen=false           ；超出绘制范围时是否仍然绘制