### PR TITLE
混乱索敌自定义

### DIFF
--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -427,6 +427,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->AnimCraterReduceTiberium.Read(exINI, GameStrings::General, "AnimCraterReduceTiberium");
 
+	this->BerzerkTargeting.Read(exINI, GameStrings::CombatDamage, "BerzerkTargeting");
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -776,6 +777,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->TunnelPathingDistTooFar)
 		.Process(this->BalloonHoverPathingFix)
 		.Process(this->AnimCraterReduceTiberium)
+		.Process(this->BerzerkTargeting)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -363,6 +363,8 @@ public:
 		Valueable<bool> BalloonHoverPathingFix;
 		
 		Valueable<bool> AnimCraterReduceTiberium;
+		
+		Valueable<AffectedHouse> BerzerkTargeting;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -667,6 +669,8 @@ public:
 			, BalloonHoverPathingFix { true }
 
 			, AnimCraterReduceTiberium { true }
+			
+			, BerzerkTargeting { AffectedHouse::All }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -306,6 +306,17 @@ DEFINE_HOOK(0x6FC339, TechnoClass_CanFire, 0x6)
 
 	GET(TechnoClass*, pThis, ESI);
 	GET(WeaponTypeClass*, pWeapon, EDI);
+	GET(ObjectClass*, pTargetObj, EBP);
+
+	if (auto pTargetTechno=abstract_cast<TechnoClass*>(pTargetObj))
+	{
+		if (pThis->Berzerk
+			&& RulesExt::Global()->BerzerkTargeting != AffectedHouse::All
+			&& !EnumFunctions::CanTargetHouse(RulesExt::Global()->BerzerkTargeting, pThis->Owner, pTargetTechno->Owner))
+		{
+			return CannotFire;
+		}
+	}
 
 	// Checking for nullptr is not required here, since the game has already executed them before calling the hook  -- Belonit
 	const auto pWH = pWeapon->Warhead;


### PR DESCRIPTION
 2-90. 混乱索敌自定义
原本游戏中，被混乱的单位也会攻击敌军，导致混乱的效果很差（尤其对AI）。
现在你可以限制单位处于混乱状态时可以攻击的目标。

[CombatDamage]
BerzerkTargeting=all                         ；混乱时可以攻击的目标所属类型，Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)