### PR TITLE
小修正

### DIFF
--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -649,7 +649,8 @@ public:
 			, WreckageInitialHealthPercent { 0.1 }
 
 			, HarvesterScanAfterUnload { false }
-			, BalloonHoverPathingFix { false }
+			
+			, BalloonHoverPathingFix { true }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -1844,7 +1844,7 @@ DEFINE_HOOK(0x4C7655, EventClass_RespondToEvent_ExtraTargeting, 0x7)
 
 static inline bool ExtraTargeting_OnLoseTarget(TechnoClass* pThis)
 {
-	if (!RulesExt::Global()->ExtraTargeting_OnLoseTarget || pThis->Spawned) return false;
+	if (!RulesExt::Global()->ExtraTargeting_OnLoseTarget || pThis->Spawned || pThis->SpawnOwner) return false;
 	auto coord = pThis->GetCoords();
 	return pThis->TargetAndEstimateDamage(coord, ThreatType::Range);
 }
@@ -1948,14 +1948,14 @@ DEFINE_HOOK(0x6FA697, TechnoClass_Update_AutoTargetMissionCheck, 0x6)
 {
 	enum { CanTargeting = 0x6FA6AC };
 	GET(TechnoClass* const, pThis, ESI);
-	return pThis->CurrentMission == Mission::Attack && RulesExt::Global()->ExtraTargeting_OnNoTargetAssigned && !pThis->Spawned ? CanTargeting : 0;
+	return pThis->CurrentMission == Mission::Attack && RulesExt::Global()->ExtraTargeting_OnNoTargetAssigned && !pThis->Spawned && !pThis->SpawnOwner ? CanTargeting : 0;
 }
 
 DEFINE_HOOK(0x7093E9, TechnoClass_CanPassiveAquireNow_MissionCheck, 0x7)
 {
 	enum { CanTargeting = 0x7093F8 };
 	GET(TechnoClass* const, pThis, ESI);
-	return pThis->CurrentMission == Mission::Attack && RulesExt::Global()->ExtraTargeting_OnNoTargetAssigned && !pThis->Spawned && CanRetarget(pThis, pThis->Target) ? CanTargeting : 0;
+	return pThis->CurrentMission == Mission::Attack && RulesExt::Global()->ExtraTargeting_OnNoTargetAssigned && !pThis->Spawned && !pThis->SpawnOwner && CanRetarget(pThis, pThis->Target) ? CanTargeting : 0;
 }
 
 DEFINE_HOOK(0x70CE85, TechnoClass_ThreatCoefficient_CanAttackMeThreatBonus, 0x5)

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -1332,6 +1332,7 @@ DEFINE_HOOK(0x4DF410, FootClass_UpdateAttackMove_TargetAcquired, 0x6)
 				pJumpjetLoco->DestinationCoords.Y = crd.Y;
 				pJumpjetLoco->CurrentSpeed = 0;
 				pJumpjetLoco->MaxSpeed = 0;
+				pJumpjetLoco->State = JumpjetLocomotionClass::State::Hovering;
 				pThis->AbortMotion();
 			}
 			else

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -2012,4 +2012,37 @@ DEFINE_HOOK(0x73F0A7, UnitClass_IsCellOccupied_Start, 0x9)
 	return pThis->IsInAir() && pThis->Type->BalloonHover && RulesExt::Global()->BalloonHoverPathingFix ? MoveOK : 0;
 }
 
+namespace ApproachTargetContext
+{
+	bool IsBalloonHover = false;
+}
+
+DEFINE_HOOK(0x4D5690, FootClass_ApproachTarget_SetContext, 0x6)
+{
+	GET(FootClass*, pThis, ECX);
+	ApproachTargetContext::IsBalloonHover = pThis->GetTechnoType()->BalloonHover && RulesExt::Global()->BalloonHoverPathingFix;
+	return 0;
+}
+
+DEFINE_HOOK_AGAIN(0x4D5A42, FootClass_ApproachTarget_ResetContext, 0x5);
+DEFINE_HOOK_AGAIN(0x4D5AB5, FootClass_ApproachTarget_ResetContext, 0x5);
+DEFINE_HOOK_AGAIN(0x4D68DE, FootClass_ApproachTarget_ResetContext, 0x5);
+DEFINE_HOOK_AGAIN(0x4D6A8B, FootClass_ApproachTarget_ResetContext, 0x5);
+DEFINE_HOOK(0x4D5744, FootClass_ApproachTarget_ResetContext, 0x5)
+{
+	ApproachTargetContext::IsBalloonHover = false;
+	return 0;
+}
+
+DEFINE_HOOK(0x4834A0, CellClass_IsClearToMove_Start, 0x5)
+{
+	if (ApproachTargetContext::IsBalloonHover)
+	{
+		R->AL(true);
+		return 0x483605;
+	}
+
+	return 0;
+}
+
 #pragma endregion


### PR DESCRIPTION
1. 更新了BalloonHover寻路修正功能，现在也会修正追赶敌人时的寻路。该功能现在默认开启。
2. 修正了AttackMove.StopWhenTargetAcquired生效时会导致JJ单位朝向右下的问题。