### PR TITLE
交换loco

### DIFF
--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -1008,6 +1008,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->LastSensorsMapCoords)
 		.Process(this->PlayerAssignedLastTarget)
 		.Process(this->IsWreckage)
+		.Process(this->BuildingOccupying)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -92,6 +92,8 @@ public:
 
 		bool IsWreckage;
 
+		BuildingClass* BuildingOccupying;
+
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, TypeExtData { nullptr }
 			, Shield {}
@@ -156,6 +158,7 @@ public:
 			, LastSensorsMapCoords { CellStruct::Empty }
 			, PlayerAssignedLastTarget { 0xFFFFFFFF }
 			, IsWreckage { false }
+			, BuildingOccupying { }
 		{ }
 
 		void OnEarlyUpdate();

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -1497,9 +1497,13 @@ DEFINE_HOOK(0x51BDCF, InfantryClass_Update_Reload, 0x7)
 DEFINE_HOOK(0x522937, InfantryClass_EnterOccupyBuilding_KeepUpdate, 0xA)
 {
 	GET(InfantryClass*, pThis, ESI);
+	GET_STACK(BuildingClass*, pBuilding, STACK_OFFSET(0x1C, 0x4));
 
 	if (RulesExt::Global()->UpdateInLimbo_Occupier)
+	{
 		LogicClass::Instance.AddObject(pThis, false);
+		TechnoExt::ExtMap.Find(pThis)->BuildingOccupying = pBuilding;
+	}
 
 	return 0;
 }
@@ -1537,6 +1541,20 @@ DEFINE_HOOK(0x6FF7F9, SITechnoClass_Fire_LimboLaunch, 0x6)
 		LogicClass::Instance.AddObject(pThis, false);
 
 	return 0;
+}
+
+DEFINE_HOOK(0x4580B4, BuildingClass_OccupantLeaveAll_UpdateState,0x5)
+{
+	GET(InfantryClass*, pOccupant, EDI);
+	TechnoExt::ExtMap.Find(pOccupant)->BuildingOccupying = nullptr;
+	return 0;
+}
+
+DEFINE_HOOK(0x6FC5B3, TechnoClass_GetFireError_InLimbo, 0x6)
+{
+	enum { Illegal = 0x6FC86A };
+	GET(TechnoClass*, pThis, ESI);
+	return !pThis->InLimbo || TechnoExt::ExtMap.Find(pThis)->BuildingOccupying || pThis->InOpenToppedTransport ? 0 : Illegal;
 }
 
 #pragma endregion

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -185,7 +185,8 @@ DEFINE_HOOK(0x701DFF, TechnoClass_ReceiveDamage_FlyingStrings, 0x7)
 
 	if ((state == DamageState::NowDead) && !WarheadTypeExt::ExtMap.Find(pWH)->SuppressWreckage)
 	{
-		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pThis->GetTechnoType());
+		const auto pType = pThis->GetTechnoType();
+		const auto pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
 
 		if (const auto pWreckageType = pTypeExt->WreckageType)
 		{
@@ -196,6 +197,21 @@ DEFINE_HOOK(0x701DFF, TechnoClass_ReceiveDamage_FlyingStrings, 0x7)
 				{
 					const auto pWreckage = static_cast<TechnoClass*>(pWreckageType->CreateObject(pOwner));
 					pWreckage->Health = static_cast<int>(pWreckageType->Strength * pTypeExt->WreckageInitialHealthPercent.Get(RulesExt::Global()->WreckageInitialHealthPercent));
+
+					if (pTypeExt->WreckageSwapLocomotor
+						&& pWreckage->WhatAmI() != AbstractType::Building
+						&& pThis->WhatAmI() != AbstractType::Building)
+					{
+						auto pFoot = (FootClass*)pThis;
+						auto pWreckageFoot = (FootClass*)pWreckage;
+
+						auto temp = pFoot->Locomotor;
+						pFoot->Locomotor = pWreckageFoot->Locomotor;
+						pWreckageFoot->Locomotor=temp;
+						pWreckageFoot->Locomotor->Link_To_Object(pWreckageFoot);
+						pFoot->Locomotor->Link_To_Object(pFoot);
+					}
+
 					++Unsorted::ScenarioInit;
 					pWreckage->Unlimbo((pWreckage->AbstractFlags & AbstractFlags::Foot) != AbstractFlags::None ? pThis->GetCoords() : pThis->Location, DirType::North);
 					--Unsorted::ScenarioInit;

--- a/src/Ext/Techno/Hooks.ReceiveDamage.cpp
+++ b/src/Ext/Techno/Hooks.ReceiveDamage.cpp
@@ -207,7 +207,7 @@ DEFINE_HOOK(0x701DFF, TechnoClass_ReceiveDamage_FlyingStrings, 0x7)
 
 						auto temp = pFoot->Locomotor;
 						pFoot->Locomotor = pWreckageFoot->Locomotor;
-						pWreckageFoot->Locomotor=temp;
+						pWreckageFoot->Locomotor = temp;
 						pWreckageFoot->Locomotor->Link_To_Object(pWreckageFoot);
 						pFoot->Locomotor->Link_To_Object(pFoot);
 					}

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -879,6 +879,7 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->WreckageOwner.Read(exINI, pSection, "WreckageOwner");
 	this->WreckageLeaveOnWater.Read(exINI, pSection, "WreckageLeaveOnWater");
 	this->WreckageLeaveInAir.Read(exINI, pSection, "WreckageLeaveInAir");
+	this->WreckageSwapLocomotor.Read(exINI, pSection, "WreckageSwapLocomotor");
 
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
@@ -1508,6 +1509,7 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->WreckageOwner)
 		.Process(this->WreckageLeaveOnWater)
 		.Process(this->WreckageLeaveInAir)
+		.Process(this->WreckageSwapLocomotor)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -441,6 +441,7 @@ public:
 		Valueable<OwnerHouseKind> WreckageOwner;
 		Valueable<bool> WreckageLeaveOnWater;
 		Valueable<bool> WreckageLeaveInAir;
+		Valueable<bool> WreckageSwapLocomotor;
 
 		struct LaserTrailDataEntry
 		{
@@ -892,6 +893,7 @@ public:
 			, WreckageOwner { OwnerHouseKind::Default }
 			, WreckageLeaveOnWater { false }
 			, WreckageLeaveInAir { false }
+			, WreckageSwapLocomotor { false }
 		{ }
 
 		virtual ~ExtData() = default;


### PR DESCRIPTION
WreckageSwapLocomotor=false           ；单位是否会跟残骸交换locomotor。这有助于残骸保持在正确的位置上，但请确保原有的单位在受伤后会立即死亡。