### PR TITLE
作战方被击败行为扩展

### DIFF
--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -1261,4 +1261,93 @@ bool HouseExt::ReachedBuildLimit(const HouseClass* pHouse, const TechnoTypeClass
 
 	return false;
 }
+
+void HouseExt::ReorganizeAllTo(HouseClass* pFromHouse, HouseClass* pToHouse)
+{
+	for (auto pTechno : TechnoClass::Array)
+	{
+		if (pTechno->OriginallyOwnedByHouse == pFromHouse)
+			pTechno->OriginallyOwnedByHouse = pToHouse;
+
+		if (pTechno->Owner == pFromHouse)
+			pTechno->SetOwningHouse(pToHouse, true);
+	}
+}
+
+void __fastcall HouseExt::DecideTechnosFate(HouseClass* pThis)
+{
+	auto behavior = RulesExt::Global()->DefeatedBehavior;
+
+	if (!behavior) // Vanilla behavior
+	{
+		pThis->DestroyAll();
+	}
+	else if (behavior > 0) // Reorganized to ally
+	{
+		bool includeHuman = false;
+		DynamicVectorClass<HouseClass*> allies;
+		for (auto pHouse : HouseClass::Array) // Find a house to give. Human player first.
+		{
+			if (pHouse->Type->MultiplayPassive)
+				continue;
+
+			if (!pThis->IsAlliedWith(pHouse))
+				continue;
+
+			if (includeHuman)
+			{
+				if (pHouse->IsControlledByHuman())
+					allies.AddItem(pHouse);
+			}
+			else
+			{
+				if (pHouse->IsControlledByHuman())
+				{
+					includeHuman = true;
+					allies.Clear();
+				}
+				allies.AddItem(pHouse);
+			}
+		}
+		if (allies.Count)
+		{
+			HouseExt::ReorganizeAllTo(pThis, allies[ScenarioClass::Instance->Random.RandomRanged(0, allies.Count)]);
+		}
+		else
+			pThis->DestroyAll();
+	}
+	else // Surrender to enemy
+	{
+		bool includeHuman = false;
+		DynamicVectorClass<HouseClass*> enemies;
+		for (auto pHouse : HouseClass::Array) // Find a house to give. Human player first.
+		{
+			if (pHouse->Type->MultiplayPassive)
+				continue;
+
+			if (pThis->IsAlliedWith(pHouse))
+				continue;
+
+			if (includeHuman)
+			{
+				if (pHouse->IsControlledByHuman())
+					enemies.AddItem(pHouse);
+			}
+			else
+			{
+				if (pHouse->IsControlledByHuman())
+				{
+					includeHuman = true;
+					enemies.Clear();
+				}
+				enemies.AddItem(pHouse);
+			}
+		}
+		if (enemies.Count)
+			HouseExt::ReorganizeAllTo(pThis, enemies[ScenarioClass::Instance->Random.RandomRanged(0, enemies.Count)]);
+		else
+			pThis->DestroyAll();
+	}
+}
+
 #pragma endregion

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -1270,90 +1270,54 @@ void HouseExt::ReorganizeAllTo(HouseClass* pFromHouse, HouseClass* pToHouse)
 			pTechno->OriginallyOwnedByHouse = pToHouse;
 
 		if (pTechno->Owner == pFromHouse)
+		{
 			pTechno->SetOwningHouse(pToHouse, true);
+			pTechno->SetTarget(nullptr);
+			pTechno->SetDestination(nullptr, false);
+			pTechno->EnterIdleMode(false, true);
+		}
 	}
+
+	int money = pFromHouse->Available_Money();
+	pFromHouse->TransactMoney(-money);
+	pToHouse->TransactMoney(money);
 }
 
 void __fastcall HouseExt::DecideTechnosFate(HouseClass* pThis)
 {
-	auto behavior = RulesExt::Global()->DefeatedBehavior;
+	bool includeHuman = false;
+	DynamicVectorClass<HouseClass*> houses;
 
-	if (!behavior) // Vanilla behavior
+	for (auto pHouse : HouseClass::Array) // Find a house to give. Human player first.
 	{
+		if (pHouse->Type->MultiplayPassive
+			|| pHouse->Defeated
+			|| pHouse->IsObserver())
+			continue;
+
+		if (!EnumFunctions::CanTargetHouse(RulesExt::Global()->ReorganizeToWhenDefeated, pThis, pHouse))
+			continue;
+
+		if (includeHuman)
+		{
+			if (pHouse->IsControlledByHuman())
+				houses.AddItem(pHouse);
+		}
+		else
+		{
+			if (pHouse->IsControlledByHuman())
+			{
+				includeHuman = true;
+				houses.Clear();
+			}
+			houses.AddItem(pHouse);
+		}
+	}
+
+	if (houses.Count)
+		HouseExt::ReorganizeAllTo(pThis, houses[ScenarioClass::Instance->Random.RandomRanged(0, houses.Count - 1)]);
+	else
 		pThis->DestroyAll();
-	}
-	else if (behavior > 0) // Reorganized to ally
-	{
-		bool includeHuman = false;
-		DynamicVectorClass<HouseClass*> allies;
-		for (auto pHouse : HouseClass::Array) // Find a house to give. Human player first.
-		{
-			if (pHouse->Type->MultiplayPassive
-				|| pHouse->Defeated
-				|| pHouse->IsObserver()
-				|| pHouse == pThis)
-				continue;
-
-			if (!pThis->IsAlliedWith(pHouse))
-				continue;
-
-			if (includeHuman)
-			{
-				if (pHouse->IsControlledByHuman())
-					allies.AddItem(pHouse);
-			}
-			else
-			{
-				if (pHouse->IsControlledByHuman())
-				{
-					includeHuman = true;
-					allies.Clear();
-				}
-				allies.AddItem(pHouse);
-			}
-		}
-		if (allies.Count)
-		{
-			HouseExt::ReorganizeAllTo(pThis, allies[ScenarioClass::Instance->Random.RandomRanged(0, allies.Count)]);
-		}
-		else
-			pThis->DestroyAll();
-	}
-	else // Surrender to enemy
-	{
-		bool includeHuman = false;
-		DynamicVectorClass<HouseClass*> enemies;
-		for (auto pHouse : HouseClass::Array) // Find a house to give. Human player first.
-		{
-			if (pHouse->Type->MultiplayPassive
-				|| pHouse->Defeated
-				|| pHouse->IsObserver()
-				|| pHouse == pThis)
-				continue;
-
-			if (pThis->IsAlliedWith(pHouse))
-				continue;
-
-			if (includeHuman)
-			{
-				if (pHouse->IsControlledByHuman())
-					enemies.AddItem(pHouse);
-			}
-			else
-			{
-				if (pHouse->IsControlledByHuman())
-				{
-					includeHuman = true;
-					enemies.Clear();
-				}
-				enemies.AddItem(pHouse);
-			}
-		}
-		if (enemies.Count)
-			HouseExt::ReorganizeAllTo(pThis, enemies[ScenarioClass::Instance->Random.RandomRanged(0, enemies.Count)]);
-		else
-			pThis->DestroyAll();
-	}
 }
 
 #pragma endregion

--- a/src/Ext/House/Body.cpp
+++ b/src/Ext/House/Body.cpp
@@ -1288,7 +1288,10 @@ void __fastcall HouseExt::DecideTechnosFate(HouseClass* pThis)
 		DynamicVectorClass<HouseClass*> allies;
 		for (auto pHouse : HouseClass::Array) // Find a house to give. Human player first.
 		{
-			if (pHouse->Type->MultiplayPassive)
+			if (pHouse->Type->MultiplayPassive
+				|| pHouse->Defeated
+				|| pHouse->IsObserver()
+				|| pHouse == pThis)
 				continue;
 
 			if (!pThis->IsAlliedWith(pHouse))
@@ -1322,7 +1325,10 @@ void __fastcall HouseExt::DecideTechnosFate(HouseClass* pThis)
 		DynamicVectorClass<HouseClass*> enemies;
 		for (auto pHouse : HouseClass::Array) // Find a house to give. Human player first.
 		{
-			if (pHouse->Type->MultiplayPassive)
+			if (pHouse->Type->MultiplayPassive
+				|| pHouse->Defeated
+				|| pHouse->IsObserver()
+				|| pHouse == pThis)
 				continue;
 
 			if (pThis->IsAlliedWith(pHouse))

--- a/src/Ext/House/Body.h
+++ b/src/Ext/House/Body.h
@@ -218,4 +218,7 @@ public:
 	static int CountOwnedNowWithDeployOrUpgrade(HouseClass* pHouse, BuildingTypeClass* pBuildingType, bool upgrade = true, bool deploy = true);
 	static bool CheckOwnerBitfieldForCurrentPlayer(TechnoTypeClass* pType);
 	static void RecheckOwnerBitfieldForCurrentPlayer();
+
+	static void ReorganizeAllTo(HouseClass* pFromHouse, HouseClass* pToHouse);
+	static void __fastcall DecideTechnosFate(HouseClass* pHouse);
 };

--- a/src/Ext/House/Hooks.cpp
+++ b/src/Ext/House/Hooks.cpp
@@ -566,3 +566,11 @@ DEFINE_HOOK(0x4FD616, HouseClass_sub4FD500_DontAngerOnAlly, 0x9)
 
 	return (!RulesExt::Global()->AIAngerOnAlly && pThis->IsAlliedWith(pTargetHouse)) ? SkipAlly : 0;
 }
+
+DEFINE_HOOK_AGAIN(0x4F87FA, HouseClass_Update_DestroyAll, 0x5);
+DEFINE_HOOK(0x4F8F7B, HouseClass_Update_DestroyAll, 0x5)
+{
+	GET(HouseClass*, pThis, ECX);
+	HouseExt::DecideTechnosFate(pThis);
+	return R->Origin() + 0x5;
+}

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -427,7 +427,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->AnimCraterReduceTiberium.Read(exINI, GameStrings::General, "AnimCraterReduceTiberium");
 	
-	this->DefeatedBehavior.Read(exINI, GameStrings::General, "DefeatedBehavior");
+	this->ReorganizeToWhenDefeated.Read(exINI, GameStrings::General, "ReorganizeToWhenDefeated");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -778,7 +778,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->TunnelPathingDistTooFar)
 		.Process(this->BalloonHoverPathingFix)
 		.Process(this->AnimCraterReduceTiberium)
-		.Process(this->DefeatedBehavior)
+		.Process(this->ReorganizeToWhenDefeated)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -426,6 +426,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->BalloonHoverPathingFix.Read(exINI, GameStrings::General, "BalloonHoverPathingFix");
 
 	this->AnimCraterReduceTiberium.Read(exINI, GameStrings::General, "AnimCraterReduceTiberium");
+	
+	this->DefeatedBehavior.Read(exINI, GameStrings::General, "DefeatedBehavior");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -776,6 +778,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->TunnelPathingDistTooFar)
 		.Process(this->BalloonHoverPathingFix)
 		.Process(this->AnimCraterReduceTiberium)
+		.Process(this->DefeatedBehavior)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -364,7 +364,7 @@ public:
 		
 		Valueable<bool> AnimCraterReduceTiberium;
 		
-		Valueable<int> DefeatedBehavior;
+		Valueable<AffectedHouse> ReorganizeToWhenDefeated;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -670,7 +670,7 @@ public:
 
 			, AnimCraterReduceTiberium { true }
 			
-			, DefeatedBehavior { 0 }
+			, ReorganizeToWhenDefeated { AffectedHouse::None }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -363,6 +363,8 @@ public:
 		Valueable<bool> BalloonHoverPathingFix;
 		
 		Valueable<bool> AnimCraterReduceTiberium;
+		
+		Valueable<int> DefeatedBehavior;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -667,6 +669,8 @@ public:
 			, BalloonHoverPathingFix { true }
 
 			, AnimCraterReduceTiberium { true }
+			
+			, DefeatedBehavior { 0 }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Misc/Hooks.Ares.cpp
+++ b/src/Misc/Hooks.Ares.cpp
@@ -7,6 +7,7 @@
 
 #include <Ext/Sidebar/Body.h>
 #include <Ext/Techno/Body.h>
+#include <Ext/House/Body.h>
 
 // Remember that we still don't fix Ares "issues" a priori. Extensions as well.
 // Patches presented here are exceptions rather that the rule. They must be short, concise and correct.
@@ -61,6 +62,9 @@ void Apply_Ares3_0_Patches()
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x46C6D, &ConvertToType);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4B397, &ConvertToType);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4C099, &ConvertToType);
+	
+	// Replace the DestroyAll when defeated:
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x24AC9, &HouseExt::DecideTechnosFate);
 }
 
 void Apply_Ares3_0p1_Patches()
@@ -95,4 +99,7 @@ void Apply_Ares3_0p1_Patches()
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4780D, &ConvertToType);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4BFF7, &ConvertToType);
 	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x4CCF9, &ConvertToType);
+	
+	// Replace the DestroyAll when defeated:
+	Patch::Apply_CALL(AresHelper::AresBaseAddress + 0x255E9, &HouseExt::DecideTechnosFate);
 }


### PR DESCRIPTION
 2-91. 作战方被击败行为扩展
原本游戏中，非战役模式下作战方可以被击败，作战方被击败后其所有单位会被摧毁。
现在你可以其它方式处理被击败作战方剩下的单位。
注意1：如果找不到合适的作战方，那就会执行原本的摧毁行为。
注意2：会优先选择玩家控制的作战方。

[General]
DefeatedBehavior=0                            ；整数，大于0时剩余单位会被友军收编，小于0时会向敌人投降，等于0时会被摧毁。