### PR TITLE
超时空保持距离计算bug修复

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -549,6 +549,7 @@ This page lists all the individual contributions to the project by their author.
   - Customize whether `Crater=yes` animation would destroy tiberium
   - Targeting limitation for berzerk technos
   - Allows refineries to use multiple ActiveAnim simultaneously
+  - Several attackmove related enhancement
 - **tyuah8**:
   - Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-piggybacked bugfix
   - Destroyed unit leaves sensors bugfix

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -579,10 +579,10 @@ Grinding.Weapon.RequiredCredits=0  ; integer
 
 In `rulesmd.ini`:
 ```ini
-[SOMEWARHEAD]
+[SOMEWARHEAD]             ; WarheadType
 ElectricAssaultLevel=1    ; integer
 
-[SOMEBUILDING]
+[SOMEBUILDING]            ; BuildingType
 Overpower.KeepOnline=2    ; integer, negative values mean that cannot keep online
 Overpower.ChargeWeapon=1  ; integer, negative values mean that weapons can never be switched
 ```
@@ -1132,10 +1132,10 @@ DebrisMinimums=     ; List of integers
 
 ```{hint}
 How to generate `DebrisTypes` in the game:
-- Generate the total number of debris through `MaxDebris` and `MinDebris` first.
-- Traverse `DebrisTypes` and limit the quantity range through `DebrisMaximums` and `DebrisMinimums`.
-- When the number of generated debris will exceeds the total number, limit the quantity and end the traversal.
-- When the number of debris generated after a single traversal is not enough to exceed the total number, it will end if `DebrisTypes.Limit` is enabled, otherwise the traversal will restart like vanilla game do.
+1. Generate the total number of debris through `MaxDebris` and `MinDebris` first.
+2. Traverse `DebrisTypes` and limit the quantity range through `DebrisMaximums` and `DebrisMinimums`.
+3. When the number of generated debris will exceeds the total number, limit the quantity and end the traversal.
+4. When the number of debris generated after a single traversal is not enough to exceed the total number, it will end if `DebrisTypes.Limit` is enabled, otherwise the traversal will restart like vanilla game do.
 ```
 
 ### Exploding object customizations
@@ -1632,7 +1632,7 @@ In `rulesmd.ini`:
 [General]
 HarvesterScanAfterUnload=false     ; boolean
 
-[SOMEVEHICLE]
+[SOMEVEHICLE]                      ; VehicleType
 HarvesterScanAfterUnload=          ; boolean, default to [General] -> HarvesterScanAfterUnload
 ```
 
@@ -1733,7 +1733,7 @@ In `rulesmd.ini`:
 [General]
 HarvesterDumpAmount=0.0               ; float point value
 
-[SOMEVEHICLE]
+[SOMEVEHICLE]                         ; VehicleType
 HarvesterDumpAmount=                  ; float point value
 ```
 

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1171,6 +1171,54 @@ AttackMove.Aggressive=         ; boolean, default to [General] -> AttackMove.Agg
 AttackMove.UpdateTarget=       ; boolean, default to [General] -> AttackMove.UpdateTarget
 ```
 
+### Attack move - behavior when target acquired
+
+- Now you can make attack-moving units stop moving when they spot an enemy using `AttackMove.StopWhenTargetAcquired`. This is more like the attack move behavior in Starcraft and Warcraft.
+  - This feature is used to prevent units from charging forward and taking more damage during an attack move command.
+- You can also make them keep chasing on the spotted target using `AttackMove.PursuitTarget`.
+  - This feature should be useful for close range units like ZEP.
+
+
+In `rulesmd.ini`:
+```ini
+[General]
+AttackMove.StopWhenTargetAcquired=         ; boolean
+
+[SOMETECHNO]                               ; TechnoType
+AttackMove.StopWhenTargetAcquired=         ; boolean, default to [General] -> AttackMove.StopWhenTargetAcquired if set, inverse of OpportunityFire otherwise.
+AttackMove.PursuitTarget=                  ; boolean
+```
+
+```{note}
+1. Many units would have stopped when they found an enemy during an attack move command already. This behavior is independent from `AttackMove.StopWhenTargetAcquired`.
+2. Some units (f.ex. jumpjets) will not fire correctly under the vanilla attack move command. The exact reason is not clear, but this feature can fix this problem.
+3. Jumpjets with `AttackMove.StopWhenTargetAcquired=true` will stop immediatly and not scatter to a cell. This is designed for practical reason.
+```
+
+### Attack move - follow
+
+- Now you can have some units following surrounding units when executing an attack move command. The follow behavior is equivalent to the behavior of follow command (`ctrl + alt`).
+  - Use `AttackMove.Follow.IncludeAir` to determine whether the follower will follow an air unit.
+- This feature should be useful for supportive units such as medics and repairers.
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                               ; TechnoType
+AttackMove.Follow=false                    ; boolean
+AttackMove.Follow.IncludeAir=false         ; boolean
+```
+
+### Attack move - without weapon
+
+- In vanilla, attack move command is not allowed to be given to units without weapons. Now you can disable this hardcoded behavior using `AttackMove.IgnoreWeaponCheck=true`.
+  - Unarmed units cannot actually execute attack move commands. This feature is to prevent the attack move pointer from being disabled when you select unarmed units and other units at the same time.
+
+In `rulesmd.ini`:
+```ini
+[General]
+AttackMove.IgnoreWeaponCheck=false    ; boolean
+```
+
 ### Aircraft spawner customizations
 
 ![image](_static/images/spawnrange-01.gif)

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -142,7 +142,7 @@ ReflectDamage.Override=                            ; integer
 ReflectDamage.UseInvokerAsOwner=false              ; boolean
 DisableWeapons=false                               ; boolean
 Unkillable=false                                   ; boolean
-LaserTrail.Type=                                ; lasertrail type
+LaserTrail.Type=                                   ; lasertrail type
 Groups=                                            ; comma-separated list of strings (group IDs)
 
 [SOMETECHNO]                                       ; TechnoType

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -699,35 +699,35 @@ Positional superweapon hotkeys are an experimental feature and currently the use
 In `uimd.ini`:
 ```ini
 [Sidebar]
-SuperWeaponSidebar=false              ; boolean
-SuperWeaponSidebar.Pyramid=true      ; boolean
-SuperWeaponSidebar.Interval=0         ; integer, pixels
-SuperWeaponSidebar.LeftOffset=0       ; integer, pixels
-SuperWeaponSidebar.CameoHeight=48     ; integer, pixels
-SuperWeaponSidebar.Max=0              ; integer
-SuperWeaponSidebar.MaxColumns=        ; integer
+SuperWeaponSidebar=false                    ; boolean
+SuperWeaponSidebar.Pyramid=true             ; boolean
+SuperWeaponSidebar.Interval=0               ; integer, pixels
+SuperWeaponSidebar.LeftOffset=0             ; integer, pixels
+SuperWeaponSidebar.CameoHeight=48           ; integer, pixels
+SuperWeaponSidebar.Max=0                    ; integer
+SuperWeaponSidebar.MaxColumns=              ; integer
 ```
 
 In `rulesmd.ini`:
 ```ini
 [GlobalControls]
-SuperWeaponSidebarKeysEnabled=false    ; boolean
+SuperWeaponSidebarKeysEnabled=false         ; boolean
 
 [AudioVisual]
-SuperWeaponSidebar.AllowByDefault=false   ; boolean
+SuperWeaponSidebar.AllowByDefault=false     ; boolean
 
-[SOMESIDE]
-SuperWeaponSidebar.OnPCX=             ; filename - including the .pcx extension
-SuperWeaponSidebar.OffPCX=            ; filename - including the .pcx extension
-SuperWeaponSidebar.TopPCX=            ; filename - including the .pcx extension
-SuperWeaponSidebar.CenterPCX=         ; filename - including the .pcx extension
-SuperWeaponSidebar.BottomPCX=         ; filename - including the .pcx extension
+[SOMESIDE]                                  ; Side
+SuperWeaponSidebar.OnPCX=                   ; filename - including the .pcx extension
+SuperWeaponSidebar.OffPCX=                  ; filename - including the .pcx extension
+SuperWeaponSidebar.TopPCX=                  ; filename - including the .pcx extension
+SuperWeaponSidebar.CenterPCX=               ; filename - including the .pcx extension
+SuperWeaponSidebar.BottomPCX=               ; filename - including the .pcx extension
 
-[SOMESW]
-SuperWeaponSidebar.Allow=             ; boolean
-SuperWeaponSidebar.PriorityHouses=    ; List of house types
-SuperWeaponSidebar.RequiredHouses=    ; List of house types
-SuperWeaponSidebar.Significance=0     ; integer
+[SOMESW]                                    ; SuperWeaponType
+SuperWeaponSidebar.Allow=                   ; boolean
+SuperWeaponSidebar.PriorityHouses=          ; List of house types
+SuperWeaponSidebar.RequiredHouses=          ; List of house types
+SuperWeaponSidebar.Significance=0           ; integer
 ```
 
 In `RA2MD.INI`:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -404,7 +404,7 @@ New:
 - [Customize limit and sound when engineer repair a building](New-or-Enhanced-Logics.md#engineer-repair-customization) (by NetsuNegi)
 - [Customizable debris trailer anim spawn delay](Fixed-or-Improved-Logics.md#customizable-debris-trailer-anim-spawn-delay) (by CrimRecya)
 - [Display banner](AI-Scripting-and-Mapping.md#display-banner) (by Morton & ststl)
-- Allows refineries to use multiple ActiveAnim simultaneously (by TaranDahl)
+- [Allows refineries to use multiple ActiveAnim simultaneously](Fixed-or-Improved-Logics.md#allows-refineries-to-use-multiple-activeanim-simultaneously) (by TaranDahl)
 - Electric/RadBeam trail for laser tails (by NetsuNegi)
 - Add `DebrisMinimums` to keep the count of debris within a certain range (by CrimRecya)
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -407,6 +407,7 @@ New:
 - [Allows refineries to use multiple ActiveAnim simultaneously](Fixed-or-Improved-Logics.md#allows-refineries-to-use-multiple-activeanim-simultaneously) (by TaranDahl)
 - Electric/RadBeam trail for laser tails (by NetsuNegi)
 - Add `DebrisMinimums` to keep the count of debris within a certain range (by CrimRecya)
+- Several attackmove related enhancement (by TaranDahl)
 
 Vanilla fixes:
 - Fixed sidebar not updating queued unit numbers when adding or removing units when the production is on hold (by CrimRecya)

--- a/docs/locale/zh_CN/LC_MESSAGES/AI-Scripting-and-Mapping.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/AI-Scripting-and-Mapping.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Phobos \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-29 22:49+0800\n"
+"POT-Creation-Date: 2025-06-19 21:54+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,6 +134,7 @@ msgstr ""
 
 #: ../../AI-Scripting-and-Mapping.md:24 ../../AI-Scripting-and-Mapping.md:99
 #: ../../AI-Scripting-and-Mapping.md:201 ../../AI-Scripting-and-Mapping.md:422
+#: ../../AI-Scripting-and-Mapping.md:685
 msgid "In `rulesmd.ini`:"
 msgstr "在 `rulesmd.ini`："
 
@@ -428,7 +429,7 @@ msgstr "*重复*"
 msgid "*Target Priority*"
 msgstr "*目标优先级*"
 
-#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:768
+#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:809
 msgid "*Description*"
 msgstr "*描述*"
 
@@ -1656,10 +1657,10 @@ msgstr "例如：`盟军战役25: 僵僵の钱 - 钱全被偷光了!`。"
 #: ../../AI-Scripting-and-Mapping.md:555 ../../AI-Scripting-and-Mapping.md:581
 #: ../../AI-Scripting-and-Mapping.md:594 ../../AI-Scripting-and-Mapping.md:606
 #: ../../AI-Scripting-and-Mapping.md:619 ../../AI-Scripting-and-Mapping.md:647
-#: ../../AI-Scripting-and-Mapping.md:661 ../../AI-Scripting-and-Mapping.md:675
-#: ../../AI-Scripting-and-Mapping.md:702 ../../AI-Scripting-and-Mapping.md:729
-#: ../../AI-Scripting-and-Mapping.md:754 ../../AI-Scripting-and-Mapping.md:772
-#: ../../AI-Scripting-and-Mapping.md:786
+#: ../../AI-Scripting-and-Mapping.md:661 ../../AI-Scripting-and-Mapping.md:700
+#: ../../AI-Scripting-and-Mapping.md:716 ../../AI-Scripting-and-Mapping.md:743
+#: ../../AI-Scripting-and-Mapping.md:770 ../../AI-Scripting-and-Mapping.md:795
+#: ../../AI-Scripting-and-Mapping.md:813 ../../AI-Scripting-and-Mapping.md:827
 msgid "In `mycampaign.map`:"
 msgstr "在 `mycampaign.map`："
 
@@ -1845,15 +1846,15 @@ msgstr "在指定位置发射 `[SuperWeaponTypes]` 列表中的超级武器。"
 msgid "`HouseIndex` can take various values:"
 msgstr "`HouseIndex` 可取以下值："
 
-#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:768
+#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:809
 msgid "*House Index*"
 msgstr "*所属方索引*"
 
-#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:768
+#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:809
 msgid ">= 0"
 msgstr ">= 0"
 
-#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:768
+#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:809
 msgid "The index of the current House in the map"
 msgstr "地图上当前所属方的索引"
 
@@ -1865,7 +1866,7 @@ msgstr "4475-4482"
 msgid "Like in the index range 0-7"
 msgstr "类似范围 0-7 的索引"
 
-#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:768
+#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:809
 msgid "-1"
 msgstr "-1"
 
@@ -1873,7 +1874,7 @@ msgstr "-1"
 msgid "Pick a random House that isn't Neutral"
 msgstr "选择一个非中立的随机所属方"
 
-#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:768
+#: ../../AI-Scripting-and-Mapping.md ../../AI-Scripting-and-Mapping.md:809
 msgid "-2"
 msgstr "-2"
 
@@ -2028,18 +2029,150 @@ msgstr ""
 "...\n"
 
 #: ../../AI-Scripting-and-Mapping.md:669
+msgid "`800-802` Display Banner"
+msgstr "`800-802` 显示横幅"
+
+#: ../../AI-Scripting-and-Mapping.md:671
+msgid "Display a 'banner' at a fixed location that is relative to the screen."
+msgstr "在屏幕固定位置显示一个“横幅”。"
+
+#: ../../AI-Scripting-and-Mapping.md:672
+msgid ""
+"Action `800` will create a new banner or replace the banner with the same"
+" Banner ID if it exists. Using a local variable's value when displaying a"
+" text banner."
+msgstr "结果 `800` 将会创建一个新的横幅或替换掉拥有相同 Banner ID 的旧有横幅。显示文本横幅时将使用 **局部** 变量的值。"
+
+#: ../../AI-Scripting-and-Mapping.md:673
+msgid ""
+"Action `801` will create a new banner or replace the banner with the same"
+" Banner ID if it exists. Using a global variable's value when displaying "
+"a text banner."
+msgstr "结果 `801` 将会创建一个新的横幅或替换掉拥有相同 Banner ID 的旧有横幅。显示文本横幅时将使用 **全局** 变量的值。"
+
+#: ../../AI-Scripting-and-Mapping.md:674
+msgid "Action `802` will delete the banner corresponding to the set Banner ID."
+msgstr "结果 `802` 将会删除与设定 Banner ID 相同的横幅。"
+
+#: ../../AI-Scripting-and-Mapping.md:675
+msgid ""
+"To make use of this, you need to set the properties of a `BannerType` in "
+"your ini file. The banner can either be a `PCX` file, a Shape (`SHP`) "
+"file or a `CSF` text. If multiple are set the first one in the above "
+"listed order takes effect."
+msgstr ""
+"使用该功能前需在 ini 文件中配置 `BannerType` 属性。横幅支持使用一个 PCX 文件，一个 SHP 文件，或一个 CSF "
+"条目。若多项同时设置则同样按此处所列的优先级顺序生效。"
+
+#: ../../AI-Scripting-and-Mapping.md:676
+msgid ""
+"`SHP.Palette` controls the palette that'll be used when drawing a banner "
+"for Shape file."
+msgstr "`SHP.Palette` 控制绘制 SHP 横幅时所使用的色盘。"
+
+#: ../../AI-Scripting-and-Mapping.md:677
+msgid ""
+"`CSF.Color` controls the color of the text that'll be used when drawing a"
+" text banner."
+msgstr "`CSF.Color` 控制使用 CSF 条目横幅时的文本颜色"
+
+#: ../../AI-Scripting-and-Mapping.md:678
+msgid ""
+"`CSF.Background` controls whether a black background will be displayed "
+"below the text banner."
+msgstr "`CSF.Background` 控制使用 CSF 条目横幅时是否具有黑色底色。"
+
+#: ../../AI-Scripting-and-Mapping.md:679
+msgid ""
+"`CSF.VariableFormat` controls the way to print a variable together with "
+"the text banner."
+msgstr "`CSF.VariableFormat` 控制使用 CSF 条目横幅时的变量显示方式。"
+
+#: ../../AI-Scripting-and-Mapping.md:680
+msgid "`none` will make the text banner not display the variable."
+msgstr "`none` - 不显示变量。"
+
+#: ../../AI-Scripting-and-Mapping.md:681
+msgid ""
+"`variable` will make the text banner display the variable alone and will "
+"ignore the text in `CSF`."
+msgstr "`variable` - 仅显示变量，并忽略 CSF 条目文本。"
+
+#: ../../AI-Scripting-and-Mapping.md:682
+msgid ""
+"`prefix`/`prefixed` will make the text banner display the variable before"
+" any other text."
+msgstr "`prefix`/`prefixed` - 变量在其他文本 **前** 显示。"
+
+#: ../../AI-Scripting-and-Mapping.md:683
+msgid ""
+"`surfix`/`surfixed` will make the text banner display the variable after "
+"any other text."
+msgstr "`surfix`/`surfixed` - 变量在其他文本 **后** 显示。"
+
+#: ../../AI-Scripting-and-Mapping.md:686
+msgid ""
+"[BannerTypes]\n"
+"0=SOMEBANNER\n"
+"\n"
+"[SOMEBANNER]                ; BannerType\n"
+"PCX=                        ; filename - excluding the .pcx extension\n"
+"SHP=                        ; filename - excluding the .shp extension\n"
+"SHP.Palette=palette.pal     ; filename - excluding the .pal extension\n"
+"CSF=                        ; CSF entry key\n"
+"CSF.Color=                  ; integer - R,G,B, defaults to "
+"MessageTextColor of the owner Side\n"
+"CSF.Background=false        ; boolean\n"
+"CSF.VariableFormat=none     ; List of Variable Format Enumeration "
+"(none|variable|prefix/prefixed|surfix/surfixed)\n"
+msgstr ""
+"[BannerTypes]\n"
+"0=SOMEBANNER\n"
+"\n"
+"[SOMEBANNER]                ; BannerType\n"
+"PCX=                        ; filename - excluding the .pcx extension\n"
+"SHP=                        ; filename - excluding the .shp extension\n"
+"SHP.Palette=palette.pal     ; filename - excluding the .pal extension\n"
+"CSF=                        ; CSF entry key\n"
+"CSF.Color=                  ; integer - R,G,B, defaults to "
+"MessageTextColor of the owner Side\n"
+"CSF.Background=false        ; boolean\n"
+"CSF.VariableFormat=none     ; List of Variable Format Enumeration "
+"(none|variable|prefix/prefixed|surfix/surfixed)\n"
+
+#: ../../AI-Scripting-and-Mapping.md:701
+msgid ""
+"[Actions]\n"
+"...\n"
+"ID=ActionCount,[Action1],800,4,[SOMEBANNER],[Unique ID],[Horizontal "
+"position],[Vertical position],[VariableIndex],A,[ActionX]\n"
+"ID=ActionCount,[Action1],801,4,[SOMEBANNER],[Unique ID],[Horizontal "
+"position],[Vertical position],[VariableIndex],A,[ActionX]\n"
+"ID=ActionCount,[Action1],802,0,[Unique ID],0,0,0,0,A,[ActionX]\n"
+"...\n"
+msgstr ""
+"[Actions]\n"
+"...\n"
+"ID=ActionCount,[Action1],800,4,[SOMEBANNER],[Unique ID],[Horizontal "
+"position],[Vertical position],[VariableIndex],A,[ActionX]\n"
+"ID=ActionCount,[Action1],801,4,[SOMEBANNER],[Unique ID],[Horizontal "
+"position],[Vertical position],[VariableIndex],A,[ActionX]\n"
+"ID=ActionCount,[Action1],802,0,[Unique ID],0,0,0,0,A,[ActionX]\n"
+"...\n"
+
+#: ../../AI-Scripting-and-Mapping.md:710
 msgid "Trigger events"
 msgstr "触发条件"
 
-#: ../../AI-Scripting-and-Mapping.md:671
+#: ../../AI-Scripting-and-Mapping.md:712
 msgid "`500-511` Variable comparation"
 msgstr "`500-511` 变量比较"
 
-#: ../../AI-Scripting-and-Mapping.md:673
+#: ../../AI-Scripting-and-Mapping.md:714
 msgid "Compares the variable's value with given number."
 msgstr "比较变量值与给定值。"
 
-#: ../../AI-Scripting-and-Mapping.md:676
+#: ../../AI-Scripting-and-Mapping.md:717
 msgid ""
 "[Events]\n"
 "...\n"
@@ -2127,15 +2260,15 @@ msgstr "510"
 msgid "511"
 msgstr "511"
 
-#: ../../AI-Scripting-and-Mapping.md:698
+#: ../../AI-Scripting-and-Mapping.md:739
 msgid "`512-523` Variable comparation with local variable"
 msgstr "`512-523` 变量与局部变量比较"
 
-#: ../../AI-Scripting-and-Mapping.md:700
+#: ../../AI-Scripting-and-Mapping.md:741
 msgid "Compares the variable's value with given local variable value."
 msgstr "比较变量值与给定局部变量值。"
 
-#: ../../AI-Scripting-and-Mapping.md:703
+#: ../../AI-Scripting-and-Mapping.md:744
 msgid ""
 "[Events]\n"
 "...\n"
@@ -2221,15 +2354,15 @@ msgstr "522"
 msgid "523"
 msgstr "523"
 
-#: ../../AI-Scripting-and-Mapping.md:725
+#: ../../AI-Scripting-and-Mapping.md:766
 msgid "`524-535` Variable comparation with global variable"
 msgstr "`524-535` 变量与全局变量比较"
 
-#: ../../AI-Scripting-and-Mapping.md:727
+#: ../../AI-Scripting-and-Mapping.md:768
 msgid "Compares the variable's value with given global variable value."
 msgstr "比较变量值与给定全局变量值。"
 
-#: ../../AI-Scripting-and-Mapping.md:730
+#: ../../AI-Scripting-and-Mapping.md:771
 msgid ""
 "[Events]\n"
 "...\n"
@@ -2315,11 +2448,11 @@ msgstr "534"
 msgid "535"
 msgstr "535"
 
-#: ../../AI-Scripting-and-Mapping.md:752
+#: ../../AI-Scripting-and-Mapping.md:793
 msgid "`600` The shield of the attached object is broken"
 msgstr "`600` 对象护盾被摧毁"
 
-#: ../../AI-Scripting-and-Mapping.md:755
+#: ../../AI-Scripting-and-Mapping.md:796
 msgid ""
 "[Events]\n"
 "...\n"
@@ -2331,27 +2464,27 @@ msgstr ""
 "ID=EventCount,...,600,2,0,0,...\n"
 "...\n"
 
-#: ../../AI-Scripting-and-Mapping.md:762
+#: ../../AI-Scripting-and-Mapping.md:803
 msgid "`601-602` House owns/doesn't own Techno Type"
 msgstr "`601-602` 检查所属方是否有／无科技类型"
 
-#: ../../AI-Scripting-and-Mapping.md:764
+#: ../../AI-Scripting-and-Mapping.md:805
 msgid ""
 "`601`: Springs when specified house owns at least 1 instance of set "
 "TechnoType."
 msgstr "`601`：当指定所属方至少拥有一个设定的科技类型时触发。"
 
-#: ../../AI-Scripting-and-Mapping.md:765
+#: ../../AI-Scripting-and-Mapping.md:806
 msgid ""
 "`602`: Springs when specified house doesn't own a single instance of set "
 "TechnoType."
 msgstr "`602`：当指定所属方没有任何一个设定的科技类型时触发。"
 
-#: ../../AI-Scripting-and-Mapping.md:766
+#: ../../AI-Scripting-and-Mapping.md:807
 msgid "Multiplayer houses (indices 4475 through 4482) are supported."
 msgstr "多人游戏所属方（索引 4475 至 4482）支持。"
 
-#: ../../AI-Scripting-and-Mapping.md:769
+#: ../../AI-Scripting-and-Mapping.md:810
 msgid ""
 "These events, as opposed to [events 81 & 82 from Ares](https://ares-"
 "developers.github.io/Ares-docs/new/triggerevents.html#house-owns-techno-"
@@ -2362,7 +2495,7 @@ msgstr ""
 "docs/new/triggerevents.html#house-owns-techno-"
 "type-81-82)不同，这些使用条件中的所属方参数而不是触发的所有者。"
 
-#: ../../AI-Scripting-and-Mapping.md:773
+#: ../../AI-Scripting-and-Mapping.md:814
 msgid ""
 "[Events]\n"
 "...\n"
@@ -2374,44 +2507,31 @@ msgstr ""
 "ID=EventCount,...,[EVENTID],2,[HouseIndex],[TechnoType],...\n"
 "...\n"
 
-#: ../../AI-Scripting-and-Mapping.md:780
+#: ../../AI-Scripting-and-Mapping.md:821
 msgid "`604-605` Checking if a specific Techno enters in a cell"
 msgstr "`604-605` 检查特定科技类型进入单元格"
 
-#: ../../AI-Scripting-and-Mapping.md:782
+#: ../../AI-Scripting-and-Mapping.md:823
 msgid ""
 "`604`: Checks if the techno that entered in the cell has the same ID "
 "specified in the event."
 msgstr "`604`：检查进入单元格的科技类型是否与条件中指定的 ID相同。"
 
-#: ../../AI-Scripting-and-Mapping.md:783
+#: ../../AI-Scripting-and-Mapping.md:824
 msgid ""
 "`605`: Checks if the techno that entered in the cell appears in the "
 "selected list in `AITargetTypes`."
 msgstr "`605`：检查进入单元格的科技类型是否出现在选定的 `AITargetTypes` 列表中。"
 
-#: ../../AI-Scripting-and-Mapping.md:784
+#: ../../AI-Scripting-and-Mapping.md:825
 msgid "`HouseIndex` can be customized to focus in a specified house."
 msgstr "`HouseIndex` 可以自定义为指定所属方。"
 
-#: ../../AI-Scripting-and-Mapping.md:768
+#: ../../AI-Scripting-and-Mapping.md:809
 msgid "This value is ignored (any house is valid)"
 msgstr "该值将被忽略（任何所属方均有效）"
 
-#: ../../AI-Scripting-and-Mapping.md:768
+#: ../../AI-Scripting-and-Mapping.md:809
 msgid "Pick the owner of the map trigger"
 msgstr "选择地图触发的所有者"
-
-#~ msgid ""
-#~ "[Events]\n"
-#~ "...\n"
-#~ "ID=EventCount,...,604,2,[HouseIndex],[TechnoType],...\n"
-#~ "ID=EventCount,...,605,2,[HouseIndex],[AITargetTypes index#],...\n"
-#~ "...\n"
-#~ msgstr ""
-#~ "[Events]\n"
-#~ "...\n"
-#~ "ID=EventCount,...,604,2,[HouseIndex],[TechnoType],...\n"
-#~ "ID=EventCount,...,605,2,[HouseIndex],[AITargetTypes index#],...\n"
-#~ "...\n"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/CREDITS.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Phobos \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-15 21:26+0800\n"
+"POT-Creation-Date: 2025-06-23 01:10+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -185,11 +185,11 @@ msgstr "VSCode 配置"
 msgid "Code style"
 msgstr "代码样式"
 
-#: ../../../CREDITS.md:48 ../../../CREDITS.md:438
+#: ../../../CREDITS.md:48 ../../../CREDITS.md:443
 msgid "Customizable ElectricBolt Arcs"
 msgstr "自定义 EBolt 电弧"
 
-#: ../../../CREDITS.md:50 ../../../CREDITS.md:290
+#: ../../../CREDITS.md:50 ../../../CREDITS.md:291
 msgid "Voxel light source position customization"
 msgstr "自定义 Voxel 光源"
 
@@ -205,7 +205,7 @@ msgstr "目标血量作为弹头生效条件"
 msgid "**Uranusian (Thrifinesma)**:"
 msgstr "**Uranusian (Thrifinesma)**："
 
-#: ../../../CREDITS.md:54 ../../../CREDITS.md:80
+#: ../../../CREDITS.md:54 ../../../CREDITS.md:81
 msgid "Mind Control enhancement"
 msgstr "心灵控制增强"
 
@@ -213,7 +213,7 @@ msgstr "心灵控制增强"
 msgid "Custom warhead splash list"
 msgstr "自定义弹头水花动画"
 
-#: ../../../CREDITS.md:56 ../../../CREDITS.md:323
+#: ../../../CREDITS.md:56 ../../../CREDITS.md:325
 msgid "Harvester counter"
 msgstr "矿车计数器"
 
@@ -241,7 +241,7 @@ msgstr "标签快捷键放置修复"
 msgid "Producing progress indicators"
 msgstr "生产进度指示器"
 
-#: ../../../CREDITS.md:64 ../../../CREDITS.md:87
+#: ../../../CREDITS.md:64 ../../../CREDITS.md:88
 msgid "Custom ore gathering anim"
 msgstr "自定义矿石采集动画"
 
@@ -277,856 +277,864 @@ msgstr "允许部署士兵使用两个武器"
 msgid "Observer PCX loading screen"
 msgstr "观察者 PCX 载入图"
 
-#: ../../../CREDITS.md:73 ../../../CREDITS.md:101 ../../../CREDITS.md:229
-#: ../../../CREDITS.md:409
+#: ../../../CREDITS.md:73 ../../../CREDITS.md:102 ../../../CREDITS.md:230
+#: ../../../CREDITS.md:411
 msgid "Original `Arcing` elevation inaccuracy fix"
 msgstr "原版 `Arcing` 高差打偏问题修复"
 
-#: ../../../CREDITS.md:74
+#: ../../../CREDITS.md:74 ../../../CREDITS.md:419
+msgid "Display banner improvement"
+msgstr "横幅改进"
+
+#: ../../../CREDITS.md:75
 msgid "Official CN docs for Build#29 and previous versions"
 msgstr "Build#29 及之前版本的 Phobos 官方中文文档"
 
-#: ../../../CREDITS.md:75
+#: ../../../CREDITS.md:76
 msgid "**secsome (SEC-SOME)**:"
 msgstr "**secsome (SEC-SOME)**："
 
-#: ../../../CREDITS.md:76
+#: ../../../CREDITS.md:77
 msgid "Debug info dump hotkey"
 msgstr "输出对象信息快捷键"
 
-#: ../../../CREDITS.md:77
+#: ../../../CREDITS.md:78
 msgid "Refactoring & porting of Ares helper code"
 msgstr "重构与导入 Ares 助手代码"
 
-#: ../../../CREDITS.md:78
+#: ../../../CREDITS.md:79
 msgid "Disguise removal warhead"
 msgstr "移除伪装弹头"
 
-#: ../../../CREDITS.md:79
+#: ../../../CREDITS.md:80
 msgid "Mind Control removal warhead"
 msgstr "解除心控弹头"
 
-#: ../../../CREDITS.md:81
+#: ../../../CREDITS.md:82
 msgid "Shields logic help"
 msgstr "护盾逻辑帮助"
 
-#: ../../../CREDITS.md:82
+#: ../../../CREDITS.md:83
 msgid "`AnimList.PickRandom`"
 msgstr "`AnimList.PickRandom`"
 
-#: ../../../CREDITS.md:83
+#: ../../../CREDITS.md:84
 msgid "`MoveToCell` fix"
 msgstr "`3 - 移动到坐标` 修复"
 
-#: ../../../CREDITS.md:84
+#: ../../../CREDITS.md:85
 msgid "Unlimited waypoints"
 msgstr "无限制路径点"
 
-#: ../../../CREDITS.md:85
+#: ../../../CREDITS.md:86
 msgid "`Build At` trigger action buildup anim fix"
 msgstr "触发结果 `125 将建筑建于...` 建造动画修复"
 
-#: ../../../CREDITS.md:86
+#: ../../../CREDITS.md:87
 msgid "Undeploy building into a unit plays `EVA_NewRallyPointEstablished` fix"
 msgstr "建筑反部署成载具时播放 `EVA_NewRallyPointEstablished` 问题修复"
 
-#: ../../../CREDITS.md:88
+#: ../../../CREDITS.md:89
 msgid "`TemporalClass` related crash"
 msgstr "`TemporalClass` 相关修复"
 
-#: ../../../CREDITS.md:89
+#: ../../../CREDITS.md:90
 msgid "Retry dialog on mission failure"
 msgstr "任务失败重开对话框"
 
-#: ../../../CREDITS.md:90
+#: ../../../CREDITS.md:91
 msgid "Default disguise for individual InfantryTypes"
 msgstr "步兵类型微观定义默认伪装"
 
-#: ../../../CREDITS.md:91
+#: ../../../CREDITS.md:92
 msgid "PowerPlant Enhancer"
 msgstr "电厂增幅器"
 
-#: ../../../CREDITS.md:92
+#: ../../../CREDITS.md:93
 msgid "SaveGame Trigger Action"
 msgstr "保存游戏触发结果"
 
-#: ../../../CREDITS.md:93
+#: ../../../CREDITS.md:94
 msgid "QuickSave command"
 msgstr "快速保存命令"
 
-#: ../../../CREDITS.md:94
+#: ../../../CREDITS.md:95
 msgid "Numeric variables"
 msgstr "数字化变量"
 
-#: ../../../CREDITS.md:95
+#: ../../../CREDITS.md:96
 msgid "Custom gravity for projectiles"
 msgstr "抛射体自定义重力"
 
-#: ../../../CREDITS.md:96
+#: ../../../CREDITS.md:97
 msgid "Retint map actions bugfix"
 msgstr "地图触发光照 bug 修复"
 
-#: ../../../CREDITS.md:97
+#: ../../../CREDITS.md:98
 msgid "Sharpnel enhancement"
 msgstr "溅射增强"
 
-#: ../../../CREDITS.md:98
+#: ../../../CREDITS.md:99
 msgid "Vanilla map preview reading bugfix"
 msgstr "原版地图预览图读取 bug 修复"
 
-#: ../../../CREDITS.md:99
+#: ../../../CREDITS.md:100
 msgid "Customizable tooltip background"
 msgstr "自定义拓展工具条背景"
 
-#: ../../../CREDITS.md:100
+#: ../../../CREDITS.md:101
 msgid "Parts of Ares calling code"
 msgstr "部分 Ares 调用代码"
 
-#: ../../../CREDITS.md:102
+#: ../../../CREDITS.md:103
 msgid "Dehardcode 255 limit of `OverlayType`"
 msgstr "解除了覆盖物最多 255 个的数量限制"
 
-#: ../../../CREDITS.md:103
+#: ../../../CREDITS.md:104
 msgid "**Otamaa (Fahroni, BoredEXE)**:"
 msgstr "**Otamaa (Fahroni, BoredEXE)**："
 
-#: ../../../CREDITS.md:104
+#: ../../../CREDITS.md:105
 msgid "Help with CellSpread"
 msgstr "`CellSpread` 相关协助"
 
-#: ../../../CREDITS.md:105
+#: ../../../CREDITS.md:106
 msgid "Ported and fixed custom RadType code"
 msgstr "引入并修复了自定义辐射的代码"
 
-#: ../../../CREDITS.md:106
+#: ../../../CREDITS.md:107
 msgid "Togglable ElectricBolt bolts"
 msgstr "可开关的 EBolt 特效"
 
-#: ../../../CREDITS.md:107
+#: ../../../CREDITS.md:108
 msgid "Customizable Chrono Locomotor properties per TechnoClass"
 msgstr "科技类型自定义超时空运动模式属性"
 
-#: ../../../CREDITS.md:108
+#: ../../../CREDITS.md:109
 msgid "Building Placement Preview"
 msgstr "建筑放置预览"
 
-#: ../../../CREDITS.md:109
+#: ../../../CREDITS.md:110
 msgid "`DebrisMaximums` fixes"
 msgstr "`DebrisMaximums` 修复"
 
-#: ../../../CREDITS.md:110
+#: ../../../CREDITS.md:111
 msgid "Anim-to-Unit"
 msgstr "动画生成单位"
 
-#: ../../../CREDITS.md:111
+#: ../../../CREDITS.md:112
 msgid "`NotHuman` anim sequences improvements"
 msgstr "`NotHuman` 动画序列增强"
 
-#: ../../../CREDITS.md:112
+#: ../../../CREDITS.md:113
 msgid "Customizable `OpenTopped` Properties"
 msgstr "自定义 `OpenTopped` 属性"
 
-#: ../../../CREDITS.md:113
+#: ../../../CREDITS.md:114
 msgid "Hooks for ScriptType Actions 92 & 93"
 msgstr "动作脚本 92 与 93 的钩子"
 
-#: ../../../CREDITS.md:114
+#: ../../../CREDITS.md:115
 msgid "Ore stage threshold for `HideIfNoOre`"
 msgstr "`HideIfNoOre` 的矿石阶段阈值"
 
-#: ../../../CREDITS.md:115
+#: ../../../CREDITS.md:116
 msgid "Occupied building `MuzzleFlashX` bugfix"
 msgstr "驻军建筑 `MuzzleFlashX` bug 修复"
 
-#: ../../../CREDITS.md:116
+#: ../../../CREDITS.md:117
 msgid "`EnemyUIName` for other TechnoTypes"
 msgstr "其他科技类型的 `EnemyUIName`"
 
-#: ../../../CREDITS.md:117
+#: ../../../CREDITS.md:118
 msgid "TerrainType `DestroyAnim` & `DestroySound`"
 msgstr "地形对象的 `DestroyAnim` 和 `DestroySound`"
 
-#: ../../../CREDITS.md:118
+#: ../../../CREDITS.md:119
 msgid "Laser trails for VoxelAnims"
 msgstr "Voxel 碎片的激光尾焰"
 
-#: ../../../CREDITS.md:119
+#: ../../../CREDITS.md:120
 msgid "`MakeInfantry` logic on BombClass bugfix"
 msgstr "`MakeInfantry` 逻辑在 BombClass 上的 bug 修复"
 
-#: ../../../CREDITS.md:120 ../../../CREDITS.md:207
+#: ../../../CREDITS.md:121 ../../../CREDITS.md:208
 msgid "Debris & meteor impact behaviour settings"
 msgstr "碎片 & 流星撞击行为设置"
 
-#: ../../../CREDITS.md:121
+#: ../../../CREDITS.md:122
 msgid "Upgrade logic to allow altering of `SpySat` status"
 msgstr "允许加载物逻辑更改 `SpySat` 效果"
 
-#: ../../../CREDITS.md:122 ../../../CREDITS.md:284
+#: ../../../CREDITS.md:123 ../../../CREDITS.md:285
 msgid "Ares detection and integration"
 msgstr "Ares 检测和集成"
 
-#: ../../../CREDITS.md:123
+#: ../../../CREDITS.md:124
 msgid "Help with custom locomotors"
 msgstr "自定义运动模式相关的帮助"
 
-#: ../../../CREDITS.md:124 ../../../CREDITS.md:227
+#: ../../../CREDITS.md:125 ../../../CREDITS.md:228
 msgid "Extension class optimization"
 msgstr "扩展类优化"
 
-#: ../../../CREDITS.md:125
+#: ../../../CREDITS.md:126
 msgid "Overload characteristic dehardcoded"
 msgstr "自定义脑车过载"
 
-#: ../../../CREDITS.md:126
+#: ../../../CREDITS.md:127
 msgid "Customizable garrison and bunker properties"
 msgstr "自定义驻军建筑与坦克碉堡属性"
 
-#: ../../../CREDITS.md:127
+#: ../../../CREDITS.md:128
 msgid "Disable `DamageSound` for buildings"
 msgstr "禁用 `DamageSound`"
 
-#: ../../../CREDITS.md:128 ../../../CREDITS.md:510
+#: ../../../CREDITS.md:129 ../../../CREDITS.md:516
 msgid "Power plant damage factor"
 msgstr "伤残电厂电量系数"
 
-#: ../../../CREDITS.md:129
+#: ../../../CREDITS.md:130
 msgid "**FS-21**:"
 msgstr "**FS-21**："
 
-#: ../../../CREDITS.md:130
+#: ../../../CREDITS.md:131
 msgid "Dump Object Info enhancements"
 msgstr "输出对象信息增强"
 
-#: ../../../CREDITS.md:131
+#: ../../../CREDITS.md:132
 msgid "`Powered.KillSpawns`"
 msgstr "`Powered.KillSpawns`"
 
-#: ../../../CREDITS.md:132
+#: ../../../CREDITS.md:133
 msgid "`Spawner.LimitRange`"
 msgstr "`Spawner.LimitRange`"
 
-#: ../../../CREDITS.md:133
+#: ../../../CREDITS.md:134
 msgid "Majority of ScriptType actions"
 msgstr "大多数动作脚本行为"
 
-#: ../../../CREDITS.md:134
+#: ../../../CREDITS.md:135
 msgid "MC deployer fixes"
 msgstr "被心灵控制状态下部署行为的修复"
 
-#: ../../../CREDITS.md:135 ../../../CREDITS.md:292
+#: ../../../CREDITS.md:136 ../../../CREDITS.md:294
 msgid "Help with docs"
 msgstr "文档相关的帮助"
 
-#: ../../../CREDITS.md:136
+#: ../../../CREDITS.md:137
 msgid "Automatic Passenger Deletion logic"
 msgstr "自动删除乘客逻辑"
 
-#: ../../../CREDITS.md:137
+#: ../../../CREDITS.md:138
 msgid "`Fire SW At Location/Waypoint` Trigger Action"
 msgstr "`在坐标／路径点释放超级武器` 触发结果"
 
-#: ../../../CREDITS.md:138
+#: ../../../CREDITS.md:139
 msgid "Kill Object Automatically logic prototype"
 msgstr "单位自毁逻辑雏形"
 
-#: ../../../CREDITS.md:139
+#: ../../../CREDITS.md:140
 msgid "Customizable resource storage"
 msgstr "自定义资源存储"
 
-#: ../../../CREDITS.md:140
+#: ../../../CREDITS.md:141
 msgid "Override uncloaked underwater attack behavior"
 msgstr "覆盖对非隐形状态水下目标的攻击行为"
 
-#: ../../../CREDITS.md:141
+#: ../../../CREDITS.md:142
 msgid "Override target under EMP attack behavior"
 msgstr "覆盖对被 EMP 瘫痪的目标的攻击行为"
 
-#: ../../../CREDITS.md:142
+#: ../../../CREDITS.md:143
 msgid "AI Aircraft docks fix"
 msgstr "AI 战机对接修复"
 
-#: ../../../CREDITS.md:143
+#: ../../../CREDITS.md:144
 msgid "Shared ammo logic"
 msgstr "共享弹药逻辑"
 
-#: ../../../CREDITS.md:144
+#: ../../../CREDITS.md:145
 msgid "Customizable FLH when infantry is prone or deployed"
 msgstr "自定义步兵匍匐或部署时的 FLH"
 
-#: ../../../CREDITS.md:145
+#: ../../../CREDITS.md:146
 msgid "Initial strength for cloned infantry"
 msgstr "克隆步兵的初始血量"
 
-#: ../../../CREDITS.md:146
+#: ../../../CREDITS.md:147
 msgid "Map Events 604 & 605 for checking if a specific Techno enters in a cell"
 msgstr "用于检查特定科技类型是否进入单元格的 604 与 605 号地图触发条件"
 
-#: ../../../CREDITS.md:147
+#: ../../../CREDITS.md:148
 msgid "Warhead that can not kill"
 msgstr "弹头击杀限制"
 
-#: ../../../CREDITS.md:148
+#: ../../../CREDITS.md:149
 msgid "`Pips.HideIfNoStrength` and `SelfHealing.EnabledBy` additions for shields"
 msgstr "护盾新增功能 `Pips.HideIfNoStrength` 与 `SelfHealing.EnabledBy`"
 
-#: ../../../CREDITS.md:149
+#: ../../../CREDITS.md:150
 msgid "Warhead activation target health thresholds enhancements"
 msgstr "目标血量作为弹头生效条件的进一步改进"
 
-#: ../../../CREDITS.md:150
+#: ../../../CREDITS.md:151
 msgid "**Starkku**:"
 msgstr "**Starkku**："
 
-#: ../../../CREDITS.md:151
+#: ../../../CREDITS.md:152
 msgid "Misc. minor bugfixes & improvements"
 msgstr "各种小 bug 修复与改进"
 
-#: ../../../CREDITS.md:152
+#: ../../../CREDITS.md:153
 msgid "AI script actions:"
 msgstr "AI 脚本动作："
 
-#: ../../../CREDITS.md:153
+#: ../../../CREDITS.md:154
 msgid "Chronoshift to Enemy Base"
 msgstr "超时空传送到敌方基地"
 
-#: ../../../CREDITS.md:154
+#: ../../../CREDITS.md:155
 msgid "Warhead shield penetration & breaking"
 msgstr "弹头穿盾和破盾"
 
-#: ../../../CREDITS.md:155 ../../../CREDITS.md:307
+#: ../../../CREDITS.md:156 ../../../CREDITS.md:309
 msgid "Strafing aircraft weapon customization"
 msgstr "自定义战机武器扫射"
 
-#: ../../../CREDITS.md:156
+#: ../../../CREDITS.md:157
 msgid "Vehicle `DeployFire` fixes/improvements"
 msgstr "载具 `DeployFire` 修复／改进"
 
-#: ../../../CREDITS.md:157
+#: ../../../CREDITS.md:158
 msgid "Stationary VehicleTypes"
 msgstr "静止的载具"
 
-#: ../../../CREDITS.md:158
+#: ../../../CREDITS.md:159
 msgid "Burst logic improvements"
 msgstr "Burst 逻辑改进"
 
-#: ../../../CREDITS.md:159
+#: ../../../CREDITS.md:160
 msgid "TechnoType auto-firing weapons"
 msgstr "科技类型自动发射武器"
 
-#: ../../../CREDITS.md:160
+#: ../../../CREDITS.md:161
 msgid "Secondary weapon fallback customization"
 msgstr "自定义副武器自动推算"
 
-#: ../../../CREDITS.md:161
+#: ../../../CREDITS.md:162
 msgid "Weapon target type filtering"
 msgstr "武器目标类型过滤"
 
-#: ../../../CREDITS.md:162
+#: ../../../CREDITS.md:163
 msgid "`AreaFire` targeting customization"
 msgstr "自定义 `AreaFire` 目标选择"
 
-#: ../../../CREDITS.md:163
+#: ../../../CREDITS.md:164
 msgid "`CreateUnit` improvements"
 msgstr "`CreateUnit` 改进"
 
-#: ../../../CREDITS.md:164
+#: ../../../CREDITS.md:165
 msgid "Attached animation & jumpjet unit layer customization"
 msgstr "自定义附着动画与 Jumpjet 单位图层"
 
-#: ../../../CREDITS.md:165
+#: ../../../CREDITS.md:166
 msgid "`IsSimpleDeployer` improvements"
 msgstr "`IsSimpleDeployer` 改进"
 
-#: ../../../CREDITS.md:166
+#: ../../../CREDITS.md:167
 msgid "Shield modification warheads"
 msgstr "护盾修改弹头"
 
-#: ../../../CREDITS.md:167
+#: ../../../CREDITS.md:168
 msgid "Warhead decloaking toggle"
 msgstr "弹头解除隐形逻辑"
 
-#: ../../../CREDITS.md:168
+#: ../../../CREDITS.md:169
 msgid "`Warp(In/Out)Weapon`"
 msgstr "`Warp(In/Out)Weapon`"
 
-#: ../../../CREDITS.md:169
+#: ../../../CREDITS.md:170
 msgid "Grinder improvements / additions"
 msgstr "回收站改进／补充"
 
-#: ../../../CREDITS.md:170
+#: ../../../CREDITS.md:171
 msgid "Attached animation position customization"
 msgstr "自定义附着动画位置"
 
-#: ../../../CREDITS.md:171
+#: ../../../CREDITS.md:172
 msgid "Critical hit logic additions"
 msgstr "暴击逻辑补充"
 
-#: ../../../CREDITS.md:172
+#: ../../../CREDITS.md:173
 msgid "Aircraft & jumpjet speed modifiers fix"
 msgstr "战机与 Jumpjet 单位速度修正的修复"
 
-#: ../../../CREDITS.md:173
+#: ../../../CREDITS.md:174
 msgid "Local warhead screen shaking"
 msgstr "限制屏幕抖动于当前视角"
 
-#: ../../../CREDITS.md:174
+#: ../../../CREDITS.md:175
 msgid "Vehicle custom palette fix"
 msgstr "载具自定义色盘修复"
 
-#: ../../../CREDITS.md:175
+#: ../../../CREDITS.md:176
 msgid "Feedback weapon"
 msgstr "反馈武器"
 
-#: ../../../CREDITS.md:176
+#: ../../../CREDITS.md:177
 msgid "TerrainType & ore minimap color customization"
 msgstr "自定义地形对象与矿石小地图颜色"
 
-#: ../../../CREDITS.md:177
+#: ../../../CREDITS.md:178
 msgid "Laser fixes & improvements"
 msgstr "激光修复和改进"
 
-#: ../../../CREDITS.md:178
+#: ../../../CREDITS.md:179
 msgid "Mind control indicator animation cloak fix"
 msgstr "隐形状态下的心灵控制指示动画修复"
 
-#: ../../../CREDITS.md:179
+#: ../../../CREDITS.md:180
 msgid "Warhead / Play animation trigger animation owner fix"
 msgstr "弹头／播放动画触发的动画所属方修复"
 
-#: ../../../CREDITS.md:180
+#: ../../../CREDITS.md:181
 msgid "Nuke carrier & payload `Bright` fix"
 msgstr "核弹载体与载荷武器 `Bright` 修复"
 
-#: ../../../CREDITS.md:181
+#: ../../../CREDITS.md:182
 msgid "Display damage numbers hotkey command"
 msgstr "显示伤害数字快捷键命令"
 
-#: ../../../CREDITS.md:182
+#: ../../../CREDITS.md:183
 msgid "`TransactMoney.Display`"
 msgstr "`TransactMoney.Display`"
 
-#: ../../../CREDITS.md:183
+#: ../../../CREDITS.md:184
 msgid "Building-provided self-heal customization"
 msgstr "自定义建筑提供的自愈"
 
-#: ../../../CREDITS.md:184
+#: ../../../CREDITS.md:185
 msgid "AI deploy script `DeploysInto` fix"
 msgstr "AI 部署脚本中 `DeploysInto` 的修复"
 
-#: ../../../CREDITS.md:185
+#: ../../../CREDITS.md:186
 msgid "Passable & buildable-upon TerrainTypes"
 msgstr "可通行和可建造于其上的地形对象"
 
-#: ../../../CREDITS.md:186
+#: ../../../CREDITS.md:187
 msgid "Automatic passenger owner change toggle"
 msgstr "自动更改乘客所属方"
 
-#: ../../../CREDITS.md:187
+#: ../../../CREDITS.md:188
 msgid "Interceptor improvements"
 msgstr "抛射体拦截逻辑改进"
 
-#: ../../../CREDITS.md:188
+#: ../../../CREDITS.md:189
 msgid "`OpenTopped` transport behaviour customizations"
 msgstr "自定义 `OpenTopped` 运输工具行为"
 
-#: ../../../CREDITS.md:189
+#: ../../../CREDITS.md:190
 msgid "Animation damage / weapon improvements"
 msgstr "动画伤害／武器改进"
 
-#: ../../../CREDITS.md:190
+#: ../../../CREDITS.md:191
 msgid "Warhead self-damaging toggle"
 msgstr "弹头自伤开关"
 
-#: ../../../CREDITS.md:191
+#: ../../../CREDITS.md:192
 msgid "Trailer animation owner inheritance"
 msgstr "尾烟动画所属方继承"
 
-#: ../../../CREDITS.md:192
+#: ../../../CREDITS.md:193
 msgid "Warhead detonation on all objects on map"
 msgstr "全图弹头"
 
-#: ../../../CREDITS.md:193
+#: ../../../CREDITS.md:194
 msgid "Animated TerrainTypes extension"
 msgstr "动画化地形对象扩展"
 
-#: ../../../CREDITS.md:194
+#: ../../../CREDITS.md:195
 msgid "TerrainType damage & crumbling frames"
 msgstr "地形对象伤残与倒坍帧"
 
-#: ../../../CREDITS.md:195
+#: ../../../CREDITS.md:196
 msgid "Exploding unit passenger killing customization"
 msgstr "自定义易爆单位乘客死亡"
 
-#: ../../../CREDITS.md:196
+#: ../../../CREDITS.md:197
 msgid "Railgun particle target coordinate fix"
 msgstr "轨道炮粒子目标坐标修复"
 
-#: ../../../CREDITS.md:197
+#: ../../../CREDITS.md:198
 msgid "Building target coordinate offset fix"
 msgstr "建筑瞄准坐标偏移修复"
 
-#: ../../../CREDITS.md:198
+#: ../../../CREDITS.md:199
 msgid "Warhead / weapon detonation at superweapon target cell"
 msgstr "在目标单元格处引爆弹头／武器"
 
-#: ../../../CREDITS.md:199
+#: ../../../CREDITS.md:200
 msgid "Cloaked & disguised objects displaying to observers"
 msgstr "隐形和伪装对象对观察者可见"
 
-#: ../../../CREDITS.md:200
+#: ../../../CREDITS.md:201
 msgid "Building airstrike target eligibility customization"
 msgstr "自定义建筑能否作为空袭目标"
 
-#: ../../../CREDITS.md:201
+#: ../../../CREDITS.md:202
 msgid "IvanBomb detonation & image display centered on buildings"
 msgstr "伊文炸弹引爆与图像显示于建筑中心"
 
-#: ../../../CREDITS.md:202
+#: ../../../CREDITS.md:203
 msgid "Customizable `ROF` random delay"
 msgstr "自定义 `ROF` 随机间隔"
 
-#: ../../../CREDITS.md:203
+#: ../../../CREDITS.md:204
 msgid "`BibShape` drawing during buildup fix"
 msgstr "建筑拔起期间绘制 `BibShape` 的修复"
 
-#: ../../../CREDITS.md:204
+#: ../../../CREDITS.md:205
 msgid "Spawner spawn delay customization"
 msgstr "自定义子机生成间隔"
 
-#: ../../../CREDITS.md:205
+#: ../../../CREDITS.md:206
 msgid "`Cluster` scatter distance customization"
 msgstr "自定义 `Cluster` 散布距离"
 
-#: ../../../CREDITS.md:206
+#: ../../../CREDITS.md:207
 msgid "`FlakScatter` distance customization"
 msgstr "自定义 `FlakScatter` 散布距离"
 
-#: ../../../CREDITS.md:208
+#: ../../../CREDITS.md:209
 msgid "Custom warhead debris animations"
 msgstr "自定义弹头碎片动画"
 
-#: ../../../CREDITS.md:209
+#: ../../../CREDITS.md:210
 msgid "Attached particle system for animations"
 msgstr "动画的附加粒子系统"
 
-#: ../../../CREDITS.md:210
+#: ../../../CREDITS.md:211
 msgid "Removal of hardcoded AA & Gattling weapon selection restrictions"
 msgstr "移除硬编码的对空与盖特逻辑的武器选用限制"
 
-#: ../../../CREDITS.md:211
+#: ../../../CREDITS.md:212
 msgid "Projectile obstacle logic additions"
 msgstr "抛射体障碍逻辑补充"
 
-#: ../../../CREDITS.md:212
+#: ../../../CREDITS.md:213
 msgid "`AnimList` on zero damage Warheads toggle"
 msgstr "0 伤害弹头上的 `AnimList` 播放开关"
 
-#: ../../../CREDITS.md:213
+#: ../../../CREDITS.md:214
 msgid "Additions to automatic passenger deletion"
 msgstr "自动删除乘客的补充"
 
-#: ../../../CREDITS.md:214
+#: ../../../CREDITS.md:215
 msgid "Buildings considered as vehicles"
 msgstr "将建筑视为载具"
 
-#: ../../../CREDITS.md:215
+#: ../../../CREDITS.md:216
 msgid "TechnoType target evaluation map zone check behaviour customization"
 msgstr "自定义目标评估地图区域检查行为"
 
-#: ../../../CREDITS.md:216
+#: ../../../CREDITS.md:217
 msgid "CanC4 damage rounding fix & toggle"
 msgstr "CanC4 伤害值四舍五入修复及开关"
 
-#: ../../../CREDITS.md:217
+#: ../../../CREDITS.md:218
 msgid "Option to center pause menu background"
 msgstr "暂停菜单背景居中"
 
-#: ../../../CREDITS.md:218
+#: ../../../CREDITS.md:219
 msgid "Disguise logic improvements"
 msgstr "伪装逻辑改进"
 
-#: ../../../CREDITS.md:219
+#: ../../../CREDITS.md:220
 msgid "Custom insignias"
 msgstr "自定义军衔"
 
-#: ../../../CREDITS.md:220
+#: ../../../CREDITS.md:221
 msgid "`ZShapePointMove` buildup toggle"
 msgstr "拔起动画使用 `ZShapePointMove` 开关"
 
-#: ../../../CREDITS.md:221
+#: ../../../CREDITS.md:222
 msgid "`UndeploysInto` building selling buildup sequence length customization"
 msgstr "自定义可反部署建筑出售序列动画长度"
 
-#: ../../../CREDITS.md:222
+#: ../../../CREDITS.md:223
 msgid "AI naval vehicle production fix"
 msgstr "AI 海军载具生产修复"
 
-#: ../../../CREDITS.md:223
+#: ../../../CREDITS.md:224
 msgid "Crushing tilt and slowdown customization"
 msgstr "自定义碾压倾斜和减速"
 
-#: ../../../CREDITS.md:224
+#: ../../../CREDITS.md:225
 msgid "Extra warhead detonations on weapons"
 msgstr "在武器上引爆额外弹头"
 
-#: ../../../CREDITS.md:225
+#: ../../../CREDITS.md:226
 msgid "Chrono sparkle animation display customization and improvements"
 msgstr "超时空闪烁动画显示的自定义与改进"
 
-#: ../../../CREDITS.md:226
+#: ../../../CREDITS.md:227
 msgid "`PipScale` pip size & ammo pip frame customization"
 msgstr "自定义 `PipScale` 中的 pip 大小与弹药 pip 帧"
 
-#: ../../../CREDITS.md:228
+#: ../../../CREDITS.md:229
 msgid "Additional sync logging"
 msgstr "额外的同步日志"
 
-#: ../../../CREDITS.md:230
+#: ../../../CREDITS.md:231
 msgid "`EMPulseCannon` projectile gravity fix"
 msgstr "`EMPulseCannon` 抛射体重力修复"
 
-#: ../../../CREDITS.md:231
+#: ../../../CREDITS.md:232
 msgid "Custom palette support for wall overlays"
 msgstr "墙类覆盖物的自定义色盘支持"
 
-#: ../../../CREDITS.md:232
+#: ../../../CREDITS.md:233
 msgid "Warhead animation improvements"
 msgstr "弹头动画改进"
 
-#: ../../../CREDITS.md:233
+#: ../../../CREDITS.md:234
 msgid "Reloading ammo in transports"
 msgstr "在运输工具内重装填弹药"
 
-#: ../../../CREDITS.md:234
+#: ../../../CREDITS.md:235
 msgid "Straight projectile trajectory additions"
 msgstr "直线抛射体轨迹补充"
 
-#: ../../../CREDITS.md:235
+#: ../../../CREDITS.md:236
 msgid "Airstrike & spy plane fixed spawn distance & height"
 msgstr "空袭与间谍飞机固定生成距离与高度"
 
-#: ../../../CREDITS.md:236
+#: ../../../CREDITS.md:237
 msgid "Negative damage `Verses/PercentAtMax` toggle"
 msgstr "负值伤害 `Verses/PercentAtMax` 开关"
 
-#: ../../../CREDITS.md:237
+#: ../../../CREDITS.md:238
 msgid "Misc. singleplayer mission improvements"
 msgstr "各种单人任务改进"
 
-#: ../../../CREDITS.md:238
+#: ../../../CREDITS.md:239
 msgid "Weapon effect obstacle interaction fix"
 msgstr "武器的障碍交互效果修复"
 
-#: ../../../CREDITS.md:239
+#: ../../../CREDITS.md:240
 msgid "Fire particle rotation coordinate adjust toggle"
 msgstr "Fire 粒子旋转坐标调整开关"
 
-#: ../../../CREDITS.md:240
+#: ../../../CREDITS.md:241
 msgid "`AmbientDamage` warhead & main target ignore customization"
 msgstr "自定义 `AmbientDamage` 弹头和忽略直接目标"
 
-#: ../../../CREDITS.md:241
+#: ../../../CREDITS.md:242
 msgid "Projectile return weapon"
 msgstr "抛射体归返武器"
 
-#: ../../../CREDITS.md:242
+#: ../../../CREDITS.md:243
 msgid "Aircraft landing / docking direction"
 msgstr "战机着陆／对接方向"
 
-#: ../../../CREDITS.md:243
+#: ../../../CREDITS.md:244
 msgid "`DeploysInto` cursor desync fix"
 msgstr "`DeploysInto` 光标异步修复"
 
-#: ../../../CREDITS.md:244
+#: ../../../CREDITS.md:245
 msgid "Minor crate logic improvements"
 msgstr "箱子逻辑的小小改进"
 
-#: ../../../CREDITS.md:245
+#: ../../../CREDITS.md:246
 msgid "Custom tint effects"
 msgstr "自定义染色效果"
 
-#: ../../../CREDITS.md:246
+#: ../../../CREDITS.md:247
 msgid "Revenge weapons"
 msgstr "复仇武器"
 
-#: ../../../CREDITS.md:247
+#: ../../../CREDITS.md:248
 msgid "AttachEffect"
 msgstr "Attach Effect"
 
-#: ../../../CREDITS.md:248
+#: ../../../CREDITS.md:249
 msgid "Air unit tracking fix for large range / `CellSpread`"
 msgstr "大范围目标检索和 `CellSpread` 对空中单位的追踪"
 
-#: ../../../CREDITS.md:249
+#: ../../../CREDITS.md:250
 msgid "Extra tint intensity for Iron Curtain & Force Shield"
 msgstr "铁幕和力场护盾的额外染色强度"
 
-#: ../../../CREDITS.md:250
+#: ../../../CREDITS.md:251
 msgid ""
 "Option to enable parsing 8-bit RGB values from `[ColorAdd]` instead of "
 "RGB565"
 msgstr "可选是否对 `[ColorAdd]` 使用 8 位 RGB 值解析而不是使用 RGB565"
 
-#: ../../../CREDITS.md:251
+#: ../../../CREDITS.md:252
 msgid "Customizing height and speed at which subterranean units travel"
 msgstr "自定义潜地单位移动高度和速度"
 
-#: ../../../CREDITS.md:252
+#: ../../../CREDITS.md:253
 msgid "AI superweapon delay timer customization"
 msgstr "自定义 AI 超级武器发射延迟"
 
-#: ../../../CREDITS.md:253
+#: ../../../CREDITS.md:254
 msgid "Disabling `MultipleFactory` bonus from specific BuildingType"
 msgstr "将特定建筑类型在 `MultipleFactory` 加成中排除"
 
-#: ../../../CREDITS.md:254
+#: ../../../CREDITS.md:255
 msgid "Customizable ChronoSphere teleport delays for units"
 msgstr "自定义单位的超时空传送延迟"
 
-#: ../../../CREDITS.md:255
+#: ../../../CREDITS.md:256
 msgid "Allowed and disallowed types for `FactoryPlant`"
 msgstr "`FactoryPlant` 的黑白名单"
 
-#: ../../../CREDITS.md:256
+#: ../../../CREDITS.md:257
 msgid "Forbidding parallel AI queues for specific TechnoTypes"
 msgstr "禁止特定科技类型的 AI 克隆生产效果"
 
-#: ../../../CREDITS.md:257
+#: ../../../CREDITS.md:258
 msgid "Nonprovocative Warheads"
 msgstr "非挑衅弹头"
 
-#: ../../../CREDITS.md:258
+#: ../../../CREDITS.md:259
 msgid "Customizing effect of level lighting on air units"
 msgstr "自定义光照等级对空中单位的影响"
 
-#: ../../../CREDITS.md:259
+#: ../../../CREDITS.md:260
 msgid "Reimplemented `Airburst` & `Splits` logic with more customization options"
 msgstr "重新实现 `Airburst` 与 `Splits` 逻辑以提供更多自定义选项"
 
-#: ../../../CREDITS.md:260
+#: ../../../CREDITS.md:261
 msgid "Buildings considered as destroyable pathfinding obstacles"
 msgstr "建筑物视为可破坏的寻路障碍物"
 
-#: ../../../CREDITS.md:261
+#: ../../../CREDITS.md:262
 msgid "Animation visibility customization settings"
 msgstr "自定义动画可见性设置"
 
-#: ../../../CREDITS.md:262
+#: ../../../CREDITS.md:263
 msgid "Light effect customizations"
 msgstr "自定义灯光效果"
 
-#: ../../../CREDITS.md:263
+#: ../../../CREDITS.md:264
 msgid "Building unit repair customizations"
 msgstr "在建筑上自定义单位维修效果"
 
-#: ../../../CREDITS.md:264
+#: ../../../CREDITS.md:265
 msgid "Build area customizations"
 msgstr "自定义建造区域"
 
-#: ../../../CREDITS.md:265
+#: ../../../CREDITS.md:266
 msgid "`Scorch` / `Flamer` fire animation customization"
 msgstr "自定义 `Scorch`／`Flamer` 火焰动画"
 
-#: ../../../CREDITS.md:266
+#: ../../../CREDITS.md:267
 msgid "EM Pulse cannon logic improvements"
 msgstr "EMP 炮逻辑改进"
 
-#: ../../../CREDITS.md:267
+#: ../../../CREDITS.md:268
 msgid "`<Player @ X>` as owner for pre-placed objects"
 msgstr "允许 `<Player @ X>` 作为地图预置对象所有者"
 
-#: ../../../CREDITS.md:268
+#: ../../../CREDITS.md:269
 msgid "Custom exit cell for infantry factory"
 msgstr "自定义兵营退出单元格"
 
-#: ../../../CREDITS.md:269
+#: ../../../CREDITS.md:270
 msgid "Vehicles keeping target on move command"
 msgstr "载具在移动命令中保持目标"
 
-#: ../../../CREDITS.md:270
+#: ../../../CREDITS.md:271
 msgid "`IsSonic` wave drawing crash fix"
 msgstr "`IsSonic` 波绘制崩溃修复"
 
-#: ../../../CREDITS.md:271
+#: ../../../CREDITS.md:272
 msgid "Customizable electric bolt duration and electric bolt-related fixes"
 msgstr "自定义 EBolt 持续时间和 EBolt 相关修复"
 
-#: ../../../CREDITS.md:272
+#: ../../../CREDITS.md:273
 msgid "Airstrike flare visual customizations & fixes"
 msgstr "空袭引导效果的自定义和修复"
 
-#: ../../../CREDITS.md:273
+#: ../../../CREDITS.md:274
 msgid "**Morton (MortonPL)**:"
 msgstr "**Morton (MortonPL)**："
 
-#: ../../../CREDITS.md:274
+#: ../../../CREDITS.md:275
 msgid "`XDrawOffset` for animations"
 msgstr "动画的 `XDrawOffset`"
 
-#: ../../../CREDITS.md:275
+#: ../../../CREDITS.md:276
 msgid "Shield passthrough & absorption"
 msgstr "护盾穿透与吸收"
 
-#: ../../../CREDITS.md:276
+#: ../../../CREDITS.md:277
 msgid "Building `LimboDelivery` logic"
 msgstr "建筑 `LimboDelivery` 逻辑"
 
-#: ../../../CREDITS.md:277
+#: ../../../CREDITS.md:278
 msgid "Fix for `Image` in art rules"
 msgstr "修复 art 规则中的 `Image` 逻辑"
 
-#: ../../../CREDITS.md:278
+#: ../../../CREDITS.md:279
 msgid "Power delta counter"
 msgstr "电力变动指示器"
 
-#: ../../../CREDITS.md:279
+#: ../../../CREDITS.md:280
 msgid "Super Weapons launching other Super Weapons"
 msgstr "超级武器发射其他超级武器"
 
-#: ../../../CREDITS.md:280
+#: ../../../CREDITS.md:281
 msgid "SpyEffects expansion, launching Super Weapons on building infiltration"
 msgstr "间谍效果扩展，允许在建筑被渗透时发射超级武器"
 
-#: ../../../CREDITS.md:281
+#: ../../../CREDITS.md:282
 msgid "Real time timers"
 msgstr "实时计时器"
 
-#: ../../../CREDITS.md:282
+#: ../../../CREDITS.md:283
 msgid "Default campaign game speed override and custom campaign game speed FPS"
 msgstr "默认战役游戏速度覆盖与自定义战役速度 FPS"
 
-#: ../../../CREDITS.md:283
+#: ../../../CREDITS.md:284
 msgid "Including INI files and inheriting INI sections"
 msgstr "包含 INI 文件与继承 INI 节"
 
-#: ../../../CREDITS.md:285
+#: ../../../CREDITS.md:286
 msgid "TechnoType conversion warhead & superweapon"
 msgstr "单位转换弹头与超级武器"
 
-#: ../../../CREDITS.md:286
+#: ../../../CREDITS.md:287
 msgid "Unlimited skirmish colors"
 msgstr "无限制遭遇战颜色"
 
-#: ../../../CREDITS.md:287
+#: ../../../CREDITS.md:288
 msgid "Show designator & inhibitor range"
 msgstr "显示指示者和抑制者范围"
 
-#: ../../../CREDITS.md:288
+#: ../../../CREDITS.md:289
 msgid "Dump variables to file on scenario end / hotkey"
 msgstr "在场景结束／按下快捷键时将变量输出至文件"
 
-#: ../../../CREDITS.md:289
+#: ../../../CREDITS.md:290
 msgid ""
 "`601 House owns TechnoType` and `602 House doesn't own TechnoType` "
 "trigger events"
 msgstr "`601 所属方存在科技类型...` 与 `602 所属方不·存在科技类型...` 触发条件"
 
-#: ../../../CREDITS.md:291
+#: ../../../CREDITS.md:292
 msgid "Extending `Power` to all TechnoTypes"
 msgstr "将 `Power` 扩展到所有科技类型"
 
-#: ../../../CREDITS.md:293
+#: ../../../CREDITS.md:293 ../../../CREDITS.md:429
+msgid "Display banner by triggers"
+msgstr "横幅相关触发"
+
+#: ../../../CREDITS.md:295
 msgid ""
 "**ChrisLv_CN** (work relicensed under [following "
 "permission](https://github.com/Phobos-"
@@ -1135,393 +1143,393 @@ msgstr ""
 "**ChrisLv_CN**（授权见[此处](https://github.com/Phobos-"
 "developers/Phobos/blob/develop/images/ChrisLv-relicense.png)）："
 
-#: ../../../CREDITS.md:294
+#: ../../../CREDITS.md:296
 msgid "General assistance"
 msgstr "一般性协助"
 
-#: ../../../CREDITS.md:295
+#: ../../../CREDITS.md:297
 msgid "Interceptor logic prototype"
 msgstr "拦截抛射体逻辑雏形"
 
-#: ../../../CREDITS.md:296
+#: ../../../CREDITS.md:298
 msgid "LaserTrails prototype"
 msgstr "激光尾焰雏形"
 
-#: ../../../CREDITS.md:297
+#: ../../../CREDITS.md:299
 msgid "Laser fixes prototype"
 msgstr "激光修复雏形"
 
-#: ../../../CREDITS.md:298
+#: ../../../CREDITS.md:300
 msgid "**Trsdy**:"
 msgstr "**Trsdy**："
 
-#: ../../../CREDITS.md:299
+#: ../../../CREDITS.md:301
 msgid "Preserve IronCurtain status upon `DeploysInto/UndeploysInto`"
 msgstr "`DeploysInto/UndeploysInto` 保留铁幕效果"
 
-#: ../../../CREDITS.md:300
+#: ../../../CREDITS.md:302
 msgid "Several jumpjet fixes:"
 msgstr "多项 Jumpjet 修复："
 
-#: ../../../CREDITS.md:301
+#: ../../../CREDITS.md:303
 msgid "Facing towards target even if not omni-firing"
 msgstr "即便并非全向开火也会朝向目标"
 
-#: ../../../CREDITS.md:302
+#: ../../../CREDITS.md:304
 msgid "Turret direction in idle state fix"
 msgstr "闲置状态炮塔方向修复"
 
-#: ../../../CREDITS.md:303
+#: ../../../CREDITS.md:305
 msgid "Sensor fix"
 msgstr "隐形探测修复"
 
-#: ../../../CREDITS.md:304
+#: ../../../CREDITS.md:306
 msgid "Allow to tilt regardless of `TiltCrashJumpjet`"
 msgstr "无视 `TiltCrashJumpjet` 允许倾斜"
 
-#: ../../../CREDITS.md:305
+#: ../../../CREDITS.md:307
 msgid "Forbid firing when crashing"
 msgstr "禁止在坠毁中继续开火"
 
-#: ../../../CREDITS.md:306
+#: ../../../CREDITS.md:308
 msgid "`OmniFire.TurnToTarget`"
 msgstr "`OmniFire.TurnToTarget`"
 
-#: ../../../CREDITS.md:308
+#: ../../../CREDITS.md:310
 msgid "Object Self-destruction logic"
 msgstr "物体自毁逻辑"
 
-#: ../../../CREDITS.md:309
+#: ../../../CREDITS.md:311
 msgid "Misc vanilla suicidal behavior fix"
 msgstr "各种原版自毁行为修复"
 
-#: ../../../CREDITS.md:310
+#: ../../../CREDITS.md:312
 msgid "Post-type-conversion update"
 msgstr "单位转换后的数据更新"
 
-#: ../../../CREDITS.md:311
+#: ../../../CREDITS.md:313
 msgid "Units retaining orders after changing ownership bugfix"
 msgstr "单位在更改所有者后保留命令的 bug 修复"
 
-#: ../../../CREDITS.md:312
+#: ../../../CREDITS.md:314
 msgid "Several fixes and dehardcode related to building selling/undeploying:"
 msgstr "与建筑出售／反部署相关的多项修复与去硬编码："
 
-#: ../../../CREDITS.md:313
+#: ../../../CREDITS.md:315
 msgid "Building `EVA_StructureSold` and `SellSound` dehardcode"
 msgstr "建筑 `EVA_StructureSold` 与 `SellSound` 去硬编码"
 
-#: ../../../CREDITS.md:314
+#: ../../../CREDITS.md:316
 msgid "Restore `EVA_StructureSold` for buildings with `UndeploysInto`"
 msgstr "复原 `UndeploysInto` 建筑的 `EVA_StructureSold`"
 
-#: ../../../CREDITS.md:315
+#: ../../../CREDITS.md:317
 msgid "Redeployable MCV in campaigns"
 msgstr "战役中的可重部署 MCV"
 
-#: ../../../CREDITS.md:316
+#: ../../../CREDITS.md:318
 msgid ""
 "Allow buildings with `UndeploysInto` to be sold if `Unsellable=no` even "
 "if not conyard"
 msgstr "允许不是建造厂但拥有 `UndeploysInto` 的建筑在 `Unsellable=no` 时出售"
 
-#: ../../../CREDITS.md:317
+#: ../../../CREDITS.md:319
 msgid "Trigger actions that allow/forbid MCV to redeploy in game"
 msgstr "允许／禁止 MCV 重部署的触发结果"
 
-#: ../../../CREDITS.md:318
+#: ../../../CREDITS.md:320
 msgid "`AlternateFLH` of vehicles in `OpenTopped` transport"
 msgstr "载具在 `OpenTopped` 载具中的 `AlternateFLH`"
 
-#: ../../../CREDITS.md:319
+#: ../../../CREDITS.md:321
 msgid "Slaves' house customization when owner is killed"
 msgstr "自定义奴隶矿场被毁后的奴隶所有者"
 
-#: ../../../CREDITS.md:320
+#: ../../../CREDITS.md:322
 msgid "Trigger Action spawned team IFV/OpenTopped logic fix"
 msgstr "触发结果所生成小队中 IFV／OpenTopped 逻辑的修复"
 
-#: ../../../CREDITS.md:321
+#: ../../../CREDITS.md:323
 msgid ""
 "Singleplayer Campaign AI's base node/SW-delivered/trigger action `125 "
 "Create Building At...`'s auto-repairability dehardcode"
 msgstr "单人战役 AI 的基地节点／超武 Deliver 所创建建筑／触发结果 `125 将建筑建于...` 所创建建筑其自动维修行为的去硬编码化"
 
-#: ../../../CREDITS.md:322
+#: ../../../CREDITS.md:324
 msgid "Power delta counter : blackout indication mark"
 msgstr "电力差值计数器：停电指示标记"
 
-#: ../../../CREDITS.md:324
+#: ../../../CREDITS.md:326
 msgid "Income money string indication upon ore dump"
 msgstr "倒矿时的收入资金文本显示"
 
-#: ../../../CREDITS.md:325
+#: ../../../CREDITS.md:327
 msgid "Warhead superweapon launch logic"
 msgstr "弹头发射超级武器逻辑"
 
-#: ../../../CREDITS.md:326 ../../../CREDITS.md:341
+#: ../../../CREDITS.md:328 ../../../CREDITS.md:343
 msgid "TechnoType conversion placeholder"
 msgstr "单位转换占位符"
 
-#: ../../../CREDITS.md:327
+#: ../../../CREDITS.md:329
 msgid "`606 The shield of the attached object is broken` trigger event"
 msgstr "`600 对象护盾被摧毁...` 触发条件"
 
-#: ../../../CREDITS.md:328
+#: ../../../CREDITS.md:330
 msgid "`RadialIndicator` observer visibility"
 msgstr "`RadialIndicator` 观察者可见性"
 
-#: ../../../CREDITS.md:329
+#: ../../../CREDITS.md:331
 msgid "Cloaked objects from allies displaying to player in singleplayer campaigns"
 msgstr "单人战役中友军的隐形对象对玩家显示"
 
-#: ../../../CREDITS.md:330
+#: ../../../CREDITS.md:332
 msgid "Skip `NaturalParticleSystem` displaying from in-map pre-placed structures"
 msgstr "跳过了地图上预置建筑的 `NaturalParticleSystem` 显示"
 
-#: ../../../CREDITS.md:331
+#: ../../../CREDITS.md:333
 msgid ""
 "Random crate generation limited to land option, optimization for crates' "
 "random sampling"
 msgstr "限制随机升级工具箱生成于陆地、优化箱子生成地点的随机采样"
 
-#: ../../../CREDITS.md:332
+#: ../../../CREDITS.md:334
 msgid "`ImmuneToCrit` for shields"
 msgstr "护盾的 `ImmuneToCrit`"
 
-#: ../../../CREDITS.md:333 ../../../CREDITS.md:376
+#: ../../../CREDITS.md:335 ../../../CREDITS.md:378
 msgid "Forbidding parallel AI queues by type"
 msgstr "按类禁止 AI 克隆生产"
 
-#: ../../../CREDITS.md:334
+#: ../../../CREDITS.md:336
 msgid "The option to allow `DieSound/VoiceDie` being played when grinding"
 msgstr "允许在被回收时播放 `DieSound/VoiceDie`"
 
-#: ../../../CREDITS.md:335
+#: ../../../CREDITS.md:337
 msgid "Allow iron-curtain effects on infantries"
 msgstr "允许在步兵上使用铁幕效果"
 
-#: ../../../CREDITS.md:336
+#: ../../../CREDITS.md:338
 msgid ""
 "Break the mindcontrol link when capturing a mind-controlled building with"
 " engineer"
 msgstr "当工程师占领被心灵控制的建筑时切断心灵控制链接"
 
-#: ../../../CREDITS.md:337
+#: ../../../CREDITS.md:339
 msgid ""
 "Remove sound events when mind-controlled vehicles deploy into buildings "
 "or when buildings considered as vehicles get captured"
 msgstr "当被心灵控制的载具部署成建筑或当被视为载具的建筑被占领时移除声音事件"
 
-#: ../../../CREDITS.md:338
+#: ../../../CREDITS.md:340
 msgid "Building LightSource tint S/L fix"
 msgstr "建筑光源染色问题的的存读档修复"
 
-#: ../../../CREDITS.md:339
+#: ../../../CREDITS.md:341
 msgid "Permanent healthbar display on units targeted by temporal weapons fix"
 msgstr "超时空武器所冻结单位的永久显示血条问题修复"
 
-#: ../../../CREDITS.md:340
+#: ../../../CREDITS.md:342
 msgid ""
 "Powered anims on buildings cease playing upon capture by different house "
 "fix"
 msgstr "当建筑被不同所属方占领时停止播放需电动画的修复"
 
-#: ../../../CREDITS.md:342
+#: ../../../CREDITS.md:344
 msgid "TechnoType conversion upon ownership change"
 msgstr "科技类型根据操作者改变而变形"
 
-#: ../../../CREDITS.md:343
+#: ../../../CREDITS.md:345
 msgid "EIP 00529A14 crash fix on Linux"
 msgstr "Linux 系统上的 EIP 00529A14 崩溃修复"
 
-#: ../../../CREDITS.md:344
+#: ../../../CREDITS.md:346
 msgid "Teleport timer reset after load game fix"
 msgstr "读档后重置超时空计时器修复"
 
-#: ../../../CREDITS.md:345
+#: ../../../CREDITS.md:347
 msgid "Teleport, Tunnel and Fly loco visual tilt fix"
 msgstr "Teleport、Tunnel 和 Fly 运动模式视觉倾斜的修复"
 
-#: ../../../CREDITS.md:346
+#: ../../../CREDITS.md:348
 msgid "Turret/Barrel/NoSpawnAlt/Multi-section voxel shadow, dynamic voxel shadow"
 msgstr "炮塔、炮管、`NoSpawnAlt`、多组件 Voxel 阴影、动态 Voxel 阴影"
 
-#: ../../../CREDITS.md:347
+#: ../../../CREDITS.md:349
 msgid "Skip units' turret rotation and jumpjets' wobbling under EMP"
 msgstr "在 EMP 状态下跳过单位的炮塔旋转和 Jumpjet 浮动"
 
-#: ../../../CREDITS.md:348
+#: ../../../CREDITS.md:350
 msgid "Droppod properties dehardcode"
 msgstr "DropPod 属性去硬编码"
 
-#: ../../../CREDITS.md:349
+#: ../../../CREDITS.md:351
 msgid "`Deployer = yes->no` infantry conversion sequence fix"
 msgstr "`Deployer = yes->no` 步兵变形的序列问题修复"
 
-#: ../../../CREDITS.md:350
+#: ../../../CREDITS.md:352
 msgid "Waypoint entering building together with engineer/agent bug fix"
 msgstr "工程师／间谍路径点自偷 Bug 的修复"
 
-#: ../../../CREDITS.md:351
+#: ../../../CREDITS.md:353
 msgid "Skippable game save on scenario start"
 msgstr "可跳过的场景开始时自动存档"
 
-#: ../../../CREDITS.md:352
+#: ../../../CREDITS.md:354
 msgid "`InfDeath=9` versus jumpjet infantry 0 damage fix"
 msgstr "`InfDeath=9` 对 Jumpjet 步兵 0 伤害效果的修复"
 
-#: ../../../CREDITS.md:353
+#: ../../../CREDITS.md:355
 msgid "Skip rally point line drawing when undeploying a building"
 msgstr "跳过建筑反部署时的集结线绘制"
 
-#: ../../../CREDITS.md:354
+#: ../../../CREDITS.md:356
 msgid "Ares' `SW.Shots` hint on extended tooltips"
 msgstr "在拓展拓展工具条中现实 Ares 的 `SW.Shots`"
 
-#: ../../../CREDITS.md:355
+#: ../../../CREDITS.md:357
 msgid "Ares' Abductor weapon fix"
 msgstr "Ares 超时空监狱吸取武器的修复"
 
-#: ../../../CREDITS.md:356
+#: ../../../CREDITS.md:358
 msgid "Suppress Ares' swizzle warning when parsing tags and taskforces"
 msgstr "在解析标签和特遣部队时抑制 Ares 的 swizzle 警告"
 
-#: ../../../CREDITS.md:357
+#: ../../../CREDITS.md:359
 msgid ""
 "Better fix for Ares academy not working on the initial payloads of "
 "vehicles built from a war factory"
 msgstr "对于 Ares 训练所逻辑在产自重工的载具其初始载员上不生效问题更好的修复方式"
 
-#: ../../../CREDITS.md:358
+#: ../../../CREDITS.md:360
 msgid "Fix Ares' InitialPayload for teams spawned by trigger actions"
 msgstr "触发结果所生成小队的 Ares 初始载员功能修复"
 
-#: ../../../CREDITS.md:359
+#: ../../../CREDITS.md:361
 msgid "Misc code refactor & maintenance, CN doc fixes, bugfixes"
 msgstr "各种代码重构与维护、中文文档修正、错误修复"
 
-#: ../../../CREDITS.md:360
+#: ../../../CREDITS.md:362
 msgid "**FlyStar**:"
 msgstr "**FlyStar**："
 
-#: ../../../CREDITS.md:361
+#: ../../../CREDITS.md:363
 msgid "Campaign load screen PCX support"
 msgstr "战役 PCX 载入图支持"
 
-#: ../../../CREDITS.md:362
+#: ../../../CREDITS.md:364
 msgid ""
 "New condition for automatic self-destruction logic when TechnoTypes "
 "exist/don't exist"
 msgstr "新的自毁条件：若科技类型存在／不存在"
 
-#: ../../../CREDITS.md:363
+#: ../../../CREDITS.md:365
 msgid "Fix `AltNextScenario` not taking effect"
 msgstr "修复了 `AltNextScenario` 无法生效的问题"
 
-#: ../../../CREDITS.md:364
+#: ../../../CREDITS.md:366
 msgid "Fix `Hospital=yes` building can't kick out infantry after loading a save"
 msgstr "修复了 `Hospital=yes` 的建筑在读档后无法让步兵离开的问题"
 
-#: ../../../CREDITS.md:365
+#: ../../../CREDITS.md:367
 msgid "`Edit/Clear Hate-Value` Trigger Action"
 msgstr "`606 编辑仇恨值`、`607 清除仇恨值` 触发结果"
 
-#: ../../../CREDITS.md:366
+#: ../../../CREDITS.md:368
 msgid "`Set Force Enemy` Trigger Action"
 msgstr "`608 强制宣战` 触发结果"
 
-#: ../../../CREDITS.md:367
+#: ../../../CREDITS.md:369
 msgid ""
 "Fix the issue where computer players did not search for new enemies after"
 " defeating them or forming alliances with them"
 msgstr "修复了 AI 玩家在消灭一家敌人或敌人结盟后不再搜索新敌人的问题"
 
-#: ../../../CREDITS.md:368
+#: ../../../CREDITS.md:370
 msgid "Customize the damage taken when falling from a bridge"
 msgstr "自定义桥上坠落伤害"
 
-#: ../../../CREDITS.md:369
+#: ../../../CREDITS.md:371
 msgid ""
 "`600 The shield of the attached object is broken` bug fix for the "
 "triggered event"
 msgstr "对 `600 对象护盾被摧毁...` 触发条件的修复"
 
-#: ../../../CREDITS.md:370
+#: ../../../CREDITS.md:372
 msgid ""
 "Fix an issue where a portion of Ares's trigger event 75/77 was determined"
 " unsuccessfully"
 msgstr "修复了 Ares 触发条件 75/77 有时判定不成功的问题"
 
-#: ../../../CREDITS.md:371
+#: ../../../CREDITS.md:373
 msgid ""
 "Second weapon with `ElectricAssault=yes` will not unconditionally attack "
 "your building with `Overpowerable=yes`"
 msgstr "有 `ElectricAssault=yes` 的副武不再会无条件地攻击己方 `Overpowerable=yes` 的建筑"
 
-#: ../../../CREDITS.md:372 ../../../CREDITS.md:426
+#: ../../../CREDITS.md:374 ../../../CREDITS.md:431
 msgid "Fix the issue where some units crashed after the deployment transformation"
 msgstr "修复了某些单位部署变形后崩溃的问题"
 
-#: ../../../CREDITS.md:373
+#: ../../../CREDITS.md:375
 msgid "Turretless vehicles with `Voxel=no` support use `FireUp` like infantry"
 msgstr "无炮塔 Shape 载具开火前摇"
 
-#: ../../../CREDITS.md:374
+#: ../../../CREDITS.md:376
 msgid "Infantry support `IsGattling=yes`"
 msgstr "步兵类现已支持使用 `IsGattling=yes` 开启盖特逻辑"
 
-#: ../../../CREDITS.md:375
+#: ../../../CREDITS.md:377
 msgid "**NetsuNegi**:"
 msgstr "**NetsuNegi**："
 
-#: ../../../CREDITS.md:377
+#: ../../../CREDITS.md:379
 msgid "Jumpjet crash speed fix when crashing onto building"
 msgstr "Jumpjet 在建筑上坠毁时的坠毁速度修复"
 
-#: ../../../CREDITS.md:378
+#: ../../../CREDITS.md:380
 msgid ""
 "Disguised units not using the correct palette if target has custom "
 "palette bugfix"
 msgstr "伪装单位在目标拥有自定义色盘时无法正确使用色盘问题的修复"
 
-#: ../../../CREDITS.md:379
+#: ../../../CREDITS.md:381
 msgid "Tunnel/Walk/Mech locomotor being stuck when moving too fast bugfix"
 msgstr "Tunnel/Walk/Mech 运动模式在移动过快时卡住的 bug 修复"
 
-#: ../../../CREDITS.md:380
+#: ../../../CREDITS.md:382
 msgid "Assign Super Weapon cameo to any sidebar tab"
 msgstr "自定义超级武器所在栏"
 
-#: ../../../CREDITS.md:381
+#: ../../../CREDITS.md:383
 msgid ""
 "Fix impassable invisible barrier created by chronosphere on uncrushable "
 "unit"
 msgstr "修复了超时空传送超武将单位传送到一个不可碾压目标上并摧毁时在原位置创建空气墙的问题"
 
-#: ../../../CREDITS.md:382
+#: ../../../CREDITS.md:384
 msgid "`FreeUnit` uses its own `SpeedType` to determine where to spawn"
 msgstr "`FreeUnit` 使用单位自己的 `SpeedType` 来寻找生成位置"
 
-#: ../../../CREDITS.md:383
+#: ../../../CREDITS.md:385
 msgid ""
 "Fix the bug where naval ships set to `AllowedToStartInMultiplayer=yes` "
 "may spawn incorrectly on land"
 msgstr "修复了海军舰船设为 `AllowedToStartInMultiplayer=yes` 可能生成在陆地上的 Bug"
 
-#: ../../../CREDITS.md:384
+#: ../../../CREDITS.md:386
 msgid ""
 "Fix the bug where pathfinding issues occur when a building performs "
 "undeploy"
 msgstr "修复了建筑执行 `UndeploysInto` 时的寻路问题"
 
-#: ../../../CREDITS.md:385
+#: ../../../CREDITS.md:387
 msgid ""
 "Fix amphibious harvesters can not automatically return to refineries with"
 " `WaterBound`"
 msgstr "修复了两栖矿车无法自动返回拥有 `WaterBound` 的矿场的问题"
 
-#: ../../../CREDITS.md:386
+#: ../../../CREDITS.md:388
 msgid ""
 "Fix [EIP "
 "004C2C19](https://modenc.renegadeprojects.com/Internal_Error#eip_004C2C19)"
@@ -1530,27 +1538,27 @@ msgstr ""
 "修复了 EBolt 相关的 [EIP "
 "004C2C19](https://modenc.renegadeprojects.com/Internal_Error#eip_004C2C19)"
 
-#: ../../../CREDITS.md:387 ../../../CREDITS.md:503
+#: ../../../CREDITS.md:389 ../../../CREDITS.md:509
 msgid "Fix `DefaultDisguise` showing wrong house colors for different players"
 msgstr "修复了 `DefaultDisguise` 为不同玩家显示不同所属方颜色的问题"
 
-#: ../../../CREDITS.md:388
+#: ../../../CREDITS.md:390
 msgid "Taking over Ares' AlphaImage respawn logic to reduce lags from it"
 msgstr "接管 Ares 的 AlphaImage 重绘逻辑以减少其造成的卡顿"
 
-#: ../../../CREDITS.md:389
+#: ../../../CREDITS.md:391
 msgid "Allow voxel projectiles to use `AnimPalette` and `FirersPalette`"
 msgstr "允许了 Voxel 抛射体使用 `AnimPalette` 和 `FirersPalette`"
 
-#: ../../../CREDITS.md:390
+#: ../../../CREDITS.md:392
 msgid "Customize damaged speed ratio of drive/ship loco"
 msgstr "自定义 `Locomotor` 为 `Drive`／`Ship` 的单位伤残状态的速度比率"
 
-#: ../../../CREDITS.md:391
+#: ../../../CREDITS.md:393
 msgid "Customize overpower logic"
 msgstr "自定义磁暴线圈充能"
 
-#: ../../../CREDITS.md:392
+#: ../../../CREDITS.md:394
 msgid ""
 "Fix the bug that `EnterBioReactorSound`, `LeaveBioReactorSound`, "
 "`EnterGrinderSound` on technotype does not used"
@@ -1558,34 +1566,34 @@ msgstr ""
 "修复了 `EnterBioReactorSound`、`LeaveBioReactorSound`、`EnterGrinderSound` "
 "在单位上微观设定无效的 Bug"
 
-#: ../../../CREDITS.md:393
+#: ../../../CREDITS.md:395
 msgid ""
 "Fix the bug that harvester dont stop unloading and cannot unload cargos "
 "anymore when lifting by `IsLocomotor=yes` warhead"
 msgstr "修复了矿车被 `IsLocomotor=yes` 的弹头抬起也不会停止卸载状态且无法继续正常卸载的 Bug"
 
-#: ../../../CREDITS.md:394 ../../../CREDITS.md:481
+#: ../../../CREDITS.md:396 ../../../CREDITS.md:486
 msgid "Fix an issue that units on the slope tilted at an excessive angle"
 msgstr "修复了单位在斜坡上倾斜角度过大的问题"
 
-#: ../../../CREDITS.md:395
+#: ../../../CREDITS.md:397
 msgid "Enhanced reveal & gap warhead"
 msgstr "增强版揭示弹与黑幕弹"
 
-#: ../../../CREDITS.md:396
+#: ../../../CREDITS.md:398
 msgid ""
 "Fix an issue that teleport units board transport vehicles on the bridge "
 "will create an impassable invisible barrier, which may cause the game to "
 "freeze or even crash"
 msgstr "修复了单位超时空进入桥上的运输载具会产生空气墙并可能导致游戏卡死乃至崩溃的问题"
 
-#: ../../../CREDITS.md:397
+#: ../../../CREDITS.md:399
 msgid ""
 "Fix wrong shadow when a vehicle has hover locomotor and is being lifted "
 "by `IsLocomotor=yes` warhead"
 msgstr "修复了使用悬浮运动模式的载具被 `IsLocomotor=yes` 弹头抬起时显示的错误阴影"
 
-#: ../../../CREDITS.md:398
+#: ../../../CREDITS.md:400
 msgid ""
 "Fix the bug that a unit can overlap with `Teleport` units after it's been"
 " damaged by a fallen unit lifted by `IsLocomotor=yes` warheads"
@@ -1593,738 +1601,750 @@ msgstr ""
 "修复了一个单位被另一个由 `IsLocomotor=yes` 弹头吊起的单位砸过后其所在单元格可以被一个 `Teleport` "
 "运动模式的单位作为超时空移动的目的地的问题"
 
-#: ../../../CREDITS.md:399
+#: ../../../CREDITS.md:401
 msgid "Customize parasite culling targets"
 msgstr "自定义寄生秒杀目标"
 
-#: ../../../CREDITS.md:400
+#: ../../../CREDITS.md:402
 msgid "Customize harvester dump amount"
 msgstr "自定义矿车单次倒矿量"
 
-#: ../../../CREDITS.md:401
+#: ../../../CREDITS.md:403
 msgid "Select box logic"
 msgstr "选择框逻辑"
 
-#: ../../../CREDITS.md:402
+#: ../../../CREDITS.md:404
 msgid "Customize airstrike targets"
 msgstr "自定义空袭目标"
 
-#: ../../../CREDITS.md:403
+#: ../../../CREDITS.md:405
 msgid ""
 "Separate the AirstrikeClass pointer between the attacker/aircraft and the"
 " target to avoid erroneous overwriting issues"
 msgstr "分离了 AirstrikeClass 中攻击者／战机与目标的指针以避免错误覆盖问题"
 
-#: ../../../CREDITS.md:404
+#: ../../../CREDITS.md:406
 msgid "Fix the bug that buildings will always be tinted as airstrike owner"
 msgstr "修复了建筑总是被染色为空袭所属方颜色的 Bug"
 
-#: ../../../CREDITS.md:405
+#: ../../../CREDITS.md:407
 msgid ""
 "Fix the bug that `AllowAirstrike=no` cannot completely prevent air "
 "strikes from being launched against it"
 msgstr "修复了 `AllowAirstrike=no` 未能完全阻止对某个单位进行空袭的 Bug"
 
-#: ../../../CREDITS.md:406
+#: ../../../CREDITS.md:408
 msgid ""
 "Fix the bug that infantry ignored `Passengers` and `SizeLimit` when "
 "entering buildings"
 msgstr "修复了步兵进入建筑时忽略 `Passengers` 和 `SizeLimit` 的 Bug"
 
-#: ../../../CREDITS.md:407
+#: ../../../CREDITS.md:409
 msgid "Tiberium eater logic"
 msgstr "马夫逻辑"
 
-#: ../../../CREDITS.md:408
+#: ../../../CREDITS.md:410
 msgid "Fix the bug that ships can travel on elevated bridges"
 msgstr "修复了船只可以在高架桥上行驶的 Bug"
 
-#: ../../../CREDITS.md:410
+#: ../../../CREDITS.md:412
 msgid ""
 "Fix the bug that uncontrolled scatter when elite techno attacked by "
 "aircraft or some unit try crush it"
 msgstr "修复精英单位在被战机攻击或一个单位尝试碾压它时强制散开的 Bug"
 
-#: ../../../CREDITS.md:411 ../../../CREDITS.md:492
+#: ../../../CREDITS.md:413 ../../../CREDITS.md:497
 msgid "Exclusive SuperWeapon Sidebar"
 msgstr "超武侧边栏"
 
-#: ../../../CREDITS.md:412
+#: ../../../CREDITS.md:414
 msgid "Fix the bug that AlphaImage remained after unit entered tunnel"
 msgstr "修复了 AlphaImage 在单位进入隧道后会遗留在隧道口的 Bug"
 
-#: ../../../CREDITS.md:413
+#: ../../../CREDITS.md:415
 msgid "Weapon target filtering by health percentage"
 msgstr "武器根据血量百分比筛选目标"
 
-#: ../../../CREDITS.md:414
+#: ../../../CREDITS.md:416
 msgid ""
 "Fix the bug that `DamageSelf` and `AllowDamageOnSelf` are ineffective on "
 "airforce"
-msgstr ""
-"修复了 `DamageSelf` 和 `AllowDamageOnSelf` 对空军无效的 Bug"
+msgstr "修复了 `DamageSelf` 和 `AllowDamageOnSelf` 对空军无效的 Bug"
 
-#: ../../../CREDITS.md:415
+#: ../../../CREDITS.md:417
 msgid "Customize limit when engineer repair a building"
 msgstr "自定义工程师维修建筑时的修复值"
 
-#: ../../../CREDITS.md:416
+#: ../../../CREDITS.md:418
 msgid ""
 "Fix the bug that damaged particle dont disappear after building has "
 "repaired by engineer"
-msgstr ""
-"修复了建筑在被工程师修复后受损粒子不会移除的 Bug"
+msgstr "修复了建筑在被工程师修复后受损粒子不会移除的 Bug"
 
-#: ../../../CREDITS.md:417
+#: ../../../CREDITS.md:420
+msgid "Electric/RadBeam trail for laser tails"
+msgstr "激光尾焰逻辑支持 EBolt／辐射波"
+
+#: ../../../CREDITS.md:421
 msgid "**Apollo** - Translucent SHP drawing patches"
 msgstr "**Apollo** - 半透明 SHP 绘制补丁"
 
-#: ../../../CREDITS.md:418
+#: ../../../CREDITS.md:422
 msgid "**ststl**:"
 msgstr "**ststl**："
 
-#: ../../../CREDITS.md:419
+#: ../../../CREDITS.md:423
 msgid "Customizable `ShowTimer` priority of superweapons"
 msgstr "自定义超武 `ShowTimer` 优先级"
 
-#: ../../../CREDITS.md:420
+#: ../../../CREDITS.md:424
 msgid "Iron Curtain effects customization on infantries and organic units"
 msgstr "自定义对步兵和有机体的铁幕效果"
 
-#: ../../../CREDITS.md:421
+#: ../../../CREDITS.md:425
 msgid "Use `CustomPalette` for animations with `Tiled=yes`"
 msgstr "允许 `Tiled=yes` 的动画使用 `CustomPalette` 自定义色盘"
 
-#: ../../../CREDITS.md:422
+#: ../../../CREDITS.md:426
 msgid "Unlimited `AlternateFLH` entries"
 msgstr "无限制 `AlternateFLH` 条目"
 
-#: ../../../CREDITS.md:423
+#: ../../../CREDITS.md:427
 msgid "Build limit group"
 msgstr "建造限制组"
 
-#: ../../../CREDITS.md:424
+#: ../../../CREDITS.md:428
 msgid "Customizing whether passengers are kicked out when an aircraft fires"
 msgstr "自定义战机开火时是否踹出乘客"
 
-#: ../../../CREDITS.md:425
+#: ../../../CREDITS.md:430
 msgid "New SuperWeapon Type template"
 msgstr "新超武类型模版"
 
-#: ../../../CREDITS.md:427
+#: ../../../CREDITS.md:432
 msgid "**TwinkleStar**:"
 msgstr "**TwinkleStar**："
 
-#: ../../../CREDITS.md:428
+#: ../../../CREDITS.md:433
 msgid "Custom slaves free sound"
 msgstr "自定义奴隶解放音效"
 
-#: ../../../CREDITS.md:429
+#: ../../../CREDITS.md:434
 msgid "Jumpjet crash rotation control"
 msgstr "Jumpjet 坠毁旋转控制"
 
-#: ../../../CREDITS.md:430
+#: ../../../CREDITS.md:435
 msgid "Vehicle voxel turret shadows & body multi-section shadows"
 msgstr "Voxel 载具炮塔与多组件 Voxel 车体影子"
 
-#: ../../../CREDITS.md:431
+#: ../../../CREDITS.md:436
 msgid "`TurretOffset` support for SHP vehicles"
 msgstr "Shape 载具的 `TurretOffset` 支持"
 
-#: ../../../CREDITS.md:432 ../../../CREDITS.md:498
+#: ../../../CREDITS.md:437 ../../../CREDITS.md:504
 msgid "Customizable rocker amplitude"
 msgstr "自定义掀起幅度"
 
-#: ../../../CREDITS.md:433
+#: ../../../CREDITS.md:438
 msgid "Customizable wake anim"
 msgstr "自定义水波动画"
 
-#: ../../../CREDITS.md:434
+#: ../../../CREDITS.md:439
 msgid "Initial effort on optimization for crates' random distribution"
 msgstr "对箱子随机分布的初步优化"
 
-#: ../../../CREDITS.md:435
+#: ../../../CREDITS.md:440
 msgid "Customizable spawns queue"
 msgstr "自定义子机序列"
 
-#: ../../../CREDITS.md:436
+#: ../../../CREDITS.md:441
 msgid "Initial spawns number"
 msgstr "初始子机数量"
 
-#: ../../../CREDITS.md:437
+#: ../../../CREDITS.md:442
 msgid "**Fryone**:"
 msgstr "**Fryone**："
 
-#: ../../../CREDITS.md:439
+#: ../../../CREDITS.md:444
 msgid "Sound entry on unit's creation"
 msgstr "单位创建时的音效条目"
 
-#: ../../../CREDITS.md:440
+#: ../../../CREDITS.md:445
 msgid "Auto-deploy/Deploy block on ammo change"
 msgstr "根据弹药自动部署／阻止部署"
 
-#: ../../../CREDITS.md:441
+#: ../../../CREDITS.md:446
 msgid "Flashing Technos on selecting"
 msgstr "闪烁选中的科技类型"
 
-#: ../../../CREDITS.md:442
+#: ../../../CREDITS.md:447
 msgid "Promotion animation"
 msgstr "升级动画"
 
-#: ../../../CREDITS.md:443
+#: ../../../CREDITS.md:448
 msgid "Damaged unit image changes"
 msgstr "单位伤残更换图像"
 
-#: ../../../CREDITS.md:444
+#: ../../../CREDITS.md:449
 msgid "`VoiceDeploy` through hot-key/command bar fix"
 msgstr "修复了通过快捷键／底边栏按钮部署时不播放 `VoiceDeploy` 的问题"
 
-#: ../../../CREDITS.md:445
+#: ../../../CREDITS.md:450
 msgid "**ZivDero**:"
 msgstr "**ZivDero**："
 
-#: ../../../CREDITS.md:446
+#: ../../../CREDITS.md:451
 msgid "Re-enable the Veinhole Monster and Weeds from TS"
 msgstr "重启 TS 中的泰伯利亚藤蔓怪和泰伯利亚废矿逻辑"
 
-#: ../../../CREDITS.md:447
+#: ../../../CREDITS.md:452
 msgid "Recreate the weed-charging of SWs like the TS Chemical Missile"
 msgstr "重新创建类似于 TS 中化学飞弹那样的超武根据废矿充能效果"
 
-#: ../../../CREDITS.md:448
+#: ../../../CREDITS.md:453
 msgid "Allow to change the speed of gas particles"
 msgstr "允许更改 gas 粒子的速度"
 
-#: ../../../CREDITS.md:449
+#: ../../../CREDITS.md:454
 msgid "Fix a jumpjet crash related to voxel shadow drawing"
 msgstr "修复与 Voxel 阴影绘制相关的 Jumpjet 崩溃问题"
 
-#: ../../../CREDITS.md:450
+#: ../../../CREDITS.md:455
 msgid "Replace `BLOWFISH.DLL` using Red Alert source code"
 msgstr "使用 RA 源码替代掉 `BLOWFISH.DLL`"
 
-#: ../../../CREDITS.md:451
+#: ../../../CREDITS.md:456
 msgid "**CrimRecya**:"
 msgstr "**CrimRecya**："
 
-#: ../../../CREDITS.md:452
+#: ../../../CREDITS.md:457
 msgid "Fix `LimboKill` not working reliably"
 msgstr "修复 `LimboKill` 未能可靠工作的问题"
 
-#: ../../../CREDITS.md:453
+#: ../../../CREDITS.md:458
 msgid "Allow using waypoints, area guard and attack move with aircraft"
 msgstr "允许战机使用路径点、区域警戒和移动攻击"
 
-#: ../../../CREDITS.md:454
+#: ../../../CREDITS.md:459
 msgid "Fix `Stop` command not working so well in many cases"
 msgstr "修复 `停止` 命令很多情况下不工作的问题"
 
-#: ../../../CREDITS.md:455
+#: ../../../CREDITS.md:460
 msgid "Fix aircraft `MovementZone` and `SpeedType` inconsistencies"
 msgstr "修复战机自身设置的 `MovementZone` 和 `SpeedType` 与寻路所用的这两项不一致的问题"
 
-#: ../../../CREDITS.md:456
+#: ../../../CREDITS.md:461
 msgid ""
 "Use 2D distance instead of 3D to check whether in air team members have "
 "arrived destination"
 msgstr "使用 2D 而不是 3D 距离来检查空中的小队成员是否抵达目的地"
 
-#: ../../../CREDITS.md:457
+#: ../../../CREDITS.md:462
 msgid "No rearm and reload in EMP or temporal"
 msgstr "EMP 或超时空停止 CD"
 
-#: ../../../CREDITS.md:458
+#: ../../../CREDITS.md:463
 msgid "Enhanced Straight trajectory"
 msgstr "增强的直线轨迹"
 
-#: ../../../CREDITS.md:459
+#: ../../../CREDITS.md:464
 msgid "Enable Building Production Queue"
 msgstr "启用建筑生产队列"
 
-#: ../../../CREDITS.md:460
+#: ../../../CREDITS.md:465
 msgid "Fix for sidebar not updating queued unit numbers when on hold"
 msgstr "修复侧边栏在生产暂停时未能更新预购单位订单数量的问题"
 
-#: ../../../CREDITS.md:461
+#: ../../../CREDITS.md:466
 msgid "New Parabola trajectory"
 msgstr "新的抛物线轨迹"
 
-#: ../../../CREDITS.md:462 ../../../CREDITS.md:501
+#: ../../../CREDITS.md:467 ../../../CREDITS.md:507
 msgid "Enhanced Bombard trajectory"
 msgstr "增强的轰击轨迹"
 
-#: ../../../CREDITS.md:463 ../../../CREDITS.md:525
+#: ../../../CREDITS.md:468 ../../../CREDITS.md:532
 msgid "No turret unit turn to the target"
 msgstr "无炮塔单位转向目标"
 
-#: ../../../CREDITS.md:464
+#: ../../../CREDITS.md:469
 msgid "Damage multiplier for different houses"
 msgstr "对不同所属方的伤害修正比"
 
-#: ../../../CREDITS.md:465
+#: ../../../CREDITS.md:470
 msgid "Extended gattling rate down logic"
 msgstr "拓展的盖特掉档逻辑"
 
-#: ../../../CREDITS.md:466
+#: ../../../CREDITS.md:471
 msgid "Sell or undeploy building on impact"
 msgstr "弹头将建筑出售或反部署"
 
-#: ../../../CREDITS.md:467
+#: ../../../CREDITS.md:472
 msgid "Draw visual effects for airburst weapons"
 msgstr "空爆武器正常绘制武器特效"
 
-#: ../../../CREDITS.md:468
+#: ../../../CREDITS.md:473
 msgid "Technos recount current burst index when change the firing weapon"
 msgstr "科技类型在更换开火武器时重置当前连发索引"
 
-#: ../../../CREDITS.md:469
+#: ../../../CREDITS.md:474
 msgid "Units will not always stuck in the factory"
 msgstr "单位将不再会被卡在工厂内"
 
-#: ../../../CREDITS.md:470
+#: ../../../CREDITS.md:475
 msgid "Technos can maintain a suitable distance after firing"
 msgstr "科技类型可以在开火后保持适当的距离"
 
-#: ../../../CREDITS.md:471
+#: ../../../CREDITS.md:476
 msgid "Projectile subject to ground check before firing"
 msgstr "开火前检查抛射体是否会穿地"
 
-#: ../../../CREDITS.md:472
+#: ../../../CREDITS.md:477
 msgid "Delay automatic attack on the controlled unit"
 msgstr "攻击被心控单位的延迟"
 
-#: ../../../CREDITS.md:473
+#: ../../../CREDITS.md:478
 msgid "Fast access vehicle"
 msgstr "快速上车"
 
-#: ../../../CREDITS.md:474
+#: ../../../CREDITS.md:479
 msgid ""
 "Fix an issue that some amphibious technos being unable to enter on water "
 "structures"
 msgstr "修复了一些两栖单位无法进入水上建筑的问题"
 
-#: ../../../CREDITS.md:475
+#: ../../../CREDITS.md:480
 msgid ""
 "Fix an issue that aircraft carriers can not find suitable locations for "
 "attacks when under elevated bridges on their own"
 msgstr "修复了航空母舰在桥下时无法找到恰当攻击位置的问题"
 
-#: ../../../CREDITS.md:476 ../../../CREDITS.md:535
+#: ../../../CREDITS.md:481 ../../../CREDITS.md:542
 msgid ""
 "Fix an issue that in air aircraft carriers being unable to attack when it"
 " is near by elevated bridges"
 msgstr "修复了空天母舰靠近高架桥梁时无法攻击的问题"
 
-#: ../../../CREDITS.md:477
+#: ../../../CREDITS.md:482
 msgid ""
 "Fix an issue that aircraft carriers cannot retract its spawned aircraft "
 "when on the bridge"
 msgstr "修复了航空母舰在桥上无法回收子机的问题"
 
-#: ../../../CREDITS.md:478
+#: ../../../CREDITS.md:483
 msgid ""
 "Fix an issue where the shadow of jumpjet remained on the ground when it "
 "was above the elevated bridge"
 msgstr "修复了 Jumpjet 在桥梁上方时其影子残留在地面的问题"
 
-#: ../../../CREDITS.md:479
+#: ../../../CREDITS.md:484
 msgid "Laser, electric bolt and rad beam scatter"
 msgstr "激光、EBolt 和辐射波的散布"
 
-#: ../../../CREDITS.md:480
+#: ../../../CREDITS.md:485
 msgid ""
 "Fix an issue that laser, electric bolt and rad beam not support "
 "`Inviso=true` projectiles with `FlakScatter=true` to scatter"
 msgstr "修复了激光、EBolt、辐射波在 `FlakScatter=true` 的 `Inviso=true` 抛射体上不不跟随散布的问题"
 
-#: ../../../CREDITS.md:482
+#: ../../../CREDITS.md:487
 msgid ""
 "Fix an issue that the first passenger who call the transport ship no "
 "longer board the transport ship when the land units call for boarding"
 msgstr "修复了当陆地单位请求登船时第一个呼叫运输船的乘客不会登船的问题"
 
-#: ../../../CREDITS.md:483
+#: ../../../CREDITS.md:488
 msgid ""
 "Fix an issue that impassable invisible barrier generated by the behavior "
 "of infantry continuously entering vehicles"
 msgstr "修复了步兵通过路径点连续进入两个载具等行为会产生空气墙的问题"
 
-#: ../../../CREDITS.md:484
+#: ../../../CREDITS.md:489
 msgid ""
 "Fix an issue that MCV will self-destruct when using trigger 107 to "
 "teleport"
 msgstr "修复了使用 107 号触发传送时 MCV 会自毁的问题"
 
-#: ../../../CREDITS.md:485
+#: ../../../CREDITS.md:490
 msgid ""
 "Fix an issue that moving MCV with Teleport locomotion will cause "
 "reconnection error"
 msgstr "修复了超时空移动的 MCV 会引发 Reconnection Error 的问题"
 
-#: ../../../CREDITS.md:486
+#: ../../../CREDITS.md:491
 msgid "Jumpjet Tilts While Moving"
 msgstr "Jumpjet 在移动时倾斜"
 
-#: ../../../CREDITS.md:487
+#: ../../../CREDITS.md:492
 msgid ""
 "Fix an issue that game crashes (EIP:7FB178) when infantry are about to "
 "enter an occupiable building that has been removed and is not real dead"
 msgstr "修复了当步兵进入一个已被移除但并未真正死亡的可驻军建筑时导致的游戏崩溃问题"
 
-#: ../../../CREDITS.md:488
+#: ../../../CREDITS.md:493
 msgid ""
 "Fix an issue that game crashes when spawnee has been removed and is not "
 "real dead"
 msgstr "修复了当子机已被移除但并未真正死亡时导致的游戏崩溃问题"
 
-#: ../../../CREDITS.md:489
+#: ../../../CREDITS.md:494
 msgid "Aggressive attack move mission"
 msgstr "侵略性移动攻击命令"
 
-#: ../../../CREDITS.md:490
+#: ../../../CREDITS.md:495
 msgid "Amphibious access vehicle"
 msgstr "两栖载具装载拓展"
 
-#: ../../../CREDITS.md:491
+#: ../../../CREDITS.md:496
 msgid ""
 "Fix an issue that spawned `Strafe` aircraft on aircraft carriers may not "
 "be able to return normally if aircraft carriers moved a short distance "
 "when the aircraft is landing"
 msgstr "修复了 `Strafe` 状态的子机返航时如果航母移动了一小段距离会导致无法正常返航而一直绕圈的问题"
 
-#: ../../../CREDITS.md:493
+#: ../../../CREDITS.md:498
 msgid ""
 "Fix an issue that the widespread damage caused by detonation on the "
 "bridge/ground cannot affect objects on the ground/bridge who are in the "
 "opposite case"
 msgstr "修复了范围伤害在桥上／地面引爆时无法影响相对情况即在地面／桥上的对象的问题"
 
-#: ../../../CREDITS.md:494
+#: ../../../CREDITS.md:499
 msgid ""
 "Several new Infotypes, no display in specific status and a new single "
 "frame display method"
-msgstr ""
-"多种新的数显信息类型、特定情况下不显示以及一种新的单帧显示方式"
+msgstr "多种新的数显信息类型、特定情况下不显示以及一种新的单帧显示方式"
 
-#: ../../../CREDITS.md:495
+#: ../../../CREDITS.md:500
 msgid ""
 "Customizable spawn delay of `VoxelAnim`'s `TrailerAnim` and fix its "
 "incorrect position"
-msgstr ""
-"自定义 Voxel 碎片 `TrailerAnim` 生成间隔并修复其生成位置错误的问题"
+msgstr "自定义 Voxel 碎片 `TrailerAnim` 生成间隔并修复其生成位置错误的问题"
 
-#: ../../../CREDITS.md:496
+#: ../../../CREDITS.md:501
+msgid "Add `DebrisMinimums` to keep the count of debris within a certain range"
+msgstr "添加了 `DebrisMinimums` 语句以将碎片数量控制在一定范围内"
+
+#: ../../../CREDITS.md:502
 msgid "**Ollerus**:"
 msgstr "**Ollerus**："
 
-#: ../../../CREDITS.md:497
+#: ../../../CREDITS.md:503
 msgid "Build limit group enhancement"
 msgstr "建造限制组增强"
 
-#: ../../../CREDITS.md:499
+#: ../../../CREDITS.md:505
 msgid ""
 "Allow `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building "
 "upgrades"
 msgstr "允许加载物被正常计入 `AuxBuilding` 和 Ares 的 `SW.Aux/NegBuildings`"
 
-#: ../../../CREDITS.md:500
+#: ../../../CREDITS.md:506
 msgid "Type select for buildings (doc)"
 msgstr "建筑的类型选择（文档）"
 
-#: ../../../CREDITS.md:502
+#: ../../../CREDITS.md:508
 msgid "Shield armor inheritance customization"
 msgstr "自定义护盾继承单位护甲"
 
-#: ../../../CREDITS.md:504
+#: ../../../CREDITS.md:510
 msgid "Fire weapon when Warhead kills something"
 msgstr "击杀武器"
 
-#: ../../../CREDITS.md:505
+#: ../../../CREDITS.md:511
 msgid "Promotion animation deglobalization"
 msgstr "自定义升级动画"
 
-#: ../../../CREDITS.md:506
+#: ../../../CREDITS.md:512
 msgid "Forcing specific weapon by range"
 msgstr "根据射程选取武器"
 
-#: ../../../CREDITS.md:507
+#: ../../../CREDITS.md:513
 msgid "Passenger-based insignias"
 msgstr "根据乘客切换军衔"
 
-#: ../../../CREDITS.md:508
+#: ../../../CREDITS.md:514
 msgid "Use `InsigniaType` to set the properties of insignia in a batch"
 msgstr "使用 `InsigniaType` 批量设置军衔属性"
 
-#: ../../../CREDITS.md:509
+#: ../../../CREDITS.md:515
 msgid ""
 "Allow player's self-healing effects to be benefited by allied or "
 "`PlayerControl=true` houses"
 msgstr "允许玩家的自愈效果可以从友军或 `PlayerControl=true` 的所属方受益"
 
-#: ../../../CREDITS.md:511
+#: ../../../CREDITS.md:517
 msgid "Allow faking digital display for `InfoType=Health` at disguise"
 msgstr "允许 `InfoType=Health` 伪造出伪装目标的数值"
 
-#: ../../../CREDITS.md:512
+#: ../../../CREDITS.md:518
+msgid "Display banner improvement and doc"
+msgstr "横幅的改进与文档"
+
+#: ../../../CREDITS.md:519
 msgid "**NaotoYuuki** - Vertical & meteor trajectory projectile prototypes"
 msgstr "**NaotoYuuki** - 垂直和流星轨迹雏形"
 
-#: ../../../CREDITS.md:513
+#: ../../../CREDITS.md:520
 msgid "**handama** - AI script action to `16005 Jump Back To Previous Script`"
 msgstr "**handama** - AI 脚本动作 `16005 跳回上一个脚本`"
 
-#: ../../../CREDITS.md:514
+#: ../../../CREDITS.md:521
 msgid "**TaranDahl (航味麻酱)**:"
 msgstr "**TaranDahl (航味麻酱)**："
 
-#: ../../../CREDITS.md:515
+#: ../../../CREDITS.md:522
 msgid ""
 "Skirmish AI \"sell all buildings and set all technos to hunt\" behavior "
 "dehardcode"
 msgstr "遭遇战 AI 卖家冲锋行为的去硬编码化"
 
-#: ../../../CREDITS.md:516
+#: ../../../CREDITS.md:523
 msgid "Skirmish AI \"gather when MCV deploy\" behavior dehardcode"
 msgstr "遭遇战 AI 基地部署时集结行为的去硬编码化"
 
-#: ../../../CREDITS.md:517
+#: ../../../CREDITS.md:524
 msgid "Global value of `RepairBaseNodes`"
 msgstr "`RepairBaseNodes` 的全局值"
 
-#: ../../../CREDITS.md:518
+#: ../../../CREDITS.md:525
 msgid "Skip anim delay for burst fire"
 msgstr "为有 `Burst` 的武器跳过建筑开火前摇动画"
 
-#: ../../../CREDITS.md:519
+#: ../../../CREDITS.md:526
 msgid "Type select for buildings (code)"
 msgstr "建筑的类型选择（代码）"
 
-#: ../../../CREDITS.md:520
+#: ../../../CREDITS.md:527
 msgid "Raise alert when technos are taking damage"
 msgstr "当科技类型受到伤害时发出警报"
 
-#: ../../../CREDITS.md:521
+#: ../../../CREDITS.md:528
 msgid "Toggle waypoint for building"
 msgstr "建筑路径点开关"
 
-#: ../../../CREDITS.md:522
+#: ../../../CREDITS.md:529
 msgid "Parasite returning bug fix"
 msgstr "寄生返回 bug 修复"
 
-#: ../../../CREDITS.md:523
+#: ../../../CREDITS.md:530
 msgid "Bunkerable checks dehardcode"
 msgstr "坦克碉堡准入检查的去硬编码化"
 
-#: ../../../CREDITS.md:524
+#: ../../../CREDITS.md:531
 msgid ""
 "Prevent the units with locomotors that cause problems from entering the "
 "tank bunker"
 msgstr "防止使用了可能导致问题的运动模式的单位进入坦克碉堡"
 
-#: ../../../CREDITS.md:526
+#: ../../../CREDITS.md:533
 msgid ""
 "Units are now unable to kick out from a factory that is in construction "
 "process"
 msgstr "单位现在不会再从正在建造的工厂中驶出"
 
-#: ../../../CREDITS.md:527
+#: ../../../CREDITS.md:534
 msgid ""
 "Fix issues caused by incorrect reference removal (f.ex. If the unit "
 "cloaks/enters transport, it cannot gain experience from previously "
 "launched spawners/C4/projectiles)"
 msgstr "修复了错误脱引用导致的问题（例如，如果单位隐形／进入运输工具则无法自此前发射的子机／抛射体以及安置的 C4 炸弹获得经验）"
 
-#: ../../../CREDITS.md:528
+#: ../../../CREDITS.md:535
 msgid "Recycle spawner in long-range"
 msgstr "远距离回收子机"
 
-#: ../../../CREDITS.md:529
+#: ../../../CREDITS.md:536
 msgid "Play an anim when recycling a spawner"
 msgstr "回收子机时播放动画"
 
-#: ../../../CREDITS.md:530
+#: ../../../CREDITS.md:537
 msgid "Recycle the spawner on other FLH"
 msgstr "使用其他 FLH 回收子机"
 
-#: ../../../CREDITS.md:531
+#: ../../../CREDITS.md:538
 msgid ""
 "Fix the bug that spawned can not return to buildings with foundation "
 "bigger than 1x1"
 msgstr "修复了占地面积超过 1x1 的建筑无法回收子机的 Bug"
 
-#: ../../../CREDITS.md:532
+#: ../../../CREDITS.md:539
 msgid "`BombParachute` deglobalization"
 msgstr "抛射体自定义 `BombParachute`"
 
-#: ../../../CREDITS.md:533
+#: ../../../CREDITS.md:540
 msgid "Sinkablity and sinking speed customization"
 msgstr "自定义能否沉没以及沉没速度"
 
-#: ../../../CREDITS.md:534
+#: ../../../CREDITS.md:541
 msgid ""
 "Fix an issue where `FireAngle` would not work properly under certain "
 "circumstances"
 msgstr "修复了 `FireAngle` 在某些情况下未能正常工作的问题"
 
-#: ../../../CREDITS.md:536
+#: ../../../CREDITS.md:543
 msgid ""
 "Fix the bug that healing weapons could not automatically acquire aerial "
 "targets"
 msgstr "修复了治疗武器无法自动获取到空中目标的 Bug"
 
-#: ../../../CREDITS.md:537
+#: ../../../CREDITS.md:544
 msgid ""
 "Fix an issue where AI would select unreachable buildings and get stuck "
 "when looking for buildings like tank bunkers, bio reactors, etc"
 msgstr "修复了 AI 会找实际无法抵达的坦克碉堡、生化反应炉等建筑作为目标而导致卡住的问题"
 
-#: ../../../CREDITS.md:538
+#: ../../../CREDITS.md:545
 msgid "Prone speed customization"
 msgstr "自定义匍匐速度"
 
-#: ../../../CREDITS.md:539
+#: ../../../CREDITS.md:546
 msgid "RadarInvisible for non-enemy house"
 msgstr "不仅限于敌方的 `RadarInvisible`"
 
-#: ../../../CREDITS.md:540
+#: ../../../CREDITS.md:547
 msgid "Allow miners do area guard"
 msgstr "允许矿车区域警戒"
 
-#: ../../../CREDITS.md:541
+#: ../../../CREDITS.md:548
 msgid "Make harvesters do addtional scan after unload"
 msgstr "使矿车卸载后重新扫描较近的矿区"
 
-#: ../../../CREDITS.md:542
+#: ../../../CREDITS.md:549
 msgid "Customize the scatter caused by aircraft attack mission"
 msgstr "自定义战机攻击任务引发分散"
 
-#: ../../../CREDITS.md:543
+#: ../../../CREDITS.md:550
 msgid "Customize whether `Crater=yes` animation would destroy tiberium"
 msgstr "自定义 `Crater=yes` 的动画能否摧毁矿石"
 
-#: ../../../CREDITS.md:544
+#: ../../../CREDITS.md:551
 msgid "Targeting limitation for berzerk technos"
 msgstr "狂暴单位索敌限制"
 
-#: ../../../CREDITS.md:545
+#: ../../../CREDITS.md:552
+msgid "Allows refineries to use multiple ActiveAnim simultaneously"
+msgstr "允许矿场同时播放多个 `ActiveAnim` 动画"
+
+#: ../../../CREDITS.md:553
 msgid "**tyuah8**:"
 msgstr "**tyuah8**："
 
-#: ../../../CREDITS.md:546
+#: ../../../CREDITS.md:554
 msgid ""
 "Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-"
 "piggybacked bugfix"
 msgstr "修复了 Drive/Jumpjet/Ship/Teleport 运动方式在退出 piggybacked 接口时无法激活的问题"
 
-#: ../../../CREDITS.md:547
+#: ../../../CREDITS.md:555
 msgid "Destroyed unit leaves sensors bugfix"
 msgstr "单位被摧毁后遗留反隐区域的 bug 修复"
 
-#: ../../../CREDITS.md:548
+#: ../../../CREDITS.md:556
 msgid ""
 "**Aephiex** - initial fix for Ares academy not working on the initial "
 "payloads of vehicles built from a war factory"
 msgstr "**Aephiex** - 对于 Ares 训练所逻辑在产自重工的载具其初始载员上不生效问题初始的修复方式"
 
-#: ../../../CREDITS.md:549
+#: ../../../CREDITS.md:557
 msgid ""
 "**Multfinite** - Allow to toggle main exception handler via command line "
 "argument `-ExceptionHandler=boolean`"
 msgstr "**Multfinite** - 允许通过命令行参数 `-ExceptionHandler=boolean` 开关主循环异常处理程序"
 
-#: ../../../CREDITS.md:550
+#: ../../../CREDITS.md:558
 msgid ""
 "**hejiajun107, Xkein** - Fix a jumpjet crash related to voxel shadow "
 "drawing"
 msgstr "**hejiajun107, Xkein** - 修复与 Voxel 阴影绘制相关的 Jumpjet 崩溃问题"
 
-#: ../../../CREDITS.md:551
+#: ../../../CREDITS.md:559
 msgid "**Ares developers**:"
 msgstr "**Ares developers**："
 
-#: ../../../CREDITS.md:552
+#: ../../../CREDITS.md:560
 msgid ""
 "YRpp and Syringe which are used, save/load, project foundation and "
 "generally useful code from Ares"
 msgstr "Ares 所使用的 YRpp 和 Syringe、存读档、项目基础和一些通用代码"
 
-#: ../../../CREDITS.md:553
+#: ../../../CREDITS.md:561
 msgid "unfinished RadTypes code"
 msgstr "半成品自定义辐射类型代码"
 
-#: ../../../CREDITS.md:554
+#: ../../../CREDITS.md:562
 msgid "prototype deployer fixes"
 msgstr "部署修复雏形"
 
-#: ../../../CREDITS.md:555
+#: ../../../CREDITS.md:563
 msgid "Superweapon launch site & availability code"
 msgstr "超级武器发射地点与超武可用性代码"
 
-#: ../../../CREDITS.md:556
+#: ../../../CREDITS.md:564
 msgid "AI vehicle production update code"
 msgstr "AI 载具生产更新代码"
 
-#: ../../../CREDITS.md:557
+#: ../../../CREDITS.md:565
 msgid "parts of TechnoType conversion placeholder code"
 msgstr "单位转换占位符代码的一部分"
 
-#: ../../../CREDITS.md:558
+#: ../../../CREDITS.md:566
 msgid "**ststl, FlyStar, NaotoYuuki, Saigyouji, JunJacobYoung** - Digital Display"
 msgstr "**ststl, FlyStar, NaotoYuuki, Saigyouji, JunJacobYoung** - 数字化显示"
 
-#: ../../../CREDITS.md:559
+#: ../../../CREDITS.md:567
 msgid "**SukaHati (Erzoid)** - Minimum interceptor guard range"
 msgstr "**SukaHati (Erzoid)** - 抛射体最小拦截距离"
 
-#: ../../../CREDITS.md:560
+#: ../../../CREDITS.md:568
 msgid "**E1 Elite** - TileSet 255 and above bridge repair fix"
 msgstr "**E1 Elite** - TileSet 达到 255 以上后的桥梁维修修复"
 
-#: ../../../CREDITS.md:561
+#: ../../../CREDITS.md:569
 msgid "**AutoGavy** - interceptor logic, Warhead critical hit logic"
 msgstr "**AutoGavy** - 抛射体拦截逻辑、弹头暴击逻辑"
 
-#: ../../../CREDITS.md:562
+#: ../../../CREDITS.md:570
 msgid "**Chasheen (Chasheenburg)** - CN docs help for Build#24"
 msgstr "**Chasheen (Chasheenburg)** - Build#24 的中文文档协助"
 
-#: ../../../CREDITS.md:563
+#: ../../../CREDITS.md:571
 msgid ""
 "**Noble Fish** - some minor fixes, established Community Chinese docs, "
 "took over and completely rewrite the Official Chinese docs during "
 "Build#46"
 msgstr "**Noble Fish** - 一些小修复、文档维护者（官方英文文档维护、创建了社区中文文档、在 Build#46 接管并完全重写了官方中文文档）"
 
-#: ../../../CREDITS.md:564
+#: ../../../CREDITS.md:572
 msgid ""
 "**tomsons26** - all-around help, assistance and guidance in reverse-"
 "engineering, YR binary mappings"
 msgstr "**tomsons26** - 全方位协助，逆向工程方面的协助与指导、YR 二进制映射"
 
-#: ../../../CREDITS.md:565
+#: ../../../CREDITS.md:573
 msgid ""
 "**CCHyper** - all-around help, current project logo, assistance and "
 "guidance in reverse-engineering, YR binary mappings, custom locomotors "
 "example implementation"
 msgstr "**CCHyper** - 全方位协助，当前项目 Logo 设计、逆向工程方面的协助与指导、YR 二进制映射、自定义运动模式示例实现"
 
-#: ../../../CREDITS.md:566
+#: ../../../CREDITS.md:574
 msgid "**AlexB** - Original FlyingStrings implementation"
 msgstr "**AlexB** - 原始 FlyingStrings 实现"
 
-#: ../../../CREDITS.md:567
+#: ../../../CREDITS.md:575
 msgid "**Joshy** - Original FlyingStrings implementation"
 msgstr "**Joshy** - 原始 FlyingStrings 实现"
 
-#: ../../../CREDITS.md:568
+#: ../../../CREDITS.md:576
 msgid "**CnCVK** - Original custom locomotors experiment"
 msgstr "**CnCVK** - 原始的自定义运动模式尝试"
 
-#: ../../../CREDITS.md:569
+#: ../../../CREDITS.md:577
 msgid "**ZΞPHYɌUS** - win/lose themes code"
 msgstr "**ZΞPHYɌUS** - 胜利／失败主题音乐代码"
 
-#: ../../../CREDITS.md:570
+#: ../../../CREDITS.md:578
 msgid ""
 "**Neargye (Daniil Goncharov)** - [nameof "
 "library](https://github.com/Neargye/nameof) (MIT)"
@@ -2332,33 +2352,33 @@ msgstr ""
 "**Neargye (Daniil Goncharov)** - [nameof "
 "库](https://github.com/Neargye/nameof)（MIT）"
 
-#: ../../../CREDITS.md:571
+#: ../../../CREDITS.md:579
 msgid "**ayylmao** - help with docs, extensive and thorough testing"
 msgstr "**ayylmao** - 文档协助，广泛且深入的测试"
 
-#: ../../../CREDITS.md:572
+#: ../../../CREDITS.md:580
 msgid "**SMxReaver** - help with docs, extensive and thorough testing"
 msgstr "**SMxReaver** - 文档协助，广泛且深入的测试"
 
-#: ../../../CREDITS.md:573
+#: ../../../CREDITS.md:581
 msgid "**4SG** - help with docs"
 msgstr "**4SG** - 文档协助"
 
-#: ../../../CREDITS.md:574
+#: ../../../CREDITS.md:582
 msgid ""
 "**thomassneddon** - general assistance, knowledge about voxel lighting "
 "model"
 msgstr "**thomassneddon** - 一般性协助、Voxel 照明模型知识"
 
-#: ../../../CREDITS.md:575
+#: ../../../CREDITS.md:583
 msgid "**Xkein** - general assistance, YRpp edits"
 msgstr "**Xkein** - 一般性协助、YRpp 编辑"
 
-#: ../../../CREDITS.md:576
+#: ../../../CREDITS.md:584
 msgid "**mevitar** - honorary shield tester *triple* award"
 msgstr "**mevitar** - 荣誉护盾测试员 **三重** 奖章"
 
-#: ../../../CREDITS.md:577
+#: ../../../CREDITS.md:585
 msgid ""
 "**Mentalmeisters Team (Speeder, Ollerus, mevitar, Reedom, Takitoru, "
 "Terumasa, Zhelin)** - extensive and thorough testing"
@@ -2366,7 +2386,7 @@ msgstr ""
 "**Mentalmeisters Team (Speeder, Ollerus, mevitar, Reedom, Takitoru, "
 "Terumasa, Zhelin)** - 广泛且深入的测试"
 
-#: ../../../CREDITS.md:578
+#: ../../../CREDITS.md:586
 msgid ""
 "**Phobos CN Tester Group (Mantis, Swim Wing, Examon, AKB, Pusheen, ZQ, "
 "Claptrap, BunkerGeneral, Big J, Skywalker, ChickEmperor, Shifty, Mikain, "
@@ -2380,15 +2400,15 @@ msgstr ""
 "Yumeri_Rei, Nacho, Zhuzi, Ika_Aru, EUSiegfried, HanpiBaozi, Nxusbot, "
 "TientsinWind)** - 广泛且深入的测试"
 
-#: ../../../CREDITS.md:579
+#: ../../../CREDITS.md:587
 msgid "**Damfoos** - extensive and thorough testing"
 msgstr "**Damfoos** - 广泛且深入的测试"
 
-#: ../../../CREDITS.md:580
+#: ../../../CREDITS.md:588
 msgid "**Dmitry Volkov** - extensive and thorough testing"
 msgstr "**Dmitry Volkov** - 广泛且深入的测试"
 
-#: ../../../CREDITS.md:581
+#: ../../../CREDITS.md:589
 msgid "**Rise of the East community** - extensive playtesting of in-dev features"
 msgstr "**东方崛起社区** - 对开发功能的广泛测试"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Phobos \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-15 21:26+0800\n"
+"POT-Creation-Date: 2025-06-23 01:10+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -92,32 +92,23 @@ msgstr "修复了被超时空冻结的单位无法正确抹除的 Bug 并使其�
 
 #: ../../Fixed-or-Improved-Logics.md:17
 msgid ""
-"Fixed `DebrisMaximums` (spawned debris type amounts cannot go beyond "
-"specified maximums anymore). Only applied when `DebrisMaximums` values "
-"amount is more than 1 for compatibility reasons."
-msgstr ""
-"修复了 `DebrisMaximums`（被生成的碎片类型数量不能超过这里指定最大值）。仅当 `DebrisMaximums` 值数量大于 1 "
-"时才生效，以保持对旧有行为的兼容。"
-
-#: ../../Fixed-or-Improved-Logics.md:18
-msgid ""
 "Fixed building and defense tab hotkeys not enabling the placement mode "
 "after *Cannot build here.* triggered and the placement mode cancelled."
 msgstr "修复了在触发 *Cannot build here.*（摆放失败）并取消放置模式后使用切换到建筑栏和防御栏的快捷键无法再次进入放置模式的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:19
+#: ../../Fixed-or-Improved-Logics.md:18
 msgid ""
 "Fixed buildings with `UndeployInto` playing "
 "`EVA_NewRallypointEstablished` on undeploying."
 msgstr "修复了拥有 `UndeployInto` 的建筑在反部署时会播放 `EVA_NewRallypointEstablished` 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:20
+#: ../../Fixed-or-Improved-Logics.md:19
 msgid ""
 "Fixed buildings with `Naval=yes` ignoring `WaterBound=no` to be forced to"
 " place onto water."
 msgstr "修复了拥有 `Naval=yes` 的建筑会忽略 `WaterBound=no` 而被强制放置在水中的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:21
+#: ../../Fixed-or-Improved-Logics.md:20
 msgid ""
 "Fixed AI Aircraft docks bug when Ares tag `[GlobalControls] -> "
 "AllowParallelAIQueues=no` is set."
@@ -125,48 +116,48 @@ msgstr ""
 "修复了当设置 Ares 标签 `[GlobalControls] -> AllowParallelAIQueues=no` 时 AI "
 "战机对接机场的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:22
+#: ../../Fixed-or-Improved-Logics.md:21
 msgid ""
 "Fixed laser drawing code to allow for thicker lasers in house color draw "
 "mode."
 msgstr "修复了激光绘制代码以允许在所属色绘制模式下使用更粗的激光。"
 
-#: ../../Fixed-or-Improved-Logics.md:23
+#: ../../Fixed-or-Improved-Logics.md:22
 msgid "Fixed `DeathWeapon` not detonating properly."
 msgstr "修复了 `DeathWeapon` 未能正确引爆的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:24
+#: ../../Fixed-or-Improved-Logics.md:23
 msgid ""
 "Some settings are still ignored like `PreImpactAnim` *(Ares feature)*, "
 "this might change in future."
 msgstr "例如 `PreImpactAnim`（*Ares 功能*）这样的某些设置仍然被忽略，未来可能会进行更改。"
 
-#: ../../Fixed-or-Improved-Logics.md:25
+#: ../../Fixed-or-Improved-Logics.md:24
 msgid ""
 "Fixed the bug when occupied building's `MuzzleFlashX` is drawn on the "
 "center of the building when `X` goes past 10."
 msgstr "修复了当驻军建筑的 `MuzzleFlashX` 在 `X` 超过 10 后绘制在建筑中心的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:26
+#: ../../Fixed-or-Improved-Logics.md:25
 msgid ""
 "Fixed the bug where jumpjet units that are `Crashable` do not crashing to"
 " ground properly if destroyed while being pulled by a `Locomotor` "
 "warhead."
 msgstr "修复了拥有 `Crashable` 的 Jumpjet 类单位在被 `Locomotor` 弹头牵引时被摧毁则无法正常坠毁的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:27
+#: ../../Fixed-or-Improved-Logics.md:26
 msgid ""
 "Fixed the bug that prevents jumpjet units from turn to the target when "
 "firing from a different direction."
 msgstr "修复了 Jumpjet 单位从其他方向开火时无法转向目标的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:28
+#: ../../Fixed-or-Improved-Logics.md:27
 msgid ""
 "Fixed the bug allowing jumpjet units to continue firing at enemy target "
 "when crashing."
 msgstr "修复了 Jumpjet 单位在坠毁时仍可继续向敌方目标开火的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:30
+#: ../../Fixed-or-Improved-Logics.md:29
 msgid ""
 "![image](_static/images/jumpjet-turning.gif) *Jumpjet turning to target "
 "applied in Robot Storm X*"
@@ -174,51 +165,51 @@ msgstr ""
 "![image](_static/images/jumpjet-turning.gif) *Robot Storm X 中的 Jumpjet "
 "转向目标应用实例*"
 
-#: ../../Fixed-or-Improved-Logics.md:30 ../../Fixed-or-Improved-Logics.md:40
-#: ../../Fixed-or-Improved-Logics.md:50 ../../Fixed-or-Improved-Logics.md:79
-#: ../../Fixed-or-Improved-Logics.md:538 ../../Fixed-or-Improved-Logics.md:790
-#: ../../Fixed-or-Improved-Logics.md:917 ../../Fixed-or-Improved-Logics.md:942
-#: ../../Fixed-or-Improved-Logics.md:1348
-#: ../../Fixed-or-Improved-Logics.md:1413
-#: ../../Fixed-or-Improved-Logics.md:1609
-#: ../../Fixed-or-Improved-Logics.md:1992
+#: ../../Fixed-or-Improved-Logics.md:29 ../../Fixed-or-Improved-Logics.md:39
+#: ../../Fixed-or-Improved-Logics.md:49 ../../Fixed-or-Improved-Logics.md:78
+#: ../../Fixed-or-Improved-Logics.md:549 ../../Fixed-or-Improved-Logics.md:801
+#: ../../Fixed-or-Improved-Logics.md:928 ../../Fixed-or-Improved-Logics.md:953
+#: ../../Fixed-or-Improved-Logics.md:1380
+#: ../../Fixed-or-Improved-Logics.md:1445
+#: ../../Fixed-or-Improved-Logics.md:1641
 #: ../../Fixed-or-Improved-Logics.md:2037
-#: ../../Fixed-or-Improved-Logics.md:2062
+#: ../../Fixed-or-Improved-Logics.md:2082
+#: ../../Fixed-or-Improved-Logics.md:2107
 msgid "image"
 msgstr "图像"
 
-#: ../../Fixed-or-Improved-Logics.md:33
+#: ../../Fixed-or-Improved-Logics.md:32
 msgid ""
 "Fixed the bug when turreted jumpjet units always facing bottom-right "
 "direction when motion stops."
 msgstr "修复了 Jumpjet 单位总是在停止移动时朝向右下方向的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:34
+#: ../../Fixed-or-Improved-Logics.md:33
 msgid "Fixed the bug when jumpjet objects are unable to use `Sensors`."
 msgstr "修复了 Jumpjet 对象无法使用 `Sensors` 的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:35
+#: ../../Fixed-or-Improved-Logics.md:34
 msgid "Allowed usage of `AlternateFLH` of vehicles in `OpenTopped` transport."
 msgstr "允许载具在 `OpenTopped` 的运输工具中使用 `AlternateFLH`。"
 
-#: ../../Fixed-or-Improved-Logics.md:36
+#: ../../Fixed-or-Improved-Logics.md:35
 msgid ""
 "Improved the statistic distribution of the spawned crates over the "
 "visible area of the map so that they will no longer have a higher chance "
 "to show up near the edges."
 msgstr "改进了生成箱子在地图可见区域的统计分布使其不再具有更高的概率出现在地图边界。"
 
-#: ../../Fixed-or-Improved-Logics.md:37
+#: ../../Fixed-or-Improved-Logics.md:36
 msgid ""
 "Allowed usage of TileSet of 255 and above without making NE-SW broken "
 "bridges unrepairable."
 msgstr "允许使用 255 及以上的 TileSet 而不再会导致东北-西南方向的断桥无法修复。"
 
-#: ../../Fixed-or-Improved-Logics.md:38
+#: ../../Fixed-or-Improved-Logics.md:37
 msgid "Added a \"Load Game\" button to the retry dialog on mission failure."
 msgstr "在任务失败的重开对话框中添加了一个 “载入游戏” 按钮。"
 
-#: ../../Fixed-or-Improved-Logics.md:40
+#: ../../Fixed-or-Improved-Logics.md:39
 msgid ""
 "![image](_static/images/turretoffset-01.png) *Side offset voxel turret in"
 " Breaking Blue project*"
@@ -226,7 +217,7 @@ msgstr ""
 "![image](_static/images/turretoffset-01.png) *Breaking Blue project 中的 "
 "Voxel 炮塔侧向偏移*"
 
-#: ../../Fixed-or-Improved-Logics.md:43
+#: ../../Fixed-or-Improved-Logics.md:42
 msgid ""
 "`TurretOffset` tag for voxel turreted TechnoTypes now accepts FLH "
 "(forward, lateral, height) values like `TurretOffset=F,L` or "
@@ -236,15 +227,15 @@ msgstr ""
 "用于科技类型 Voxel 炮塔的 `TurretOffset` 标签现在接受像 FLH（前，侧，高）那样的值，例如 "
 "`TurretOffset=F,L` 或 `TurretOffset=F,L,H`，这意味着炮塔的位置可以在三个轴上进行调整。"
 
-#: ../../Fixed-or-Improved-Logics.md:44
+#: ../../Fixed-or-Improved-Logics.md:43
 msgid "`TurretOffset` is now supported for SHP vehicles."
 msgstr "现在 `TurretOffset` 可以支持 Shape 载具了。"
 
-#: ../../Fixed-or-Improved-Logics.md:45
+#: ../../Fixed-or-Improved-Logics.md:44
 msgid "`InfiniteMindControl` with `Damage=1` can now control more than 1 unit."
 msgstr "现在允许 `InfiniteMindControl` 在 `Damage=1` 的情况下正常控制 1 个以上的单位。"
 
-#: ../../Fixed-or-Improved-Logics.md:46
+#: ../../Fixed-or-Improved-Logics.md:45
 msgid ""
 "Aircraft with `Fighter` set to false or those using strafing pattern "
 "(weapon projectile `ROT` is below 2) now take weapon's `Burst` into "
@@ -253,7 +244,7 @@ msgstr ""
 "现在 `Fighter` 被设为 false 或使用扫射模式（抛射体 `ROT` 小于 2）的战机每次开火都会正常考虑武器的 `Burst` "
 "设置而不仅限第一次开火。"
 
-#: ../../Fixed-or-Improved-Logics.md:47
+#: ../../Fixed-or-Improved-Logics.md:46
 msgid ""
 "Vehicles using `DeployFire` will now use `DeployFireWeapon` for firing "
 "the deploy weapon if explicitly set, if not it behaves like previously "
@@ -268,13 +259,13 @@ msgstr ""
 "设置以及开火期间发出的任何停止命令。如果 `FireOnce` 设置为 true 那么单位在等于武器的 `ROF` 和 `[Unload] -> "
 "Rate` * 900 的时间内不会接受新的的部署命令。"
 
-#: ../../Fixed-or-Improved-Logics.md:48
+#: ../../Fixed-or-Improved-Logics.md:47
 msgid ""
 "Infantry with `DeployFireWeapon=-1` can now fire both weapons (decided by"
 " its target), regardless of deployed or not."
 msgstr "现在允许拥有 `DeployFireWeapon=-1` 的步兵在部署后使用所有武器（取决于目标），无论是否处于部署状态。"
 
-#: ../../Fixed-or-Improved-Logics.md:50
+#: ../../Fixed-or-Improved-Logics.md:49
 msgid ""
 "![image](_static/images/remember-target-after-deploying-01.gif) *Nod arty"
 " keeping target on attack order in [C&C: "
@@ -283,23 +274,23 @@ msgstr ""
 "![image](_static/images/remember-target-after-deploying-01.gif) *在 [C&C: "
 "Reloaded](https://www.moddb.com/mods/cncreloaded/) 中 Nod 吊炮保持了攻击指令的目标*"
 
-#: ../../Fixed-or-Improved-Logics.md:53
+#: ../../Fixed-or-Improved-Logics.md:52
 msgid ""
 "Vehicle to building deployers now keep their target when deploying with "
 "`DeployToFire`."
 msgstr "现在载具通过 `DeployToFire` 部署成的建筑会保留它们的目标。"
 
-#: ../../Fixed-or-Improved-Logics.md:54
+#: ../../Fixed-or-Improved-Logics.md:53
 msgid ""
 "Effects like lasers are no longer drawn from wrong firing offset on "
 "weapons that use Burst."
 msgstr "现在使用 `Burst` 的武器不会再在绘制激光等效果时使用错误的偏移位置。"
 
-#: ../../Fixed-or-Improved-Logics.md:55
+#: ../../Fixed-or-Improved-Logics.md:54
 msgid "Animations can now be offset on the X axis with `XDrawOffset`."
 msgstr "现在可以使用 `XDrawOffset` 在 X 轴上调整动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:56
+#: ../../Fixed-or-Improved-Logics.md:55
 msgid ""
 "`IsSimpleDeployer` units now only play `DeploySound` and `UndeploySound` "
 "once, when done with (un)deploying instead of repeating it over duration "
@@ -308,17 +299,17 @@ msgstr ""
 "现在 `IsSimpleDeployer` 的单位只会在（反）部署时播放一次 `DeploySound` 和 `UndeploySound` "
 "而不再是转向和／或播放 `DeployingAnim` 期间持续播放。"
 
-#: ../../Fixed-or-Improved-Logics.md:57
+#: ../../Fixed-or-Improved-Logics.md:56
 msgid "AITrigger can now recognize Building Upgrades as legal condition."
 msgstr "现在 AI 触发可以识别建筑的加载物为合法的条件。"
 
-#: ../../Fixed-or-Improved-Logics.md:58
+#: ../../Fixed-or-Improved-Logics.md:57
 msgid ""
 "`EWGates` and `NSGates` now will link walls like `xxGateOne` and "
 "`xxGateTwo` do."
 msgstr "现在 `EWGates` 和 `NSGates` 可以像 `xxGateOne` 和 `xxGateTwo` 那样正常与墙体连接。"
 
-#: ../../Fixed-or-Improved-Logics.md:59
+#: ../../Fixed-or-Improved-Logics.md:58
 msgid ""
 "Fixed interaction of `UnitAbsorb` & `InfantryAbsorb` with `Grinding` "
 "buildings. The keys will now make the building only accept appropriate "
@@ -327,19 +318,19 @@ msgstr ""
 "修复了 `UnitAbsorb` 和 `InfantryAbsorb` 与 `Grinding` "
 "建筑的交互。现在这些标签将使建筑只接受对应类型的对象。"
 
-#: ../../Fixed-or-Improved-Logics.md:60
+#: ../../Fixed-or-Improved-Logics.md:59
 msgid ""
 "Fixed missing `No Enter` cursor for VehicleTypes being unable to enter a "
 "`Grinding` building."
 msgstr "修复了缺少 `No Enter` 光标的载具无法进入 `Grinding` 建筑的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:61
+#: ../../Fixed-or-Improved-Logics.md:60
 msgid ""
 "Fixed Engineers being able to enter `Grinding` buildings even when they "
 "shouldn't (such as ally building at full HP)."
 msgstr "修复了工程师能够在不应进入的情况下进入 `Grinding` 建筑的 Bug（例如满血的友军建筑）。"
 
-#: ../../Fixed-or-Improved-Logics.md:62
+#: ../../Fixed-or-Improved-Logics.md:61
 msgid ""
 "Aircraft & jumpjet units are now affected by speed modifiers such as "
 "`Speed(Aircraft/Infantry/Units)Mult` on `Countries`, `VeteranSpeed` and "
@@ -349,25 +340,25 @@ msgstr ""
 "`Speed(Aircraft/Infantry/Units)Mult`、`VeteranSpeed` 和箱子／AttachEffect "
 "中速度加成效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:63
+#: ../../Fixed-or-Improved-Logics.md:62
 msgid ""
 "Both voxel and SHP vehicle units should now correctly respect custom "
 "palette set through `Palette`."
 msgstr "现在 Voxel 与 Shape 载具单位都可以正确使用 `Palette` 设置的自定义色盘。"
 
-#: ../../Fixed-or-Improved-Logics.md:64
+#: ../../Fixed-or-Improved-Logics.md:63
 msgid ""
 "Setting `RadarInvisible` to true on TerrainTypes now hides them from "
 "minimap display."
 msgstr "现在设置了 `RadarInvisible` 的地形对象将不再会显示于小地图中。"
 
-#: ../../Fixed-or-Improved-Logics.md:65
+#: ../../Fixed-or-Improved-Logics.md:64
 msgid ""
 "Mind control indicator animations will now correctly restore on mind "
 "controlled objects when uncloaked."
 msgstr "现在心灵控制指示动画将在被心灵控制的单位解除隐形后正确恢复。"
 
-#: ../../Fixed-or-Improved-Logics.md:66
+#: ../../Fixed-or-Improved-Logics.md:65
 msgid ""
 "Animations from Warhead `AnimList` & `SplashList` etc. as well as "
 "animations created through map trigger `41 Play Anim At` now have the "
@@ -376,7 +367,7 @@ msgstr ""
 "现在弹头 `AnimList` 与 `SplashList` 等语句以及地图触发 `41 播放动画在...` "
 "创建的动画都将默认将适当的所属方设置为动画的所有者。"
 
-#: ../../Fixed-or-Improved-Logics.md:67
+#: ../../Fixed-or-Improved-Logics.md:66
 msgid ""
 "Nuke carrier & payload weapons now respect `Bright` setting on the "
 "weapons always when appropriate (previously only payload did and only if "
@@ -385,7 +376,7 @@ msgstr ""
 "现在核弹载体（原版上升）与载荷（原版下落）武器在适当的情况下始终（此前只有超级武器设置了 "
 "`Nuke.SiloLaunch=false`（*Ares 功能*） 的情况下载荷武器会）尊重武器上的 `Bright` 设定"
 
-#: ../../Fixed-or-Improved-Logics.md:68
+#: ../../Fixed-or-Improved-Logics.md:67
 msgid ""
 "Self-healing pips from `InfantryGainSelfHeal` & `UnitsGainSelfHeal` now "
 "respect unit's `PixelSelectionBracketDelta` like health bar pips do."
@@ -393,52 +384,52 @@ msgstr ""
 "现在，来自 `InfantryGainSelfHeal` 与 `UnitsGainSelfHeal` 的自愈 pip 图像将会像血条那样尊重单位的"
 " `PixelSelectionBracketDelta` 。"
 
-#: ../../Fixed-or-Improved-Logics.md:69
+#: ../../Fixed-or-Improved-Logics.md:68
 msgid ""
 "Fixed the bug where the health bar of a unit being attacked by temporal "
 "weapons would not disappear after mouse hover, causing it to remain "
 "visible even when the mouse moved away."
 msgstr "修复了被超时空武器攻击的单位其血条在鼠标掠过其上后不会消失的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:70
+#: ../../Fixed-or-Improved-Logics.md:69
 msgid ""
 "Buildings using `SelfHealing` will now correctly revert to undamaged "
 "graphics if their health is restored back by self-healing."
 msgstr "现在使用 `SelfHealing` 的建筑如果通过自愈恢复了生命值将正确的恢复到未受损状态的图像。"
 
-#: ../../Fixed-or-Improved-Logics.md:71
+#: ../../Fixed-or-Improved-Logics.md:70
 msgid ""
 "Allow use of `Foundation=0x0` on TerrainTypes without crashing for "
 "similar results as for buildings."
 msgstr "允许在地形对象上使用 `Foundation=0x0` 而不会导致崩溃且其效果类似于建筑。"
 
-#: ../../Fixed-or-Improved-Logics.md:72
+#: ../../Fixed-or-Improved-Logics.md:71
 msgid ""
 "Projectiles now remember the house of the firer even if the firer is "
 "destroyed before the projectile detonates. Does not currently apply to "
 "some Ares-introduced Warhead effects like EMP."
 msgstr "现在即便开火者在抛射体引爆前被摧毁抛射体也可以保留开火者的所属方。目前暂不适用于例如 EMP 等某些 Ares 引入的弹头效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:73
+#: ../../Fixed-or-Improved-Logics.md:72
 msgid ""
 "`OpenTopped` transports now take `OpenTransportWeapon` setting of "
 "passengers into consideration when determining weapon range used for "
 "threat scanning and approaching targets."
 msgstr "`OpenTopped` 的运输工具现在确定用于威胁扫描和接近目标的武器范围时会考虑乘客的 `OpenTransportWeapon` 设置。"
 
-#: ../../Fixed-or-Improved-Logics.md:74
+#: ../../Fixed-or-Improved-Logics.md:73
 msgid ""
 "Trailer animations now inherit the owner of the object (animation, "
 "projectile or aircraft) they are attached to."
 msgstr "现在尾烟动画会继承它们所附着对象（动画，抛射体或战机）的所属方。"
 
-#: ../../Fixed-or-Improved-Logics.md:75
+#: ../../Fixed-or-Improved-Logics.md:74
 msgid ""
 "Buildings now correctly use laser parameters set for Secondary weapons "
 "instead of reading them from Primary weapon."
 msgstr "现在建筑可以正确的使用副武器设置的激光参数而不再是从主武器读取。"
 
-#: ../../Fixed-or-Improved-Logics.md:76
+#: ../../Fixed-or-Improved-Logics.md:75
 msgid ""
 "Fixed an issue that caused vehicles killed by damage dealt by a known "
 "house but without a known source TechnoType (f.ex animation warhead "
@@ -446,19 +437,19 @@ msgid ""
 "trigger events etc."
 msgstr "修复了只有所属方但没有开火者的杀伤（例如来自动画弹头伤害）击杀载具时未能正确记录因而无法触发地图事件等问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:77
+#: ../../Fixed-or-Improved-Logics.md:76
 msgid ""
 "Fixed transports recursively put into each other not having a correct "
 "killer set after second transport when being killed by something."
 msgstr "修复了被递归嵌套放置的运输工具被击杀时从第二层运输工具开始击杀来源设置不正确的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:79
+#: ../../Fixed-or-Improved-Logics.md:78
 msgid ""
 "![image](_static/images/translucency-fix.png) *Example gradient SHP "
 "drawing with 75% translucency, before and after*"
 msgstr "![image](_static/images/translucency-fix.png) *75% 透明度的 Shape 绘制示例，前后对比*"
 
-#: ../../Fixed-or-Improved-Logics.md:82
+#: ../../Fixed-or-Improved-Logics.md:81
 msgid ""
 "Translucent RLE SHPs will now be drawn using a more precise and "
 "performant algorithm that has no green tint and banding. Can be disabled "
@@ -467,11 +458,11 @@ msgstr ""
 "现在半透明的 RLE SHP 将使用更精确且性能更高的算法进行绘制，不会出现绿色色调和条纹。可以通过 `rulesmd.ini -> "
 "[General] -> FixTransparencyBlitters=no` 来禁用。"
 
-#: ../../Fixed-or-Improved-Logics.md:83
+#: ../../Fixed-or-Improved-Logics.md:82
 msgid "Only applies to Z-aware drawing mode for now."
 msgstr "目前仅适用于 Z-aware 绘图模式。"
 
-#: ../../Fixed-or-Improved-Logics.md:84
+#: ../../Fixed-or-Improved-Logics.md:83
 msgid ""
 "Fixed projectiles with `Inviso=true` suffering from potential inaccuracy "
 "problems if combined with `Airburst=yes` or Warhead with `EMEffect=true`."
@@ -479,76 +470,76 @@ msgstr ""
 "修复了带有 `Inviso=true` 的抛射体在与 `Airburst=yes` 或拥有 `EMEffect=true` "
 "的弹头结合使用时可能出现的精度问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:85
+#: ../../Fixed-or-Improved-Logics.md:84
 msgid ""
 "Fixed the bug when `MakeInfantry` logic on BombClass resulted in "
 "`Neutral` side infantry."
 msgstr "修复了 `MakeInfantry` 逻辑在 BombClass（伊文炸弹）上导致生成 `Neutral` 阵营步兵的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:86
+#: ../../Fixed-or-Improved-Logics.md:85
 msgid ""
 "Fixed railgun particles being drawn to wrong coordinate against buildings"
 " with non-default `TargetCoordOffset` or when force-firing on bridges."
 msgstr "修复了轨道炮粒子对于具有非默认 `TargetCoordOffset` 的建筑或在桥上强制开火时被绘制到错误坐标的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:87
+#: ../../Fixed-or-Improved-Logics.md:86
 msgid ""
 "Fixed building `TargetCoordOffset` not being taken into accord for "
 "several things like fire angle calculations and target lines."
 msgstr "修复了建筑 `TargetCoordOffset` 未将开火角度和目标指示线考虑在内的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:88
+#: ../../Fixed-or-Improved-Logics.md:87
 msgid ""
 "In singleplayer missions, the player can now see cloaked objects owned by"
 " allied houses."
 msgstr "在单人任务中，玩家现在可以看到盟友所属方的隐形对象。"
 
-#: ../../Fixed-or-Improved-Logics.md:89
+#: ../../Fixed-or-Improved-Logics.md:88
 msgid ""
 "IvanBomb images now display and the bombs detonate at center of buildings"
 " instead of in top-leftmost cell of the building foundation."
 msgstr "现在伊文炸弹的图像显示和炸弹引爆位置都位于建筑中心而不再是建筑占地左上角的单元格。"
 
-#: ../../Fixed-or-Improved-Logics.md:90
+#: ../../Fixed-or-Improved-Logics.md:89
 msgid ""
 "Fixed BibShape drawing for a couple of frames during buildup for "
 "buildings with long buildup animations."
 msgstr "修复了具有较长建造动画的建筑在建造过程中会绘制几帧 BibShape 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:91
+#: ../../Fixed-or-Improved-Logics.md:90
 msgid "Animation with `Tiled=yes` now supports `CustomPalette`."
 msgstr "现在带有 `Tiled=yes` 的动画也支持 `CustomPalette` 了。"
 
-#: ../../Fixed-or-Improved-Logics.md:92
+#: ../../Fixed-or-Improved-Logics.md:91
 msgid ""
 "Attempted to avoid units from retaining previous orders "
 "(attack,grind,garrison,etc) after changing ownership (mind-"
 "control,abduction,etc)."
 msgstr "尝试避免单位在更改所属方（心灵控制、超时空监狱等）后保留之前的命令（攻击，回收，进驻等）。"
 
-#: ../../Fixed-or-Improved-Logics.md:93
+#: ../../Fixed-or-Improved-Logics.md:92
 msgid ""
 "Fixed buildings' `NaturalParticleSystem` being created for in-map pre-"
 "placed structures."
 msgstr "修复了地图中预先放置的结构也会创建建筑 `NaturalParticleSystem` 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:94
+#: ../../Fixed-or-Improved-Logics.md:93
 msgid ""
 "Fixed jumpjet units being unable to visually tilt or be flipped if "
 "`TiltCrashJumpjet=no`."
 msgstr "修复了 `TiltCrashJumpjet=no` 时 Jumpjet 单位无法视觉上倾斜或翻转的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:95
+#: ../../Fixed-or-Improved-Logics.md:94
 msgid "Unlimited (more than 5) `AlternateFLH` entries for units."
 msgstr "单位的 `AlternateFLH` 条目数量不再被限制（可以超过 5 个）。"
 
-#: ../../Fixed-or-Improved-Logics.md:96
+#: ../../Fixed-or-Improved-Logics.md:95
 msgid ""
 "Warheads spawning debris now use `MaxDebris` as an actual cap for number "
 "of debris to spawn instead of `MaxDebris` - 1."
 msgstr "现在生成碎片的弹头使用 `MaxDebris` 作为实际的碎片数量上限而不再是 `MaxDebris` - 1。"
 
-#: ../../Fixed-or-Improved-Logics.md:97
+#: ../../Fixed-or-Improved-Logics.md:96
 msgid ""
 "If both `Primary` and `Secondary` weapons can fire at air targets "
 "(projectile has `AA=true`), `Primary` can now be picked instead of always"
@@ -560,7 +551,7 @@ msgstr ""
 "而不再总是强制使用 `Secondary`。这也适用于 `IsGattling=true`，奇数与偶数的 `WeaponX` 分别对应 "
 "`Primary` 与 `Secondary`。"
 
-#: ../../Fixed-or-Improved-Logics.md:98
+#: ../../Fixed-or-Improved-Logics.md:97
 msgid ""
 "`IsGattling=true` can now fall back to secondary weapon slot (even-"
 "numbered `WeaponX` slots) if primary one (odd-numbered) cannot fire at "
@@ -569,19 +560,19 @@ msgstr ""
 "现在 `IsGattling=true` 在主要武器（奇数 `WeaponX` 序列）无法对当前目标开火（受制于 "
 "Armor、`CanTarget(Houses)`、护盾等）时可以更换到次要武器（偶数 `WeaponX` 序列）。"
 
-#: ../../Fixed-or-Improved-Logics.md:99
+#: ../../Fixed-or-Improved-Logics.md:98
 msgid ""
 "Fixed `LandTargeting=1` not preventing from targeting TerrainTypes (trees"
 " etc.) on land."
 msgstr "修复了 `LandTargeting=1` 未能阻止瞄准陆地上的地形对象（树木等）的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:100
+#: ../../Fixed-or-Improved-Logics.md:99
 msgid ""
 "Fixed `NavalTargeting=6` not preventing from targeting empty water cells "
 "or TerrainTypes (trees etc.) on water."
 msgstr "修复了 `NavalTargeting=6` 未能阻止瞄准水上空置单元格或水上地形对象（树木等）的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:101
+#: ../../Fixed-or-Improved-Logics.md:100
 msgid ""
 "Fixed `NavalTargeting=7` and/or `LandTargeting=2` resulting in still "
 "targeting TerrainTypes (trees etc.) on land with `Primary` weapon."
@@ -589,19 +580,19 @@ msgstr ""
 "修复了 `NavalTargeting=7` 和／或 `LandTargeting=2` 导致在陆地上仍然使用 `Primary` "
 "武器来瞄准地形对象（树木等）的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:102
+#: ../../Fixed-or-Improved-Logics.md:101
 msgid ""
 "Fixed infantry without `C4=true` being killed in water if paradropped, "
 "chronoshifted etc. even if they can normally enter water."
 msgstr "修复了没有 `C4=true` 的步兵即便可以正常进入水中但当被空投、超时空传送等情况下在水中会死亡的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:103
+#: ../../Fixed-or-Improved-Logics.md:102
 msgid ""
 "Allowed MCV to redeploy in campaigns using a new toggle different from "
 "`[MultiplayerDialogSettings] -> MCVRedeploys`."
 msgstr "允许在战役中使用一个与 `[MultiplayerDialogSettings] -> MCVRedeploys` 不同的新开关设置重部署 MCV。"
 
-#: ../../Fixed-or-Improved-Logics.md:104
+#: ../../Fixed-or-Improved-Logics.md:103
 msgid ""
 "Fixed buildings with `UndeploysInto` but `Unsellable=no` & "
 "`ConstructionYard=no` unable to be sold normally. Restored "
@@ -610,13 +601,13 @@ msgstr ""
 "修复了拥有 `UndeploysInto` 但 `Unsellable=no` 且 `ConstructionYard=no` "
 "的建筑无法正常出售的问题。并且复原了在 `UndeploysInto` 的建筑被出售时应有的 `EVA_StructureSold` 播报语音。"
 
-#: ../../Fixed-or-Improved-Logics.md:105
+#: ../../Fixed-or-Improved-Logics.md:104
 msgid ""
 "Fixed `WaterBound=true` buildings with `UndeploysInto` not correctly "
 "setting the location for the vehicle to move into when undeployed."
 msgstr "修复了 `WaterBound=true` 且拥有 `UndeploysInto` 的建筑在反部署时无法正常设置载具移动位置的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:106
+#: ../../Fixed-or-Improved-Logics.md:105
 msgid ""
 "`CanC4=false` on building makes building take atleast 1 point of damage "
 "**if** the raw damage is non-zero but is lowered to below 1 by `Verses` "
@@ -628,13 +619,13 @@ msgstr ""
 "点。`CanC4.AllowZeroDamage=true` 可以禁用这一行为。（经 `Verses` "
 "等机制修正计算完的）负伤害将完全绕过此检查，无需额外启用。"
 
-#: ../../Fixed-or-Improved-Logics.md:107
+#: ../../Fixed-or-Improved-Logics.md:106
 msgid ""
 "Buildings with primary weapon that has `AG=false` projectile now have "
 "attack cursor when selected."
 msgstr "现在主武器具有 `AG=false` 抛射体的建筑在被选中时会正常拥有攻击光标"
 
-#: ../../Fixed-or-Improved-Logics.md:108
+#: ../../Fixed-or-Improved-Logics.md:107
 msgid ""
 "Weapons with `AA=true` projectiles can now be set to fire exclusively at "
 "air targets by setting `AAOnly=true`, regardless of other conditions. "
@@ -645,20 +636,20 @@ msgstr ""
 "现在拥有 `AA=true ` 抛射体的武器可以通过设置 `AAOnly=true` 来使其仅可对空中目标进行攻击。这很有用：毕竟 "
 "`AG=false` 只能防止瞄准地面单元格（并且无法在不破坏现有行为的情况下更改）而且它适用于无法使用 `LandTargeting` 的情况。"
 
-#: ../../Fixed-or-Improved-Logics.md:109
+#: ../../Fixed-or-Improved-Logics.md:108
 msgid ""
 "Transports with `OpenTopped=true` and weapon that has `Burst` above 1 and"
 " passengers firing out no longer have the passenger firing offset shift "
 "lateral position based on burst index."
 msgstr "现在 `OpenTopped=true` 且拥有大于 1 的 `Burst` 的武器的运输工具其载员开火不再由于连发的序数而改变侧向偏移位置。"
 
-#: ../../Fixed-or-Improved-Logics.md:110
+#: ../../Fixed-or-Improved-Logics.md:109
 msgid ""
 "Fixed disguised infantry not using custom palette for drawing the "
 "disguise when needed."
 msgstr "修复了伪装的步兵在必要时没有使用自定义色盘来绘制伪装图像的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:111
+#: ../../Fixed-or-Improved-Logics.md:110
 msgid ""
 "Disguised infantry now show appropriate insignia when disguise is "
 "visible, based on the disguise type and house. Original unit's insignia "
@@ -668,30 +659,30 @@ msgstr ""
 "现在当伪装闪烁时伪装的步兵将会根据伪装的类型和所属方显示对应的军衔。原始单位的军衔始终显示给观察者和 `[General] -> "
 "DisguiseBlinkingVisibility` 设置所支持可见伪装闪烁的当前玩家。"
 
-#: ../../Fixed-or-Improved-Logics.md:112
+#: ../../Fixed-or-Improved-Logics.md:111
 msgid ""
 "Buildings with superweapons no longer display `SuperAnimThree` at "
 "beginning of match if pre-placed on the map."
 msgstr "地图上预先放置的超级武器类建筑在游戏开始时不再显示 `SuperAnimThree`。"
 
-#: ../../Fixed-or-Improved-Logics.md:113
+#: ../../Fixed-or-Improved-Logics.md:112
 msgid "`SpySat=yes` can now be applied using building upgrades."
 msgstr "现在 `SpySat=yes` 可以通过建筑加载物获得。"
 
-#: ../../Fixed-or-Improved-Logics.md:114
+#: ../../Fixed-or-Improved-Logics.md:113
 msgid ""
 "AI players can now build `Naval=true` and `Naval=false` vehicles "
 "concurrently like human players do."
 msgstr "现在 AI 玩家可以像人类玩家一样同时建造 `Naval=true` 与 `Naval=false` 的载具。"
 
-#: ../../Fixed-or-Improved-Logics.md:115
+#: ../../Fixed-or-Improved-Logics.md:114
 msgid ""
 "Fixed the bug when jumpjets were snapping into facing bottom-right when "
 "starting movement (observable when the starting unit is a jumpjet and is "
 "ordered to move)."
 msgstr "修复了 Jumpjet 单位在开始移动时（当初始部队是 Jumpjet 单位并命令去移动时可以观察到）会突然面向右下方向的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:116
+#: ../../Fixed-or-Improved-Logics.md:115
 msgid ""
 "Objects with `Palette` set now have their color tint adjusted accordingly"
 " by superweapons, map retint actions etc. if they belong to a house using"
@@ -701,7 +692,7 @@ msgstr ""
 "现在拥有 `Palette` 设置的对象可以正常根据超级武器、地图重绘光照行为等调整其色调。只要它们属于使用了任何配色方案的所属方而不仅限于 "
 "`[Colors]` 列表前半部分那些。"
 
-#: ../../Fixed-or-Improved-Logics.md:117
+#: ../../Fixed-or-Improved-Logics.md:116
 msgid ""
 "Animations using `AltPalette` are now remapped to their owner's color "
 "scheme instead of first listed color scheme and no longer draw over "
@@ -714,13 +705,13 @@ msgstr ""
 "`[AudioVisual] -> AnimRemapDefaultColorScheme` 指定的配色方案，它同样默认为 `[Colors]` "
 "中被列出的第一个配色方案。"
 
-#: ../../Fixed-or-Improved-Logics.md:118
+#: ../../Fixed-or-Improved-Logics.md:117
 msgid ""
 "They can also have map lighting apply on them if "
 "`AltPalette.ApplyLighting` is set to true."
 msgstr "如果将 `AltPalette.ApplyLighting` 设置为 true 那么地图光照同样可以对它们生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:119
+#: ../../Fixed-or-Improved-Logics.md:118
 msgid ""
 "Fixed `DeployToFire` not considering building placement rules for "
 "`DeploysInto` buildings and as a result not working properly with "
@@ -729,13 +720,13 @@ msgstr ""
 "修复了 `DeployToFire` 未考虑 `DeploysInto` 建筑的摆放规则并导致该功能无法与 `WaterBound` "
 "建筑一起正常工作的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:120
+#: ../../Fixed-or-Improved-Logics.md:119
 msgid ""
 "Fixed `DeployToFire` not recalculating firer's position on land if it "
 "cannot currently deploy."
 msgstr "修复了 `DeployToFire` 在当前无法部署时未能重新计算开火者在陆地上所处位置的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:121
+#: ../../Fixed-or-Improved-Logics.md:120
 msgid ""
 "`Arcing=true` projectile elevation inaccuracy can now be fixed by setting"
 " `Arcing.AllowElevationInaccuracy=false`."
@@ -743,13 +734,13 @@ msgstr ""
 "现在可以通过设置 `Arcing.AllowElevationInaccuracy=false` 来修复 `Arcing=true` "
 "抛射体在有高程影响下的精度问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:122
+#: ../../Fixed-or-Improved-Logics.md:121
 msgid ""
 "Wall overlays are now drawn with the custom palette defined in `Palette` "
 "in `artmd.ini` if possible."
 msgstr "现在如果可能的话墙类覆盖物将会使用 `artmd.ini` 中使用 `Palette` 指定的自定义色盘进行绘制。"
 
-#: ../../Fixed-or-Improved-Logics.md:123
+#: ../../Fixed-or-Improved-Logics.md:122
 msgid ""
 "If `[CombatDamage] -> AllowWeaponSelectAgainstWalls` is set to true, "
 "`Secondary` will now be used against walls if `Primary` weapon Warhead "
@@ -760,7 +751,7 @@ msgstr ""
 "`Primary` 武器的弹头拥有 `Wall=false`，而 `Secondary` 武器拥有 `Wall=true` 且开火者没有将 "
 "`NoSecondaryWeaponFallback` 设为 true 那么 `Secondary` 将在应对墙时被使用。"
 
-#: ../../Fixed-or-Improved-Logics.md:124
+#: ../../Fixed-or-Improved-Logics.md:123
 msgid ""
 "Setting `ReloadInTransport` to true on units with `Ammo` will allow the "
 "ammo to be reloaded according to `Reload` or `EmptyReload` timers even "
@@ -769,7 +760,7 @@ msgstr ""
 "在拥有 `Ammo` 的单位上设置 `ReloadInTransport` 为 true 将允许在运输工具内的单位也根据 `Reload` 或 "
 "`EmptyReload` 计时器进行重新装填。"
 
-#: ../../Fixed-or-Improved-Logics.md:125
+#: ../../Fixed-or-Improved-Logics.md:124
 msgid ""
 "It is now possible to enable `Verses` and `PercentAtMax` to be applied on"
 " negative damage by setting `ApplyModifiersOnNegativeDamage` to true on "
@@ -778,24 +769,24 @@ msgstr ""
 "现在可以通过在弹头上将 `ApplyModifiersOnNegativeDamage` 设置为 true 来为负伤害启用 `Verses` 和 "
 "`PercentAtMax`。"
 
-#: ../../Fixed-or-Improved-Logics.md:126
+#: ../../Fixed-or-Improved-Logics.md:125
 msgid ""
 "Attached animations on flying units now have their layer updated "
 "immediately after the parent unit, if on same layer they always draw "
 "above the parent."
 msgstr "现在飞行单位上所附加的动画会紧随其父单位之后立即更新其图层，如果在同一图层上它们将始终绘制在父单位之上。"
 
-#: ../../Fixed-or-Improved-Logics.md:127
+#: ../../Fixed-or-Improved-Logics.md:126
 msgid ""
 "Fixed the issue where the powered anims of `Powered` / `PoweredSpecial` "
 "buildings cease to update when being captured by enemies."
 msgstr "修复了 `Powered`／`PoweredSpecial` 的建筑在被敌人占领时其受电力影响的动画不再更新的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:128
+#: ../../Fixed-or-Improved-Logics.md:127
 msgid "Fix a glitch related to incorrect target setting for missiles."
 msgstr "修复了有关于导弹目标设置不正确的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:129
+#: ../../Fixed-or-Improved-Logics.md:128
 msgid ""
 "Fix [EIP "
 "00529A14](https://modenc.renegadeprojects.com/Internal_Error/YR#eip_00529A14)"
@@ -805,123 +796,123 @@ msgstr ""
 "00529A14](https://modenc.renegadeprojects.com/Internal_Error/YR#eip_00529A14)"
 " 问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:130
+#: ../../Fixed-or-Improved-Logics.md:129
 msgid "Units will no longer rotate its turret under EMP."
 msgstr "单位在 EMP 状态下不再会旋转炮塔。"
 
-#: ../../Fixed-or-Improved-Logics.md:131
+#: ../../Fixed-or-Improved-Logics.md:130
 msgid "Jumpjets will no longer wobble under EMP."
 msgstr "Jumpjet 单位在 EMP 状态下不再会浮动。"
 
-#: ../../Fixed-or-Improved-Logics.md:132
+#: ../../Fixed-or-Improved-Logics.md:131
 msgid "Removed jumpjet units' deceleration when crashing onto buildings."
 msgstr "移除了 Jumpjet 单位坠毁到建筑上时的减速效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:133
+#: ../../Fixed-or-Improved-Logics.md:132
 msgid ""
 "Fixed `AmbientDamage` when used with `IsRailgun=yes` being cut off by "
 "elevation changes."
 msgstr "修复了 `AmbientDamage` 在与 `IsRailgun=yes` 共用时会被高度变化切断的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:134
+#: ../../Fixed-or-Improved-Logics.md:133
 msgid "Fixed railgun and fire particles being cut off by elevation changes."
 msgstr "修复了轨道炮和火焰粒子被高度变化切断的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:135
+#: ../../Fixed-or-Improved-Logics.md:134
 msgid ""
 "Fixed teleport units' (for example `[CLEG]`) frozen-still timer being "
 "cleared after load game."
 msgstr "修复了超时空单位（例如 `[CLEG]`）的僵直计时器在载入游戏后被清空的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:136
+#: ../../Fixed-or-Improved-Logics.md:135
 msgid "Fixed teleport units being unable to visually tilt on slopes."
 msgstr "修复了超时空运动模式的单位无法在斜坡上视觉性倾斜的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:137
+#: ../../Fixed-or-Improved-Logics.md:136
 msgid "Fixed rockets' shadow location."
 msgstr "修复了火箭的影子位置问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:138
+#: ../../Fixed-or-Improved-Logics.md:137
 msgid ""
 "Fixed units with Teleport, Tunnel or Fly locomotor being unable to be "
 "visually flipped like other locomotors do."
 msgstr "修复了使用 Teleport、Tunnel 或 Fly 运动模式的单位无法像其他运动模式那样视觉翻转的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:139
+#: ../../Fixed-or-Improved-Logics.md:138
 msgid ""
 "Aircraft docking on buildings now respect `[AudioVisual] -> PoseDir` as "
 "the default setting and do not always land facing north or in case of "
 "pre-placed buildings, the building's direction."
 msgstr "现在战机在建筑上停靠时尊重 `[AudioVisual] -> PoseDir` 作为默认设置而不总是朝向北方，或者在地图预置建筑上面向建筑的方向。"
 
-#: ../../Fixed-or-Improved-Logics.md:140
+#: ../../Fixed-or-Improved-Logics.md:139
 msgid "Spawned aircraft now align with the spawner's facing when landing."
 msgstr "现在生成的子机在降落时会与其母舰的朝向对正。"
 
-#: ../../Fixed-or-Improved-Logics.md:141
+#: ../../Fixed-or-Improved-Logics.md:140
 msgid ""
 "Fixed the bug that waypointing unarmed infantries with "
 "agent/engineer/occupier to a spyable/capturable/occupiable building "
 "triggers `EnteredBy` event by executing capture mission."
 msgstr "修复了在路径点中为间谍／工程师／可驻军步兵设置目标为可渗透／占领／驻军的建筑执行行为时会触发 `被...进入` 条件的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:142
+#: ../../Fixed-or-Improved-Logics.md:141
 msgid ""
 "`PowerUpN` building animations can now use `Powered` & "
 "`PoweredLight/Effect/Special` keys."
 msgstr "`PowerUpN` 建筑动画现在可以使用 `Powered` 和 `PoweredLight/Effect/Special` 类的标签。"
 
-#: ../../Fixed-or-Improved-Logics.md:143
+#: ../../Fixed-or-Improved-Logics.md:142
 msgid ""
 "Fixed a desync potentially caused by displaying of cursor over selected "
 "`DeploysInto` units."
 msgstr "修复了在选中 `DeploysInto` 单位上显示光标时可能引起的不同步问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:144
+#: ../../Fixed-or-Improved-Logics.md:143
 msgid "Skipped drawing rally point line when undeploying a factory."
 msgstr "跳过工厂类建筑反部署时的集结线绘制。"
 
-#: ../../Fixed-or-Improved-Logics.md:145
+#: ../../Fixed-or-Improved-Logics.md:144
 msgid ""
 "Tint effects are now correctly applied to SHP vehicles and all types of "
 "aircraft as well as building animations regardless of their position."
 msgstr "现在染色效果无论对象位置如何都会正确对 Shape 载具、所有类型的战机以及建筑动画生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:146
+#: ../../Fixed-or-Improved-Logics.md:145
 msgid ""
 "Iron Curtained / Force Shielded objects now always use the correct tint "
 "color."
 msgstr "现在被铁幕或力场护盾保护的对象将始终使用正确的染色效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:147
+#: ../../Fixed-or-Improved-Logics.md:146
 msgid ""
 "Objects in invalid map coordinates are no longer used for starting view "
 "and AI base center calculations."
 msgstr "位于无效地图坐标中的对象不再用于初始视图和 AI 基地中心计算。"
 
-#: ../../Fixed-or-Improved-Logics.md:148
+#: ../../Fixed-or-Improved-Logics.md:147
 msgid ""
 "Units & buildings with `DecloakToFire=false` weapons now cloak while "
 "targeting & reloading."
 msgstr "现在拥有 `DecloakToFire=false` 武器的单位和建筑在瞄准和装填时会隐形。"
 
-#: ../../Fixed-or-Improved-Logics.md:149
+#: ../../Fixed-or-Improved-Logics.md:148
 msgid "Units with `Sensors=true` will no longer reveal ally buildings."
 msgstr "拥有 `Sensors=true` 的单位将不再解除友军建筑的隐形。"
 
-#: ../../Fixed-or-Improved-Logics.md:150
+#: ../../Fixed-or-Improved-Logics.md:149
 msgid ""
 "Air units are now reliably included by target scan with large range and "
 "Warhead detonation by large `CellSpread`."
 msgstr "现在具有大范围的目标检索和大 `CellSpread` 的弹头爆炸范围可靠的包含了空中单位。"
 
-#: ../../Fixed-or-Improved-Logics.md:151
+#: ../../Fixed-or-Improved-Logics.md:150
 msgid ""
 "OverlayTypes now read and use `ZAdjust` if specified in their `artmd.ini`"
 " entry."
 msgstr "现在如果被指定那么覆盖物可以正常读取并使用它们在 `artmd.ini` 条目中的 `ZAdjust`。"
 
-#: ../../Fixed-or-Improved-Logics.md:152
+#: ../../Fixed-or-Improved-Logics.md:151
 msgid ""
 "Setting `[AudioVisual] -> ColorAddUse8BitRGB` to true makes game treat "
 "values from `[ColorAdd]` as 8-bit RGB (0-255) instead of RGB565 (0-31 for"
@@ -933,25 +924,25 @@ msgstr ""
 "`LaserTargetColor`、`IronCurtainColor`、`BerserkColor` 和 "
 "`ForceShieldColor`。（已知 KratosPP v0.1.15会抵消该逻辑）"
 
-#: ../../Fixed-or-Improved-Logics.md:153
+#: ../../Fixed-or-Improved-Logics.md:152
 msgid ""
 "Weapons with `AA=true` Projectile can now correctly fire at air units "
 "when both firer and target are over a bridge."
 msgstr "现在当开火者和目标都在桥上时拥有 `AA=true` 抛射体的武器可以正确的对空中单位射击。"
 
-#: ../../Fixed-or-Improved-Logics.md:154
+#: ../../Fixed-or-Improved-Logics.md:153
 msgid ""
 "Fixed disguised units not using the correct palette if target has custom "
 "palette."
 msgstr "修复了伪装单位在目标具有自定义调色盘时未使用正确调色盘的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:155
+#: ../../Fixed-or-Improved-Logics.md:154
 msgid ""
 "Building upgrades now consistently use building's `PowerUpN` animation "
 "settings corresponding to the upgrade's `PowersUpToLevel` where possible."
 msgstr "现在建筑加载物将尽可能一致地使用与加载物 `PowersUpToLevel` 相对应的建筑 `PowerUpN` 动画设置。"
 
-#: ../../Fixed-or-Improved-Logics.md:156
+#: ../../Fixed-or-Improved-Logics.md:155
 msgid ""
 "Subterranean units are no longer allowed to perform deploy functions like"
 " firing weapons or `IsSimpleDeployer` while burrowed or burrowing, they "
@@ -960,7 +951,7 @@ msgstr ""
 "现在钻地单位在钻地或正在钻地时不再允许执行例如发射武器或 `IsSimpleDeployer` "
 "那样的部署功能，现在它们会先像运输工具释放乘客那样先钻出地面。"
 
-#: ../../Fixed-or-Improved-Logics.md:157
+#: ../../Fixed-or-Improved-Logics.md:156
 msgid ""
 "The otherwise unused setting `[AI] -> PowerSurplus` (defaults to 50) "
 "which determines how much surplus power AI players will strive to have "
@@ -969,7 +960,7 @@ msgstr ""
 "可以通过将 `[AI] -> EnablePowerSurplus` 设置为 true 来复原 `[AI] -> "
 "PowerSurplus`（默认为 50）以决定 AI 玩家将尽力保持的富余电力值。"
 
-#: ../../Fixed-or-Improved-Logics.md:158
+#: ../../Fixed-or-Improved-Logics.md:157
 msgid ""
 "Planning paths are now shown for all units under player control or when "
 "`[GlobalControls] -> DebugPlanningPaths=yes` in singleplayer game modes."
@@ -977,45 +968,45 @@ msgstr ""
 "现在当 `[GlobalControls] -> DebugPlanningPaths=yes` "
 "时在单人游戏模式中所有受玩家操作的单位都会显示路径点规划的路径。"
 
-#: ../../Fixed-or-Improved-Logics.md:159
+#: ../../Fixed-or-Improved-Logics.md:158
 msgid ""
 "Fixed `Temporal=true` Warheads potentially crashing game if used to "
 "attack `Slaved=true` infantry."
 msgstr "修复了 `Temporal=true` 弹头在攻击 `Slaved=true` 步兵时可能崩溃的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:160
+#: ../../Fixed-or-Improved-Logics.md:159
 msgid ""
 "Fixed some locomotors (Tunnel, Walk, Mech) getting stuck when moving too "
 "fast."
 msgstr "修复了一些运动模式（Tunnel、Walk、Mech）在移动过快时卡住的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:161
+#: ../../Fixed-or-Improved-Logics.md:160
 msgid ""
 "Animations with `MakeInfantry` and `UseNormalLight=false` that are drawn "
 "in unit palette will now have cell lighting changes applied on them."
 msgstr "现在使用 `MakeInfantry` 和 `UseNormalLight=false` 并使用单位色盘绘制的动画将正常应用单元格的亮度变化。"
 
-#: ../../Fixed-or-Improved-Logics.md:162
+#: ../../Fixed-or-Improved-Logics.md:161
 msgid "Removed 0 damage effect on jumpjet infantries from `InfDeath=9` warhead."
 msgstr "移除了 `InfDeath=9` 的弹头对 Jumpjet 步兵只能造成 0 伤害的效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:163
+#: ../../Fixed-or-Improved-Logics.md:162
 msgid "Fixed Nuke & Dominator Level lighting not applying to AircraftTypes."
 msgstr "修复了核弹和心灵支配的光照等级未应用于战机类别的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:164
+#: ../../Fixed-or-Improved-Logics.md:163
 msgid ""
 "Projectiles created from `AirburstWeapon` now remember the WeaponType and"
 " can apply radiation etc."
 msgstr "现在由 `AirburstWeapon` 创建的抛射体会保留完整 WeaponType 并且可以应用辐射等效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:165
+#: ../../Fixed-or-Improved-Logics.md:164
 msgid ""
 "Fixed damaged aircraft not repairing on `UnitReload=true` docks unless "
 "they land on the dock first."
 msgstr "修复了受损的战机除非先降落于 `UnitReload=true` 的停靠点上否则不能修复的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:166
+#: ../../Fixed-or-Improved-Logics.md:165
 msgid ""
 "Certain global tileset indices (`ShorePieces`, `WaterSet`, `CliffSet`, "
 "`WaterCliffs`, `WaterBridge`, `BridgeSet` and `WoodBridgeSet`) can now be"
@@ -1029,25 +1020,25 @@ msgstr ""
 " 和 `WoodBridgeSet`）以解析月球场景。注意如果不修复例如 `WoodBridgeTileSet` 指向 "
 "`TilesInSet=0` 的地块这样的隐患就启用本功能将在游戏中引发问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:167
+#: ../../Fixed-or-Improved-Logics.md:166
 msgid ""
 "Fixed infantry `SecondaryFire` / `SecondaryProne` sequences being "
 "displayed in water instead of `WetAttack`."
 msgstr "修复了步兵在水中显示 `SecondaryFire`／`SecondaryProne` 序列而不是 `WetAttack` 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:168
+#: ../../Fixed-or-Improved-Logics.md:167
 msgid ""
 "Fixed objects with ally target and `AttackFriendlies=true` having their "
 "target reset every frame, particularly AI-owned buildings."
 msgstr "修复了目标为友军单位且 `AttackFriendlies=true` 的对象每帧重置目标的问题，尤其是 AI 拥有的建筑。"
 
-#: ../../Fixed-or-Improved-Logics.md:169
+#: ../../Fixed-or-Improved-Logics.md:168
 msgid ""
 "`<Player @ X>` can now be used as owner for pre-placed objects on "
 "skirmish and multiplayer maps."
 msgstr "现在 `<Player @ X>` 可以直接用于遭遇战和多人地图上预先放置对象的所有者。"
 
-#: ../../Fixed-or-Improved-Logics.md:170
+#: ../../Fixed-or-Improved-Logics.md:169
 msgid ""
 "Follower vehicle index for preplaced vehicles in maps is now explicitly "
 "constrained to `[Units]` list in map files and is no longer thrown off by"
@@ -1055,51 +1046,51 @@ msgid ""
 "vehicles as initial passengers."
 msgstr "现在地图预置载具的跟随索引已被明确限制在地图 `[Units]` 列表中并且不再受到无法创建的载具或创建的载具具有其他载具作为初始乘客的情况所干扰。"
 
-#: ../../Fixed-or-Improved-Logics.md:171
+#: ../../Fixed-or-Improved-Logics.md:170
 msgid ""
 "Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-"
 "piggybacked bugfix"
 msgstr "修复了 Drive/Jumpjet/Ship/Teleport 运动方式在退出 piggybacked 接口时无法激活的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:172
+#: ../../Fixed-or-Improved-Logics.md:171
 msgid "Stop command (`[S]` by default) behavior is now more correct:"
 msgstr "停止命令（默认为 `[S]`）的行为现在更加正确："
 
-#: ../../Fixed-or-Improved-Logics.md:173
+#: ../../Fixed-or-Improved-Logics.md:172
 msgid "Jumpjets no longer fall into a state of standing by idly."
 msgstr "Jumpjet 单位不再进入空闲站立状态。"
 
-#: ../../Fixed-or-Improved-Logics.md:174
+#: ../../Fixed-or-Improved-Logics.md:173
 msgid "Technos are no longer unable to stop the attack move mission."
 msgstr "科技类型现在可以停止移动攻击任务。"
 
-#: ../../Fixed-or-Improved-Logics.md:175
+#: ../../Fixed-or-Improved-Logics.md:174
 msgid "Technos are no longer unable to stop the area guard mission."
 msgstr "科技类型现在可以停止区域警戒任务。"
 
-#: ../../Fixed-or-Improved-Logics.md:176
+#: ../../Fixed-or-Improved-Logics.md:175
 msgid "Aircraft no longer find airport twice and overlap."
 msgstr "战机不再两次寻找机场并重叠。"
 
-#: ../../Fixed-or-Improved-Logics.md:177
+#: ../../Fixed-or-Improved-Logics.md:176
 msgid "Aircraft no longer briefly pause in the air before returning."
 msgstr "战机在返回前不再在空中端在停留"
 
-#: ../../Fixed-or-Improved-Logics.md:178
+#: ../../Fixed-or-Improved-Logics.md:177
 msgid "Aircraft with `AirportBound=no` no longer continue moving forward."
 msgstr "拥有 `AirportBound=no` 的战机不再会继续向前移动"
 
-#: ../../Fixed-or-Improved-Logics.md:179
+#: ../../Fixed-or-Improved-Logics.md:178
 msgid "Technos are no longer unable to stop when it is above the elevated bridge."
 msgstr "科技类型在桥上时不再无法停止。"
 
-#: ../../Fixed-or-Improved-Logics.md:180
+#: ../../Fixed-or-Improved-Logics.md:179
 msgid ""
 "Technos are still not allowed to stop moving under the elevated bridge, "
 "but can stop other missions."
 msgstr "科技类型在桥下时仍然无法停止移动，但可以停止其他任务。"
 
-#: ../../Fixed-or-Improved-Logics.md:181
+#: ../../Fixed-or-Improved-Logics.md:180
 msgid ""
 "Now in air team members will use the 2D distance instead of the 3D "
 "distance to judge whether have reached the mission destination, so as to "
@@ -1109,7 +1100,7 @@ msgstr ""
 "现在作为小队成员的空中单位将使用 2D 距离而不是 3D 距离来判断是否达到任务目的地，以防止任务卡住且无法继续的问题（例如 Jumpjet "
 "单位停在建筑上时）。"
 
-#: ../../Fixed-or-Improved-Logics.md:182
+#: ../../Fixed-or-Improved-Logics.md:181
 msgid ""
 "Unit `Speed` setting now accepts floating-point values. Internally parsed"
 " values are clamped down to maximum of 100, multiplied by 256 and divided"
@@ -1120,7 +1111,7 @@ msgstr ""
 "现在单位的 `Speed` 设置接受小数。内部解析的值被限制为最大 100，乘以 256 并除以 100，结果（此时转换为整数）被限制为最大 "
 "255，从而获得有效内部速度值范围 0 到 255，例如以 leptons 为单位每帧移动的距离。"
 
-#: ../../Fixed-or-Improved-Logics.md:183
+#: ../../Fixed-or-Improved-Logics.md:182
 msgid ""
 "`AirburstWeapon` now supports `IsLaser`, `IsElectricBolt`, `IsRadBeam`, "
 "and `AttachedParticleSystem`."
@@ -1128,13 +1119,13 @@ msgstr ""
 "现在 `AirburstWeapon` 可以支持绘制 `IsLaser`、`IsElectricBolt`、`IsRadBeam` "
 "等视觉效果并允许粒子武器正常创建 `AttachedParticleSystem` 的粒子系统。"
 
-#: ../../Fixed-or-Improved-Logics.md:184
+#: ../../Fixed-or-Improved-Logics.md:183
 msgid ""
 "Subterranean movement now benefits from speed multipliers from all "
 "sources such as veterancy, AttachEffect etc."
 msgstr "现在钻地运动方式享受来自升级、AttachEffect 等所有来源的速度加成。"
 
-#: ../../Fixed-or-Improved-Logics.md:185
+#: ../../Fixed-or-Improved-Logics.md:184
 msgid ""
 "Aircraft will now behave as expected according to it's `MovementZone` and"
 " `SpeedType` when moving onto different surfaces. In particular, this "
@@ -1144,42 +1135,42 @@ msgstr ""
 "战机现在会根据其 `MovementZone` 和 `SpeedType` "
 "在移动到不同地形上时表现得像预期一样。特别是，这修复了原版中战机被命令移动到水面却将移动命令改为附近的岸边这一异常行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:186
+#: ../../Fixed-or-Improved-Logics.md:185
 msgid "Allowed `AuxBuilding` to count building upgrades."
 msgstr "允许 `AuxBuilding` 计入建筑加载物。"
 
-#: ../../Fixed-or-Improved-Logics.md:187
+#: ../../Fixed-or-Improved-Logics.md:186
 msgid ""
 "Fixed the bug that parasite will vanish if it missed its target when its "
 "previous cell is occupied."
 msgstr "修复了寄生单位在错过目标且其先前单元格被占用时会直接消失的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:188
+#: ../../Fixed-or-Improved-Logics.md:187
 msgid ""
 "Prevent the units with locomotors that cause problems from entering the "
 "tank bunker."
 msgstr "防止拥有会导致问题的运动方式的单位进入坦克碉堡。"
 
-#: ../../Fixed-or-Improved-Logics.md:189
+#: ../../Fixed-or-Improved-Logics.md:188
 msgid ""
 "Fixed an issue where a unit will leave an impassable invisible barrier in"
 " its original position when it is teleported by ChronoSphere onto an "
 "uncrushable unit and self destruct."
 msgstr "修复了一个单位被超时空传送超武传送到一个不可碾压的单位上并自爆时会在原地留下空气墙的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:190
+#: ../../Fixed-or-Improved-Logics.md:189
 msgid "Fixed the bug that destroyed unit may leaves sensors."
 msgstr "修复了单位被摧毁仍会遗留反隐形探测效果的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:191
+#: ../../Fixed-or-Improved-Logics.md:190
 msgid "`FreeUnit` uses the unit's own `SpeedType` to find the spawn location."
 msgstr "`FreeUnit` 使用单位自己的 `SpeedType` 来寻找生成位置。"
 
-#: ../../Fixed-or-Improved-Logics.md:192
+#: ../../Fixed-or-Improved-Logics.md:191
 msgid "The bug where naval ships as StartUnit might spawn on land has been fixed."
 msgstr "修复初始船只可能生成在陆地上的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:193
+#: ../../Fixed-or-Improved-Logics.md:192
 msgid ""
 "When a building is transformed into a vehicle via `UndeploysInto`, the "
 "`SpeedType` and `MovementZone` of the target VehicleType will determine "
@@ -1188,7 +1179,7 @@ msgstr ""
 "建筑通过 `UndeploysInto` 反部署时使用目标载具的 `SpeedType` 和 `MovementZone` "
 "来决定能否向目标单元格移动。"
 
-#: ../../Fixed-or-Improved-Logics.md:194
+#: ../../Fixed-or-Improved-Logics.md:193
 msgid ""
 "Fixed an issue that harvesters with amphibious movement zone can not "
 "automatically return to refineries with `WaterBound` on water surface. "
@@ -1198,45 +1189,45 @@ msgstr ""
 "修复了两栖矿车无法自动返回水上 `WaterBound` 矿场的问题。拥有 `Teleporter=true` 的单位不受影响，因为它们只要矿场的"
 " `Naval` 为 false 就可以正常工作。"
 
-#: ../../Fixed-or-Improved-Logics.md:195
+#: ../../Fixed-or-Improved-Logics.md:194
 msgid ""
 "Units are now unable to kick out from a factory that is in construction "
 "process, and will not always stuck in the factory."
 msgstr "单位现在不会再从正在建造的工厂中驶出，并且将不再会被卡在工厂内。"
 
-#: ../../Fixed-or-Improved-Logics.md:196
+#: ../../Fixed-or-Improved-Logics.md:195
 msgid ""
 "Fixed issues caused by incorrect reference removal (f.ex. If the unit "
 "cloaks/enters transport, it cannot gain experience from previously "
 "launched spawners/C4/projectiles)."
 msgstr "修复错误脱引用导致的问题（例如，如果单位隐形／进入运输工具则无法自此前发射的子机／安置的 C4 炸弹／发射的抛射体获得经验）。"
 
-#: ../../Fixed-or-Improved-Logics.md:197
+#: ../../Fixed-or-Improved-Logics.md:196
 msgid ""
 "Fixed an issue that caused `IsSonic=true` wave drawing to crash the game "
 "if the wave traveled over a certain distance."
 msgstr "修复了一个如果 `IsSonic=true` 的波绘制超过一定距离会导致游戏崩溃的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:198
+#: ../../Fixed-or-Improved-Logics.md:197
 msgid ""
 "Buildings with foundation bigger than 1x1 can now recycle spawner "
 "correctly."
 msgstr "占地面积超过 1x1 的建筑现在可以正常回收子机。"
 
-#: ../../Fixed-or-Improved-Logics.md:199
+#: ../../Fixed-or-Improved-Logics.md:198
 msgid ""
 "Electric bolts that are supposed to update their position based on units "
 "current firing coords (by default, those fired by vehicles) now do so "
 "correctly for more than one concurrent electric bolt."
 msgstr "现在那些本应跟随单位当前开火坐标更新位置的 EBolt 效果（默认指由载具发射的）能够正确的对超过 1 个同时创建的 EBolt 效果生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:200
+#: ../../Fixed-or-Improved-Logics.md:199
 msgid ""
 "Fixed an issue where `FireAngle` would not work properly under certain "
 "circumstances."
 msgstr "修复了 `FireAngle` 在某些情况下未能正常工作的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:201
+#: ../../Fixed-or-Improved-Logics.md:200
 msgid ""
 "Fixed an issue that `MovementZone=AmphibiousDestroyer` and "
 "`MovementZone=AmphibiousCrusher` technos being unable to enter on water "
@@ -1245,59 +1236,59 @@ msgstr ""
 "修复了 `MovementZone=AmphibiousDestroyer` 与 `MovementZone=AmphibiousCrusher`"
 " 的单位无法进入水上建筑的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:202
+#: ../../Fixed-or-Improved-Logics.md:201
 msgid ""
 "Fixed an issue that aircraft carriers can not find suitable locations for"
 " attacks when under elevated bridges on their own."
 msgstr "修复了航空母舰在桥下时无法找到恰当攻击位置的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:203
+#: ../../Fixed-or-Improved-Logics.md:202
 msgid ""
 "Fixed an issue that in air aircraft carriers being unable to attack when "
 "it is near by elevated bridges."
 msgstr "修复了空天母舰靠近高架桥梁时无法攻击的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:204
+#: ../../Fixed-or-Improved-Logics.md:203
 msgid ""
 "Fixed an issue that aircraft carriers cannot retract its spawned aircraft"
 " when on the bridge."
 msgstr "修复了航空母舰在桥上无法回收子机的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:205
+#: ../../Fixed-or-Improved-Logics.md:204
 msgid ""
 "Fixed an issue where the shadow of jumpjet remained on the ground when it"
 " was above the elevated bridge."
 msgstr "修复了 Jumpjet 在桥梁上方时其影子残留在地面的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:206
+#: ../../Fixed-or-Improved-Logics.md:205
 msgid ""
 "Fixed an issue that laser, electric bolt and rad beam not support "
 "`Inviso=true` projectiles with `FlakScatter=true` to scatter."
 msgstr "修复了激光、EBolt、辐射波在 `FlakScatter=true` 的 `Inviso=true` 抛射体上不不跟随散布的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:207
+#: ../../Fixed-or-Improved-Logics.md:206
 msgid ""
 "Fixed the bug that healing weapons could not automatically acquire aerial"
 " targets."
 msgstr "修复了治疗武器无法自动获取到空中目标的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:208
+#: ../../Fixed-or-Improved-Logics.md:207
 msgid "Allow voxel projectiles to use `AnimPalette` and `FirersPalette`."
 msgstr "允许了 Voxel 抛射体使用 `AnimPalette` 和 `FirersPalette`。"
 
-#: ../../Fixed-or-Improved-Logics.md:209
+#: ../../Fixed-or-Improved-Logics.md:208
 msgid ""
 "Fixed an issue where AI would select unreachable buildings and get stuck "
 "when looking for buildings like tank bunkers, bio reactors, etc."
 msgstr "修复了 AI 会找实际无法抵达的坦克碉堡、生化反应炉等建筑作为目标而导致卡住的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:210
+#: ../../Fixed-or-Improved-Logics.md:209
 msgid ""
 "Fixed an issue that the first passenger who call the transport ship no "
 "longer board the transport ship when the land units call for boarding."
 msgstr "修复了当陆地单位请求登船时第一个呼叫运输船的乘客不会登船的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:211
+#: ../../Fixed-or-Improved-Logics.md:210
 msgid ""
 "Fixed the bug that `EnterBioReactorSound`, `LeaveBioReactorSound`, "
 "`EnterGrinderSound` on technotype does not used."
@@ -1305,42 +1296,42 @@ msgstr ""
 "修复了 `EnterBioReactorSound`、`LeaveBioReactorSound`、`EnterGrinderSound` "
 "在单位上微观设定无效的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:212
+#: ../../Fixed-or-Improved-Logics.md:211
 msgid ""
 "Fixed the bug that harvester dont stop unloading and cannot unload cargos"
 " anymore when lifting by `IsLocomotor=yes` warhead."
 msgstr "修复了矿车被 `IsLocomotor=yes` 的弹头抬起也不会停止倒矿状态且无法继续正常倒矿的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:213
+#: ../../Fixed-or-Improved-Logics.md:212
 msgid "Fixed an issue that units on the slope tilted at an excessive angle."
 msgstr "修复了单位在斜坡上倾斜角度过大的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:214
+#: ../../Fixed-or-Improved-Logics.md:213
 msgid ""
 "Fixed an issue that impassable invisible barrier generated by the "
 "behavior of infantry continuously entering vehicles."
 msgstr "修复了步兵通过路径点连续进入两个载具等行为会产生空气墙的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:215
+#: ../../Fixed-or-Improved-Logics.md:214
 msgid ""
 "Fixed an issue that teleport units board transport vehicles on the bridge"
 " will create an impassable invisible barrier, which may cause the game to"
 " freeze or even crash."
 msgstr "修复了单位超时空进入桥上的运输载具会产生空气墙并可能导致游戏卡死乃至崩溃的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:216
+#: ../../Fixed-or-Improved-Logics.md:215
 msgid ""
 "Fixed an issue that moving MCV with Teleport locomotion will cause "
 "reconnection error."
 msgstr "修复了超时空移动的 MCV 会引发 Reconnection Error 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:217
+#: ../../Fixed-or-Improved-Logics.md:216
 msgid ""
 "Fixed wrong shadow when a vehicle has hover locomotor and is being lifted"
 " by `IsLocomotor=yes` warhead."
 msgstr "修复了使用悬浮运动模式的载具被 `IsLocomotor=yes` 弹头抬起时显示的错误阴影。"
 
-#: ../../Fixed-or-Improved-Logics.md:218
+#: ../../Fixed-or-Improved-Logics.md:217
 msgid ""
 "Fixed the bug that a unit can overlap with `Teleport` units after it's "
 "been damaged by a fallen unit lifted by `IsLocomotor=yes` warheads."
@@ -1348,115 +1339,114 @@ msgstr ""
 "修复了一个单位被另一个由 `IsLocomotor=yes` 弹头吊起的单位砸过后其所在单元格可以被一个 `Teleport` "
 "运动模式的单位作为超时空移动的目的地的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:219
+#: ../../Fixed-or-Improved-Logics.md:218
 msgid ""
 "Fixed an issue that game crashes (EIP:7FB178) when infantry are about to "
 "enter an occupiable building that has been removed and is not real dead."
 msgstr "修复了当步兵进入一个已被移除但并未真正死亡的可驻军建筑时导致的游戏崩溃问题（EIP:7FB178）。"
 
-#: ../../Fixed-or-Improved-Logics.md:220
+#: ../../Fixed-or-Improved-Logics.md:219
 msgid ""
 "Fixed an issue that game crashes when spawnee has been removed and is not"
 " real dead."
 msgstr "修复了当子机已被移除但并未真正死亡时导致的游戏崩溃问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:221
+#: ../../Fixed-or-Improved-Logics.md:220
 msgid ""
 "Separated the AirstrikeClass pointer between the attacker/aircraft and "
 "the target to avoid erroneous overwriting issues."
 msgstr "分离了 AirstrikeClass 中攻击者／战机与目标的指针以避免错误覆盖问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:222
+#: ../../Fixed-or-Improved-Logics.md:221
 msgid "Fixed the bug that buildings will always be tinted as airstrike owner."
 msgstr "修复了建筑总是被染色为空袭所属方颜色的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:223
+#: ../../Fixed-or-Improved-Logics.md:222
 msgid ""
 "Fixed the bug that `AllowAirstrike=no` cannot completely prevent air "
 "strikes from being launched against it."
 msgstr "修复了 `AllowAirstrike=no` 未能完全阻止对某个单位进行空袭的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:224
+#: ../../Fixed-or-Improved-Logics.md:223
 msgid ""
 "Fixed the issue where computer players did not search for new enemies "
 "after defeating them or forming alliances with them."
 msgstr "修复了 AI 玩家在消灭一家敌人或敌人结盟后不再搜索新敌人的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:225
+#: ../../Fixed-or-Improved-Logics.md:224
 msgid ""
 "Fixed the bug that infantry ignored `Passengers` and `SizeLimit` when "
 "entering buildings."
 msgstr "修复了步兵进入建筑时忽略 `Passengers` 和 `SizeLimit` 的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:226
+#: ../../Fixed-or-Improved-Logics.md:225
 msgid "Fixed `VoiceDeploy` not played, when deployed through hot-key/command bar."
 msgstr "修复了通过快捷键／底边栏按钮部署时不播放 `VoiceDeploy` 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:227
+#: ../../Fixed-or-Improved-Logics.md:226
 msgid "Fixed the bug that ships can travel on elevated bridges."
 msgstr "修复了船只可以在高架桥上行驶的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:228
+#: ../../Fixed-or-Improved-Logics.md:227
 msgid "Dehardcoded 255 limit of `OverlayType`."
 msgstr "解除了覆盖物最多 255 个的数量限制。"
 
-#: ../../Fixed-or-Improved-Logics.md:229
+#: ../../Fixed-or-Improved-Logics.md:228
 msgid ""
 "Fixed an issue where airstrike flare line drawn to target at lower "
 "elevation would clip."
 msgstr "修复了空袭引导激光高打低时会截断的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:230
+#: ../../Fixed-or-Improved-Logics.md:229
 msgid ""
 "Fixed the bug that uncontrolled scatter when elite techno attacked by "
 "aircraft or some unit try crush it."
 msgstr "修复精英单位在被战机攻击或一个单位尝试碾压它时强制散开的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:231
+#: ../../Fixed-or-Improved-Logics.md:230
 msgid ""
 "Second weapon with `ElectricAssault=yes` will not unconditionally attack "
 "your building with `Overpowerable=yes`."
 msgstr "有 `ElectricAssault=yes` 的副武不再会无条件地攻击己方 `Overpowerable=yes` 的建筑。"
 
-#: ../../Fixed-or-Improved-Logics.md:232
+#: ../../Fixed-or-Improved-Logics.md:231
 msgid "Infantry support `IsGattling=yes`."
 msgstr "步兵类现已支持使用 `IsGattling=yes` 开启盖特逻辑"
 
-#: ../../Fixed-or-Improved-Logics.md:233
+#: ../../Fixed-or-Improved-Logics.md:232
 msgid ""
 "Fixed an issue that the widespread damage caused by detonation on the "
 "bridge/ground cannot affect objects on the ground/bridge who are in the "
 "opposite case."
 msgstr "修复了范围伤害在桥上／地面引爆时无法影响相对情况即在地面／桥上的对象的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:234
+#: ../../Fixed-or-Improved-Logics.md:233
 msgid ""
 "Fixed the bug that `DamageSelf` and `AllowDamageOnSelf` are ineffective "
 "on airforce."
-msgstr ""
-"修复了 `DamageSelf` 和 `AllowDamageOnSelf` 对空军无效的 Bug。"
+msgstr "修复了 `DamageSelf` 和 `AllowDamageOnSelf` 对空军无效的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:235
+#: ../../Fixed-or-Improved-Logics.md:234
 msgid ""
 "Fixed the bug that damaged particle dont disappear after building has "
 "repaired by engineer."
 msgstr "修复了建筑在被工程师修复后受损粒子不会移除的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:236
+#: ../../Fixed-or-Improved-Logics.md:235
 msgid "Fixed the issue of incorrect position of `TrailerAnim` in `VoxelAnim`."
 msgstr "修复了 Voxel 碎片 `TrailerAnim` 生成位置不正确的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:238
+#: ../../Fixed-or-Improved-Logics.md:237
 msgid "Fixes / interactions with other extensions"
 msgstr "修复或与其他扩展的交互"
 
-#: ../../Fixed-or-Improved-Logics.md:240
+#: ../../Fixed-or-Improved-Logics.md:239
 msgid ""
 "Weapons fired by EMPulse superweapons *(Ares feature)* now fully respect "
 "the firing building's FLH."
 msgstr "现在由 EMPulse 超级武器（*Ares 功能*）发射的武器将完全遵照发射建筑的 FLH 设置。"
 
-#: ../../Fixed-or-Improved-Logics.md:241
+#: ../../Fixed-or-Improved-Logics.md:240
 msgid ""
 "Weapons fired by EMPulse superweapons *(Ares feature)* without "
 "`EMPulse.TargetSelf=true` can now create radiation."
@@ -1464,51 +1454,51 @@ msgstr ""
 "现在由 EMPulse 超级武器（*Ares 功能*）发射的武器在没有 `EMPulse.TargetSelf=true` "
 "的情况下也可以正常产生辐射。"
 
-#: ../../Fixed-or-Improved-Logics.md:242
+#: ../../Fixed-or-Improved-Logics.md:241
 msgid ""
 "Weapons fired by EMPulse superweapons *(Ares feature)* now respect "
 "`Floater` and Phobos-added `Gravity` setting."
 msgstr "现在由 EMPulse 超级武器（*Ares 功能*）发射的武器遵守 `Floater` 与 Phobos 添加的 `Gravity` 设定"
 
-#: ../../Fixed-or-Improved-Logics.md:243
+#: ../../Fixed-or-Improved-Logics.md:242
 msgid ""
 "`IsSimpleDeployer` units with Hover locomotor and `DeployToLand` no "
 "longer get stuck after deploying or play their move sound indefinitely."
 msgstr "拥有 Hover 运动模式的 `IsSimpleDeployer` 且 `DeployToLand` 的单位在部署后不再会卡住或无限播放移动音效。"
 
-#: ../../Fixed-or-Improved-Logics.md:244
+#: ../../Fixed-or-Improved-Logics.md:243
 msgid ""
 "All forms of type conversion (including Ares') now correctly update the "
 "warp-in delay if unit with teleport `Locomotor` was converted while the "
 "delay was active."
 msgstr "现在所有单位转换形式（包括 Ares 的）在使用超时空 `Locomotor` 的单位处于僵直状态被转换时可以正确的更新传送延迟。"
 
-#: ../../Fixed-or-Improved-Logics.md:245
+#: ../../Fixed-or-Improved-Logics.md:244
 msgid ""
 "All forms of type conversion (including Ares') now correctly update "
 "`MoveSound` if a moving unit has their type changed."
 msgstr "现在所有单位转换形式（包括 Ares 的）在移动单位的类型被转换时可以正确更新 `MoveSound`。"
 
-#: ../../Fixed-or-Improved-Logics.md:246
+#: ../../Fixed-or-Improved-Logics.md:245
 msgid ""
 "All forms of type conversion (including Ares') now correctly update "
 "`OpenTopped` state of passengers in transport that is converted."
 msgstr "现在所有单位转换形式（包括 Ares 的）在运输工具被转换时可以正确更新乘客的 `OpenTopped` 状态。"
 
-#: ../../Fixed-or-Improved-Logics.md:247
+#: ../../Fixed-or-Improved-Logics.md:246
 msgid ""
 "Fixed an issue introduced by Ares that caused building `ActiveAnim` to be"
 " incorrectly restored while `SpecialAnim` was playing and the building "
 "was sold, erased or destroyed."
 msgstr "修复了 Ares 引入的一个当 `SpecialAnim` 播放且建筑被出售、删除或摧毁时它的 `ActiveAnim` 会被错误地恢复的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:248
+#: ../../Fixed-or-Improved-Logics.md:247
 msgid ""
 "Fixed Ares' Abductor weapon leaves permanent placement stats when "
 "abducting moving vehicles."
 msgstr "修复了 Ares 的超时空监狱武器在绑架移动载具时会留下永久放置统计（空气墙）的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:249
+#: ../../Fixed-or-Improved-Logics.md:248
 msgid ""
 "Suppressed Ares' swizzle warning when parsing `Tags` and `TaskForces` "
 "(typically begin with `[Developer fatal]Pointer 00000000 declared change "
@@ -1517,149 +1507,151 @@ msgstr ""
 "在解析 `Tags` 和 `TaskForces` 时抑制 Ares 的 swizzle 警告（通常以 `[Developer "
 "fatal]Pointer 00000000 declared change to both` 开头）。"
 
-#: ../../Fixed-or-Improved-Logics.md:250
+#: ../../Fixed-or-Improved-Logics.md:249
 msgid ""
 "Fixed Academy *(Ares feature)* not working on the initial payloads *(Ares"
 " feature)* of vehicles built from a war factory."
 msgstr "修复了训练所（*Ares 功能*）在由战车工厂所生产载具的初始载员（*Ares 功能*）上不起作用的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:251
+#: ../../Fixed-or-Improved-Logics.md:250
 msgid ""
 "Fixed Ares' InitialPayload not being created for vehicles spawned by "
 "trigger actions."
 msgstr "修复了 Ares 的初始荷载未为触发行为生成的载具创建的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:252
+#: ../../Fixed-or-Improved-Logics.md:251
 msgid ""
 "Allowed Ares' `SW.AuxBuildings` and `SW.NegBuildings` to count building "
 "upgrades."
 msgstr "允许了 Ares 的 `SW.AuxBuildings` 和 `SW.NegBuildings` 计入建筑加载物。"
 
-#: ../../Fixed-or-Improved-Logics.md:253
+#: ../../Fixed-or-Improved-Logics.md:252
 msgid ""
 "Taking over Ares' AlphaImage respawn logic to make it not recreate in "
 "every frame for buildings, static techno and techno without turret, in "
 "order to reduce lags from it."
 msgstr "接管了 Ares 的 AlphaImage 重绘逻辑，使其用于建筑、静止单位和无炮塔单位时不会每帧重绘，以减少其造成的卡顿。"
 
-#: ../../Fixed-or-Improved-Logics.md:254
+#: ../../Fixed-or-Improved-Logics.md:253
 msgid ""
 "Fixed an issue where a portion of Ares's trigger event 75/77 was "
 "determined unsuccessfully."
 msgstr "修复了 Ares 触发条件 75/77 有时判定不成功的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:255
+#: ../../Fixed-or-Improved-Logics.md:254
 msgid ""
 "Fixed the issue where some units crashed after the deployment "
 "transformation."
 msgstr "修复了某些单位部署变形后崩溃的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:256
+#: ../../Fixed-or-Improved-Logics.md:255
 msgid "Fixed the bug that AlphaImage remained after unit entered tunnel."
 msgstr "修复了 AlphaImage 在单位进入隧道后会遗留在隧道口的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:258
+#: ../../Fixed-or-Improved-Logics.md:257
 msgid "Aircraft"
 msgstr "战机类型"
 
-#: ../../Fixed-or-Improved-Logics.md:260
+#: ../../Fixed-or-Improved-Logics.md:259
 msgid "Carryall pickup voice"
 msgstr "吊运拾取音效"
 
-#: ../../Fixed-or-Improved-Logics.md:262
+#: ../../Fixed-or-Improved-Logics.md:261
 msgid ""
 "It is now possible to override `VoiceMove` for `Carryall=true` aircraft "
 "for when commanding it to pick up vehicles by setting `VoicePickup`."
 msgstr "现在可以通过设置 `VoicePickup` 来覆盖 `Carryall=true` 战机在命令其拾取载具时的 `VoiceMove` 音效。"
 
-#: ../../Fixed-or-Improved-Logics.md:264 ../../Fixed-or-Improved-Logics.md:274
-#: ../../Fixed-or-Improved-Logics.md:292 ../../Fixed-or-Improved-Logics.md:308
-#: ../../Fixed-or-Improved-Logics.md:320 ../../Fixed-or-Improved-Logics.md:382
-#: ../../Fixed-or-Improved-Logics.md:455 ../../Fixed-or-Improved-Logics.md:466
-#: ../../Fixed-or-Improved-Logics.md:488 ../../Fixed-or-Improved-Logics.md:504
-#: ../../Fixed-or-Improved-Logics.md:515 ../../Fixed-or-Improved-Logics.md:530
-#: ../../Fixed-or-Improved-Logics.md:552 ../../Fixed-or-Improved-Logics.md:569
-#: ../../Fixed-or-Improved-Logics.md:587 ../../Fixed-or-Improved-Logics.md:597
-#: ../../Fixed-or-Improved-Logics.md:608 ../../Fixed-or-Improved-Logics.md:638
-#: ../../Fixed-or-Improved-Logics.md:651 ../../Fixed-or-Improved-Logics.md:663
-#: ../../Fixed-or-Improved-Logics.md:679 ../../Fixed-or-Improved-Logics.md:691
-#: ../../Fixed-or-Improved-Logics.md:720 ../../Fixed-or-Improved-Logics.md:749
-#: ../../Fixed-or-Improved-Logics.md:759 ../../Fixed-or-Improved-Logics.md:771
-#: ../../Fixed-or-Improved-Logics.md:781 ../../Fixed-or-Improved-Logics.md:797
-#: ../../Fixed-or-Improved-Logics.md:813 ../../Fixed-or-Improved-Logics.md:830
-#: ../../Fixed-or-Improved-Logics.md:860 ../../Fixed-or-Improved-Logics.md:889
-#: ../../Fixed-or-Improved-Logics.md:900 ../../Fixed-or-Improved-Logics.md:922
-#: ../../Fixed-or-Improved-Logics.md:934 ../../Fixed-or-Improved-Logics.md:948
-#: ../../Fixed-or-Improved-Logics.md:968 ../../Fixed-or-Improved-Logics.md:997
-#: ../../Fixed-or-Improved-Logics.md:1050
-#: ../../Fixed-or-Improved-Logics.md:1065
-#: ../../Fixed-or-Improved-Logics.md:1077
+#: ../../Fixed-or-Improved-Logics.md:263 ../../Fixed-or-Improved-Logics.md:273
+#: ../../Fixed-or-Improved-Logics.md:291 ../../Fixed-or-Improved-Logics.md:307
+#: ../../Fixed-or-Improved-Logics.md:319 ../../Fixed-or-Improved-Logics.md:383
+#: ../../Fixed-or-Improved-Logics.md:456 ../../Fixed-or-Improved-Logics.md:477
+#: ../../Fixed-or-Improved-Logics.md:499 ../../Fixed-or-Improved-Logics.md:515
+#: ../../Fixed-or-Improved-Logics.md:526 ../../Fixed-or-Improved-Logics.md:541
+#: ../../Fixed-or-Improved-Logics.md:563 ../../Fixed-or-Improved-Logics.md:580
+#: ../../Fixed-or-Improved-Logics.md:598 ../../Fixed-or-Improved-Logics.md:608
+#: ../../Fixed-or-Improved-Logics.md:619 ../../Fixed-or-Improved-Logics.md:649
+#: ../../Fixed-or-Improved-Logics.md:662 ../../Fixed-or-Improved-Logics.md:674
+#: ../../Fixed-or-Improved-Logics.md:690 ../../Fixed-or-Improved-Logics.md:702
+#: ../../Fixed-or-Improved-Logics.md:731 ../../Fixed-or-Improved-Logics.md:760
+#: ../../Fixed-or-Improved-Logics.md:770 ../../Fixed-or-Improved-Logics.md:782
+#: ../../Fixed-or-Improved-Logics.md:792 ../../Fixed-or-Improved-Logics.md:808
+#: ../../Fixed-or-Improved-Logics.md:824 ../../Fixed-or-Improved-Logics.md:841
+#: ../../Fixed-or-Improved-Logics.md:871 ../../Fixed-or-Improved-Logics.md:900
+#: ../../Fixed-or-Improved-Logics.md:911 ../../Fixed-or-Improved-Logics.md:933
+#: ../../Fixed-or-Improved-Logics.md:945 ../../Fixed-or-Improved-Logics.md:959
+#: ../../Fixed-or-Improved-Logics.md:979 ../../Fixed-or-Improved-Logics.md:1008
+#: ../../Fixed-or-Improved-Logics.md:1061
+#: ../../Fixed-or-Improved-Logics.md:1076
 #: ../../Fixed-or-Improved-Logics.md:1088
-#: ../../Fixed-or-Improved-Logics.md:1100
-#: ../../Fixed-or-Improved-Logics.md:1114
-#: ../../Fixed-or-Improved-Logics.md:1129
-#: ../../Fixed-or-Improved-Logics.md:1152
-#: ../../Fixed-or-Improved-Logics.md:1171
-#: ../../Fixed-or-Improved-Logics.md:1182
-#: ../../Fixed-or-Improved-Logics.md:1197
-#: ../../Fixed-or-Improved-Logics.md:1224
-#: ../../Fixed-or-Improved-Logics.md:1254
-#: ../../Fixed-or-Improved-Logics.md:1267
-#: ../../Fixed-or-Improved-Logics.md:1278
-#: ../../Fixed-or-Improved-Logics.md:1298
-#: ../../Fixed-or-Improved-Logics.md:1312
-#: ../../Fixed-or-Improved-Logics.md:1355
-#: ../../Fixed-or-Improved-Logics.md:1373
-#: ../../Fixed-or-Improved-Logics.md:1394
-#: ../../Fixed-or-Improved-Logics.md:1420
-#: ../../Fixed-or-Improved-Logics.md:1439
-#: ../../Fixed-or-Improved-Logics.md:1454
-#: ../../Fixed-or-Improved-Logics.md:1466
-#: ../../Fixed-or-Improved-Logics.md:1479
-#: ../../Fixed-or-Improved-Logics.md:1492
-#: ../../Fixed-or-Improved-Logics.md:1504
-#: ../../Fixed-or-Improved-Logics.md:1521
-#: ../../Fixed-or-Improved-Logics.md:1535
-#: ../../Fixed-or-Improved-Logics.md:1546
-#: ../../Fixed-or-Improved-Logics.md:1564
-#: ../../Fixed-or-Improved-Logics.md:1584
-#: ../../Fixed-or-Improved-Logics.md:1598
+#: ../../Fixed-or-Improved-Logics.md:1099
+#: ../../Fixed-or-Improved-Logics.md:1111
+#: ../../Fixed-or-Improved-Logics.md:1125
+#: ../../Fixed-or-Improved-Logics.md:1146
+#: ../../Fixed-or-Improved-Logics.md:1161
+#: ../../Fixed-or-Improved-Logics.md:1184
+#: ../../Fixed-or-Improved-Logics.md:1203
+#: ../../Fixed-or-Improved-Logics.md:1214
+#: ../../Fixed-or-Improved-Logics.md:1229
+#: ../../Fixed-or-Improved-Logics.md:1256
+#: ../../Fixed-or-Improved-Logics.md:1286
+#: ../../Fixed-or-Improved-Logics.md:1299
+#: ../../Fixed-or-Improved-Logics.md:1310
+#: ../../Fixed-or-Improved-Logics.md:1330
+#: ../../Fixed-or-Improved-Logics.md:1344
+#: ../../Fixed-or-Improved-Logics.md:1387
+#: ../../Fixed-or-Improved-Logics.md:1405
+#: ../../Fixed-or-Improved-Logics.md:1426
+#: ../../Fixed-or-Improved-Logics.md:1452
+#: ../../Fixed-or-Improved-Logics.md:1471
+#: ../../Fixed-or-Improved-Logics.md:1486
+#: ../../Fixed-or-Improved-Logics.md:1498
+#: ../../Fixed-or-Improved-Logics.md:1511
+#: ../../Fixed-or-Improved-Logics.md:1524
+#: ../../Fixed-or-Improved-Logics.md:1536
+#: ../../Fixed-or-Improved-Logics.md:1553
+#: ../../Fixed-or-Improved-Logics.md:1567
+#: ../../Fixed-or-Improved-Logics.md:1578
+#: ../../Fixed-or-Improved-Logics.md:1596
 #: ../../Fixed-or-Improved-Logics.md:1616
-#: ../../Fixed-or-Improved-Logics.md:1635
-#: ../../Fixed-or-Improved-Logics.md:1649
-#: ../../Fixed-or-Improved-Logics.md:1665
-#: ../../Fixed-or-Improved-Logics.md:1682
-#: ../../Fixed-or-Improved-Logics.md:1699
-#: ../../Fixed-or-Improved-Logics.md:1727
-#: ../../Fixed-or-Improved-Logics.md:1758
-#: ../../Fixed-or-Improved-Logics.md:1782
-#: ../../Fixed-or-Improved-Logics.md:1801
+#: ../../Fixed-or-Improved-Logics.md:1630
+#: ../../Fixed-or-Improved-Logics.md:1648
+#: ../../Fixed-or-Improved-Logics.md:1667
+#: ../../Fixed-or-Improved-Logics.md:1681
+#: ../../Fixed-or-Improved-Logics.md:1697
+#: ../../Fixed-or-Improved-Logics.md:1714
+#: ../../Fixed-or-Improved-Logics.md:1731
+#: ../../Fixed-or-Improved-Logics.md:1759
+#: ../../Fixed-or-Improved-Logics.md:1790
 #: ../../Fixed-or-Improved-Logics.md:1814
-#: ../../Fixed-or-Improved-Logics.md:1826
-#: ../../Fixed-or-Improved-Logics.md:1842
-#: ../../Fixed-or-Improved-Logics.md:1854
-#: ../../Fixed-or-Improved-Logics.md:1867
+#: ../../Fixed-or-Improved-Logics.md:1833
+#: ../../Fixed-or-Improved-Logics.md:1846
+#: ../../Fixed-or-Improved-Logics.md:1858
+#: ../../Fixed-or-Improved-Logics.md:1874
 #: ../../Fixed-or-Improved-Logics.md:1886
-#: ../../Fixed-or-Improved-Logics.md:1908
-#: ../../Fixed-or-Improved-Logics.md:1918
-#: ../../Fixed-or-Improved-Logics.md:1929
-#: ../../Fixed-or-Improved-Logics.md:1946
-#: ../../Fixed-or-Improved-Logics.md:1960
-#: ../../Fixed-or-Improved-Logics.md:1972
-#: ../../Fixed-or-Improved-Logics.md:1984
-#: ../../Fixed-or-Improved-Logics.md:1995
-#: ../../Fixed-or-Improved-Logics.md:2006
-#: ../../Fixed-or-Improved-Logics.md:2019
+#: ../../Fixed-or-Improved-Logics.md:1899
+#: ../../Fixed-or-Improved-Logics.md:1917
+#: ../../Fixed-or-Improved-Logics.md:1941
+#: ../../Fixed-or-Improved-Logics.md:1953
+#: ../../Fixed-or-Improved-Logics.md:1963
+#: ../../Fixed-or-Improved-Logics.md:1974
+#: ../../Fixed-or-Improved-Logics.md:1991
+#: ../../Fixed-or-Improved-Logics.md:2005
+#: ../../Fixed-or-Improved-Logics.md:2017
 #: ../../Fixed-or-Improved-Logics.md:2029
-#: ../../Fixed-or-Improved-Logics.md:2045
-#: ../../Fixed-or-Improved-Logics.md:2067
-#: ../../Fixed-or-Improved-Logics.md:2078
-#: ../../Fixed-or-Improved-Logics.md:2094
-#: ../../Fixed-or-Improved-Logics.md:2116
+#: ../../Fixed-or-Improved-Logics.md:2040
+#: ../../Fixed-or-Improved-Logics.md:2051
+#: ../../Fixed-or-Improved-Logics.md:2064
+#: ../../Fixed-or-Improved-Logics.md:2074
+#: ../../Fixed-or-Improved-Logics.md:2090
+#: ../../Fixed-or-Improved-Logics.md:2112
+#: ../../Fixed-or-Improved-Logics.md:2123
+#: ../../Fixed-or-Improved-Logics.md:2139
+#: ../../Fixed-or-Improved-Logics.md:2161
 msgid "In `rulesmd.ini`:"
 msgstr "在 `rulesmd.ini`："
 
-#: ../../Fixed-or-Improved-Logics.md:265
+#: ../../Fixed-or-Improved-Logics.md:264
 msgid ""
 "[SOMEAIRCRAFT]  ; AircraftType\n"
 "VoicePickup=    ; Sound entry\n"
@@ -1667,18 +1659,18 @@ msgstr ""
 "[SOMEAIRCRAFT]  ; AircraftType\n"
 "VoicePickup=    ; Sound entry\n"
 
-#: ../../Fixed-or-Improved-Logics.md:270
+#: ../../Fixed-or-Improved-Logics.md:269
 msgid "Customize the scatter caused by aircraft attack mission"
 msgstr "自定义战机攻击任务引发分散"
 
-#: ../../Fixed-or-Improved-Logics.md:272
+#: ../../Fixed-or-Improved-Logics.md:271
 msgid ""
 "In vanilla, when an aircraft attacks, it forces the target's cell to "
 "trigger a scatter. Now you can disable this behavior by setting the "
 "following flag to `false`."
 msgstr "在原版中当一架战机发起攻击它会强制触发目标单元格上的分散效果。现在你可以通过将下面的语句设为 `false` 来禁用该行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:275
+#: ../../Fixed-or-Improved-Logics.md:274
 msgid ""
 "[SOMEAIRCRAFT]            ; AircraftType\n"
 "FiringForceScatter=true   ; boolean\n"
@@ -1686,28 +1678,28 @@ msgstr ""
 "[SOMEAIRCRAFT]            ; AircraftType\n"
 "FiringForceScatter=true   ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:280
+#: ../../Fixed-or-Improved-Logics.md:279
 msgid "Extended Aircraft Missions"
 msgstr "拓展的战机任务"
 
-#: ../../Fixed-or-Improved-Logics.md:282
+#: ../../Fixed-or-Improved-Logics.md:281
 msgid "Aircraft will now be able to use waypoints."
 msgstr "战机现在将能够使用路径点。"
 
-#: ../../Fixed-or-Improved-Logics.md:283
+#: ../../Fixed-or-Improved-Logics.md:282
 msgid ""
 "When a `guard` command (`[G]` by default) is issued, the aircraft will "
 "search for targets around the current location and return immediately "
 "when target is not found, target is destroyed or ammos are depleted."
 msgstr "当发出 `guard` 命令（默认为 `[G]`）时战机将在当前位置周围搜素目标并在未找到目标、目标被摧毁或弹药耗尽时立即返回。"
 
-#: ../../Fixed-or-Improved-Logics.md:284
+#: ../../Fixed-or-Improved-Logics.md:283
 msgid ""
 "If the target is destroyed but ammos are not depleted yet, it will also "
 "return because the aircraft's command is one-time."
 msgstr "如果目标被摧毁但弹药尚未耗尽，它同样会直接返回，因为战机的命令是一次性的。"
 
-#: ../../Fixed-or-Improved-Logics.md:285
+#: ../../Fixed-or-Improved-Logics.md:284
 msgid ""
 "When an `attack move` command (`[Ctrl]+[Shift]`) is issued, the aircraft "
 "will move towards the destination and search for nearby targets on the "
@@ -1717,18 +1709,18 @@ msgstr ""
 "当发出 `attack move` "
 "命令（`[Ctrl]+[Shift]`）时战机将向目的地移动并在路线上搜索附近的目标进行攻击。一旦弹药耗尽或抵达目的地，它将返回。"
 
-#: ../../Fixed-or-Improved-Logics.md:286
+#: ../../Fixed-or-Improved-Logics.md:285
 msgid ""
 "If the automatically selected target is destroyed but ammo is not "
 "depleted yet during the process, the aircraft will continue flying to the"
 " destination."
 msgstr "如果在过程中自动选择的目标被摧毁但弹药尚未耗尽，战机将继续飞往目的地。"
 
-#: ../../Fixed-or-Improved-Logics.md:287
+#: ../../Fixed-or-Improved-Logics.md:286
 msgid "In addition, the actions of aircraft are also changed."
 msgstr "此外，战机的行为也可以更改。"
 
-#: ../../Fixed-or-Improved-Logics.md:288
+#: ../../Fixed-or-Improved-Logics.md:287
 msgid ""
 "`ExtendedAircraftMissions.SmoothMoving` controls whether the aircraft "
 "will return to the airport when the distance to the destination is less "
@@ -1737,7 +1729,7 @@ msgstr ""
 "`ExtendedAircraftMissions.SmoothMoving` 控制战机距离目的地距离小于 `SlowdownDistance` "
 "的一半或其转弯半径时是否会返回机场。"
 
-#: ../../Fixed-or-Improved-Logics.md:289
+#: ../../Fixed-or-Improved-Logics.md:288
 msgid ""
 "`ExtendedAircraftMissions.EarlyDescend` controls whether the aircraft not"
 " have to fly directly above the airport before starting to descend when "
@@ -1747,7 +1739,7 @@ msgstr ""
 "`ExtendedAircraftMissions.EarlyDescend` 控制战机距离着陆点小于 `SlowdownDistance` "
 "时是否无需飞越机场正上方即可开始下降（对航母舰载机同样有效）。"
 
-#: ../../Fixed-or-Improved-Logics.md:290
+#: ../../Fixed-or-Improved-Logics.md:289
 msgid ""
 "`ExtendedAircraftMissions.RearApproach` controls whether the aircraft "
 "should start landing at the airport from the opposite direction of "
@@ -1756,7 +1748,7 @@ msgstr ""
 "`ExtendedAircraftMissions.RearApproach` 控制战机返回机场时是否应从与 `LandingDir` "
 "相反的方向飞入，即下降时向 `LandingDir` 的方向飞行并着陆。"
 
-#: ../../Fixed-or-Improved-Logics.md:293
+#: ../../Fixed-or-Improved-Logics.md:292
 msgid ""
 "[General]\n"
 "ExtendedAircraftMissions=false         ; boolean\n"
@@ -1780,11 +1772,11 @@ msgstr ""
 "ExtendedAircraftMissions.RearApproach=  ; boolean, default to [General] "
 "-> ExtendedAircraftMissions\n"
 
-#: ../../Fixed-or-Improved-Logics.md:303
+#: ../../Fixed-or-Improved-Logics.md:302
 msgid "Fixed spawn distance & spawn height for airstrike / SpyPlane aircraft"
 msgstr "空袭战机和侦察机的生成距离和生成高度"
 
-#: ../../Fixed-or-Improved-Logics.md:305
+#: ../../Fixed-or-Improved-Logics.md:304
 msgid ""
 "It is now possible to have aircraft spawned from "
 "`(Elite)AirstrikeTeamType` or `Type=SpyPlane` superweapons to be created "
@@ -1794,7 +1786,7 @@ msgstr ""
 "现在可以通过设置 `SpawnDistanceFromTarget` 来让由 `(Elite)AirstrikeTeamType` 或 "
 "`Type=SpyPlane` 超级武器生成的战机在与目标／目的地固定距离处生成而不再是地图边界。"
 
-#: ../../Fixed-or-Improved-Logics.md:306
+#: ../../Fixed-or-Improved-Logics.md:305
 msgid ""
 "`SpawnHeight` can also be used to override the initial height of the "
 "aircraft, which defaults to `FlightLevel`, or if not set then `[General] "
@@ -1803,18 +1795,18 @@ msgstr ""
 "也可以通过 `SpawnHeight` 来覆盖战机的初始高度，默认为 `FlightLevel`，如果没有设置则使用 `[General] -> "
 "FlightLevel`。"
 
-#: ../../Fixed-or-Improved-Logics.md:309
+#: ../../Fixed-or-Improved-Logics.md:308
 msgid ""
 "[SOMEAIRCRAFT]            ; AircraftType\n"
 "SpawnDistanceFromTarget=  ; floating point value, distance in cells\n"
 "SpawnHeight=              ; integer, height in leptons\n"
 msgstr ""
 
-#: ../../Fixed-or-Improved-Logics.md:315
+#: ../../Fixed-or-Improved-Logics.md:314
 msgid "Landing direction"
 msgstr "降落方向"
 
-#: ../../Fixed-or-Improved-Logics.md:317
+#: ../../Fixed-or-Improved-Logics.md:316
 msgid ""
 "By default aircraft land facing the direction specified by `[AudioVisual]"
 " -> PoseDir`. This can now be customized per AircraftType via "
@@ -1826,13 +1818,13 @@ msgstr ""
 " 进行自定义，默认为 `[AudioVisual] -> PoseDir`。如果战机停靠的建筑设置了[战机停靠方向](#aircraft-"
 "docking-direction)，则该设置优先于此设置。"
 
-#: ../../Fixed-or-Improved-Logics.md:318
+#: ../../Fixed-or-Improved-Logics.md:317
 msgid ""
 "Negative values are allowed as a special case for `AirportBound=false` "
 "aircraft which makes them land facing their current direction."
 msgstr "对于 `AirportBound=false` 的战机允许使用负值以使其降落时面向当前方向。"
 
-#: ../../Fixed-or-Improved-Logics.md:321
+#: ../../Fixed-or-Improved-Logics.md:320
 msgid ""
 "[SOMEAIRCRAFT]  ; AircraftType\n"
 "LandingDir=     ; Direction type (integers from 0-255). Accepts negative "
@@ -1842,15 +1834,15 @@ msgstr ""
 "LandingDir=     ; Direction type (integers from 0-255). Accepts negative "
 "values as a special case.\n"
 
-#: ../../Fixed-or-Improved-Logics.md:326
+#: ../../Fixed-or-Improved-Logics.md:325
 msgid "Animations"
 msgstr "动画类型"
 
-#: ../../Fixed-or-Improved-Logics.md:328
+#: ../../Fixed-or-Improved-Logics.md:327
 msgid "Animation weapon and damage settings"
 msgstr "动画武器和伤害设置"
 
-#: ../../Fixed-or-Improved-Logics.md:330
+#: ../../Fixed-or-Improved-Logics.md:329
 msgid ""
 "`Weapon` can be set to a WeaponType, to create a projectile and "
 "immediately detonate it instead of simply dealing `Damage` by `Warhead`. "
@@ -1859,7 +1851,7 @@ msgstr ""
 "现在 `Weapon` 可以设置为完整的 WeaponType，以创建一个抛射体并立即引爆，而不是简单地通过 `Warhead` 造成 "
 "`Damage`。这允许武器效果正常使用。"
 
-#: ../../Fixed-or-Improved-Logics.md:331
+#: ../../Fixed-or-Improved-Logics.md:330
 msgid ""
 "`Damage.Delay` determines delay between two applications of `Damage`. "
 "Requires `Damage` to be set to 1.0 or above. Value of 0 disables the "
@@ -1870,7 +1862,7 @@ msgstr ""
 "`Damage.Delay` 确定两次应用 `Damage` 之间的间隔。需要将 `Damage` 设置为 1.0 或更高。值为 0 "
 "将禁用间隔。请注意这是以动画帧为单位而不是游戏帧。动画会根据 `Rate` 可能在每个游戏帧上推进动画帧也可能不进行推进。"
 
-#: ../../Fixed-or-Improved-Logics.md:332
+#: ../../Fixed-or-Improved-Logics.md:331
 msgid ""
 "`Damage.DealtByInvoker`, if set to true, makes any `Damage` dealt to be "
 "considered as coming from the animation's invoker (f.ex, firer of the "
@@ -1886,6 +1878,13 @@ msgstr ""
 "动画则为被摧毁的载具；或者动画所附着的对象）。即便调用者已经死亡或不存在也会继续使用调用者的所属方来造成伤害并应用 Phobos "
 "引入的弹头效果。不影响由 `Warhead` 造成 `Damage` 的所属方。"
 
+#: ../../Fixed-or-Improved-Logics.md:332
+msgid ""
+"`Damage.ApplyFirepowerMult` determines whether or not firepower modifiers"
+" from the animation's invoker are applied on the damage dealt from this "
+"animation, if exists."
+msgstr "`Damage.ApplyFirepowerMult` 决定动画存在调用者时是否可以获取其火力加成效果。"
+
 #: ../../Fixed-or-Improved-Logics.md:333
 msgid ""
 "`Damage.ApplyOncePerLoop`, if set to true, makes `Damage` be dealt only "
@@ -1898,32 +1897,35 @@ msgstr ""
 "`Damage`（在单次循环的动画中只会造成一次）而不是在每帧或由 `Damage.Delay` 定义的间隔造成。造成伤害的帧由 "
 "`Damage.Delay` 决定，默认为在第一个动画帧之后。"
 
-#: ../../Fixed-or-Improved-Logics.md:335 ../../Fixed-or-Improved-Logics.md:352
-#: ../../Fixed-or-Improved-Logics.md:367 ../../Fixed-or-Improved-Logics.md:388
-#: ../../Fixed-or-Improved-Logics.md:409 ../../Fixed-or-Improved-Logics.md:433
-#: ../../Fixed-or-Improved-Logics.md:443 ../../Fixed-or-Improved-Logics.md:477
-#: ../../Fixed-or-Improved-Logics.md:619 ../../Fixed-or-Improved-Logics.md:843
-#: ../../Fixed-or-Improved-Logics.md:974 ../../Fixed-or-Improved-Logics.md:1332
-#: ../../Fixed-or-Improved-Logics.md:1405
-#: ../../Fixed-or-Improved-Logics.md:1688
+#: ../../Fixed-or-Improved-Logics.md:335 ../../Fixed-or-Improved-Logics.md:353
+#: ../../Fixed-or-Improved-Logics.md:368 ../../Fixed-or-Improved-Logics.md:389
+#: ../../Fixed-or-Improved-Logics.md:410 ../../Fixed-or-Improved-Logics.md:434
+#: ../../Fixed-or-Improved-Logics.md:444 ../../Fixed-or-Improved-Logics.md:466
+#: ../../Fixed-or-Improved-Logics.md:488 ../../Fixed-or-Improved-Logics.md:630
+#: ../../Fixed-or-Improved-Logics.md:854 ../../Fixed-or-Improved-Logics.md:985
+#: ../../Fixed-or-Improved-Logics.md:1364
+#: ../../Fixed-or-Improved-Logics.md:1437
+#: ../../Fixed-or-Improved-Logics.md:1720
 msgid "In `artmd.ini`:"
 msgstr "在 `artmd.ini`："
 
 #: ../../Fixed-or-Improved-Logics.md:336
 msgid ""
-"[SOMEANIM]                     ; AnimationType\n"
-"Weapon=                        ; WeaponType\n"
-"Damage.Delay=0                 ; integer, animation frames\n"
-"Damage.DealtByInvoker=false    ; boolean\n"
-"Damage.ApplyOncePerLoop=false  ; boolean\n"
+"[SOMEANIM]                      ; AnimationType\n"
+"Weapon=                         ; WeaponType\n"
+"Damage.Delay=0                  ; integer, animation frames\n"
+"Damage.DealtByInvoker=false     ; boolean\n"
+"Damage.ApplyOncePerLoop=false   ; boolean\n"
+"Damage.ApplyFirepowerMult=false ; boolean\n"
 msgstr ""
-"[SOMEANIM]                     ; AnimationType\n"
-"Weapon=                        ; WeaponType\n"
-"Damage.Delay=0                 ; integer, animation frames\n"
-"Damage.DealtByInvoker=false    ; boolean\n"
-"Damage.ApplyOncePerLoop=false  ; boolean\n"
+"[SOMEANIM]                      ; AnimationType\n"
+"Weapon=                         ; WeaponType\n"
+"Damage.Delay=0                  ; integer, animation frames\n"
+"Damage.DealtByInvoker=false     ; boolean\n"
+"Damage.ApplyOncePerLoop=false   ; boolean\n"
+"Damage.ApplyFirepowerMult=false ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:345
+#: ../../Fixed-or-Improved-Logics.md:346
 msgid ""
 "`Weapon` and `Damage.Delay`, beyond the other additions, should function "
 "similarly to the equivalent features introduced by Ares and take "
@@ -1932,18 +1934,18 @@ msgstr ""
 "`Weapon` 和 `Damage.Delay`，除了其他新增功能外应与 Ares 引入的等效功能类似，并且在 Phobos 与 Ares "
 "一起使用时优先于它们。"
 
-#: ../../Fixed-or-Improved-Logics.md:348
+#: ../../Fixed-or-Improved-Logics.md:349
 msgid "Attached animation position customization"
 msgstr "自定义附着动画位置"
 
-#: ../../Fixed-or-Improved-Logics.md:350
+#: ../../Fixed-or-Improved-Logics.md:351
 msgid ""
 "You can now customize whether or not animations attached to objects are "
 "centered at the object's actual center rather than the bottom of their "
 "top-leftmost cell (cell #0)."
 msgstr "现在你可以自定义附着于对象的动画是否以对象的实际中心为基准而非以其最左上角的单元格（单元格 #0）的底部为基准、"
 
-#: ../../Fixed-or-Improved-Logics.md:353
+#: ../../Fixed-or-Improved-Logics.md:354
 msgid ""
 "[SOMEANIM]                       ; AnimationType\n"
 "UseCenterCoordsIfAttached=false  ; boolean\n"
@@ -1951,11 +1953,11 @@ msgstr ""
 "[SOMEANIM]                       ; AnimationType\n"
 "UseCenterCoordsIfAttached=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:358 ../../Fixed-or-Improved-Logics.md:1793
+#: ../../Fixed-or-Improved-Logics.md:359 ../../Fixed-or-Improved-Logics.md:1825
 msgid "Customizable debris & meteor impact and warhead detonation behaviour"
 msgstr "自定义碎片 & 流星撞击和弹头引爆行为"
 
-#: ../../Fixed-or-Improved-Logics.md:360
+#: ../../Fixed-or-Improved-Logics.md:361
 msgid ""
 "`ExplodeOnWater` can be set to true to make the animation explode on "
 "impact with water. `ExpireAnim` will be played and `Warhead` is detonated"
@@ -1964,7 +1966,7 @@ msgstr ""
 "`Warhead.Detonate` 设置为 true 可以使动画在与水面接触时爆炸。`ExpireAnim` 将被触发，`Warhead` "
 "将被引爆或用于造成伤害／产生闪光。"
 
-#: ../../Fixed-or-Improved-Logics.md:361
+#: ../../Fixed-or-Improved-Logics.md:362
 msgid ""
 "`Warhead.Detonate`, if set to true, makes the `Warhead` fully detonate "
 "instead of simply being used to deal damage and generate light flash if "
@@ -1973,7 +1975,7 @@ msgstr ""
 "如果将 `Warhead.Detonate` 设置为 true，则 `Warhead` 将完全引爆，而不仅仅是用于造成伤害和产生闪光（如果它拥有 "
 "`Bright=true`）。"
 
-#: ../../Fixed-or-Improved-Logics.md:362
+#: ../../Fixed-or-Improved-Logics.md:363
 msgid ""
 "`WakeAnim` contains a wake animation to play if `ExplodeOnWater` is not "
 "set and the animation impacts with water. Defaults to `[General] -> Wake`"
@@ -1982,7 +1984,7 @@ msgstr ""
 "`WakeAnim` 包含一个在 `ExplodeOnWater` 没有设置且动画与水面接触时使用的水波动画。如果 `IsMeteor` 未设置为"
 " true 则默认为 `[General] -> Wake`，否则无动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:363
+#: ../../Fixed-or-Improved-Logics.md:364
 msgid ""
 "`SplashAnims` contains list of splash animations used if `ExplodeOnWater`"
 " is not set and the animation impacts with water. Defaults to "
@@ -1991,7 +1993,7 @@ msgstr ""
 "`SplashAnims` 包含一组在 `ExplodeOnWater` 没有设置且动画与水面接触时使用的水花动画。默认为 "
 "`[CombatDamage] -> SplashList`。"
 
-#: ../../Fixed-or-Improved-Logics.md:364
+#: ../../Fixed-or-Improved-Logics.md:365
 msgid ""
 "If `SplashAnims.PickRandom` is set to true, picks a random animation from"
 " `SplashAnims` to use on each impact with water. Otherwise last listed "
@@ -2000,13 +2002,13 @@ msgstr ""
 "如果设置 `SplashAnims.PickRandom` 为 true，则从 `SplashAnims` 中随机选择一个动画。否则使用 "
 "`SplashAnims` 中列出的最后一个动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:365
+#: ../../Fixed-or-Improved-Logics.md:366
 msgid ""
 "`ExtraShadow` can be set to false to disable the display of shadows on "
 "the ground."
 msgstr "`ExtraShadow` 可以设为 false 以禁用地面上的影子显示。"
 
-#: ../../Fixed-or-Improved-Logics.md:368
+#: ../../Fixed-or-Improved-Logics.md:369
 msgid ""
 "[SOMEANIM]                    ; AnimationType\n"
 "ExplodeOnWater=false          ; boolean\n"
@@ -2024,18 +2026,18 @@ msgstr ""
 "SplashAnims.PickRandom=false  ; boolean\n"
 "ExtraShadow=true              ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:378
+#: ../../Fixed-or-Improved-Logics.md:379
 msgid "Customize whether `Crater=yes` animation would destroy tiberium"
 msgstr "自定义 `Crater=yes` 的动画能否摧毁矿石"
 
-#: ../../Fixed-or-Improved-Logics.md:380
+#: ../../Fixed-or-Improved-Logics.md:381
 msgid ""
 "In vanilla, the anim with `Crater=yes` is hardcoded to destroy the "
 "tiberium in its cell. Now you can disable this behavior by setting the "
 "following tags to `false`."
 msgstr "在原版中带有 `Crater=yes` 的动画硬编码会摧毁其所在单元格的矿石。现在你可以通过将下面的语句设为 `false` 来禁用该行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:383
+#: ../../Fixed-or-Improved-Logics.md:384
 msgid ""
 "[General]\n"
 "AnimCraterDestroyTiberium=true  ; boolean\n"
@@ -2043,7 +2045,7 @@ msgstr ""
 "[General]\n"
 "AnimCraterDestroyTiberium=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:389
+#: ../../Fixed-or-Improved-Logics.md:390
 msgid ""
 "[SOMEANIM]                      ; AnimationType\n"
 "Crater.DestroyTiberium=         ; boolean, default to [General] -> "
@@ -2053,11 +2055,11 @@ msgstr ""
 "Crater.DestroyTiberium=         ; boolean, default to [General] -> "
 "AnimCraterDestroyTiberium\n"
 
-#: ../../Fixed-or-Improved-Logics.md:394
+#: ../../Fixed-or-Improved-Logics.md:395
 msgid "Fire animations spawned by Scorch & Flamer"
 msgstr "由 Scorch 和 Flamer 生成的火焰动画"
 
-#: ../../Fixed-or-Improved-Logics.md:396
+#: ../../Fixed-or-Improved-Logics.md:397
 msgid ""
 "Tiberian Sun allowed `Scorch=true` and `Flamer=true` animations to spawn "
 "fire animations from `[AudioVisual] -> SmallFire` & `LargeFire`. This "
@@ -2066,14 +2068,14 @@ msgstr ""
 "《泰伯利亚之日》中允许 `Scorch=true` 和 `Flamer=true` 的动画生成 `[AudioVisual] -> "
 "SmallFire` 和 `LargeFire` 指定的火焰动画。此行为已重新实现，并且完全可自定义。"
 
-#: ../../Fixed-or-Improved-Logics.md:397
+#: ../../Fixed-or-Improved-Logics.md:398
 msgid ""
 "`ConstrainFireAnimsToCellSpots` controls whether or not spawned "
 "animations are locked to cell spots (e.g the subcell positions infantry "
 "are also constrained to)."
 msgstr "`ConstrainFireAnimsToCellSpots` 控制生成的动画是否锁定到单元格位置（例如步兵也受子单元格位置限制）。"
 
-#: ../../Fixed-or-Improved-Logics.md:398
+#: ../../Fixed-or-Improved-Logics.md:399
 msgid ""
 "`FireAnimDisallowedLandTypes` controls which landtypes the fire "
 "animations are not allowed to spawn on. Defaults to "
@@ -2082,7 +2084,7 @@ msgstr ""
 "`FireAnimDisallowedLandTypes` 控制不允许生成火焰动画的地形类型。对于 `Scorch=true` 默认为 "
 "`water,rock,beach,ice` 否则为 `none`。"
 
-#: ../../Fixed-or-Improved-Logics.md:399
+#: ../../Fixed-or-Improved-Logics.md:400
 msgid ""
 "`AttachFireAnimsToParent` controls if the spawned animations are attached"
 " to the owner of the parent animation if it is also attached. Defaults to"
@@ -2091,7 +2093,7 @@ msgstr ""
 "`AttachFireAnimsToParent` 控制生成的动画是否附着于父动画所附着的对象（如果父动画也是附着动画）。对于 "
 "`Scorch=true` 默认为 true，否则为 false。"
 
-#: ../../Fixed-or-Improved-Logics.md:400
+#: ../../Fixed-or-Improved-Logics.md:401
 msgid ""
 "`SmallFireCount` determines number of small fire animations to spawn by "
 "both `Scorch=true` and `Flamer=true` animations. Defaults to 2 for "
@@ -2100,13 +2102,13 @@ msgstr ""
 "`SmallFireCount` 决定由 `Scorch=true` 和 `Flamer=true` 动画生成小火焰动画的数量。对于 "
 "`Flamer=true` 默认为 2，否则为 1。"
 
-#: ../../Fixed-or-Improved-Logics.md:401
+#: ../../Fixed-or-Improved-Logics.md:402
 msgid ""
 "`SmallFireAnims` can be used to set the animation types, defaults to "
 "`[AudioVisual] -> SmallFire` (single animation)."
 msgstr "`SmallFireAnims` 可以用于设置动画类型，默认为 `[AudioVisual] -> SmallFire`（单个动画）。"
 
-#: ../../Fixed-or-Improved-Logics.md:402
+#: ../../Fixed-or-Improved-Logics.md:403
 msgid ""
 "`SmallFireChances` is a list of probabilities for the animations to "
 "spawn, up to `SmallFireCount` amount of items are read. Last item listed "
@@ -2117,7 +2119,7 @@ msgstr ""
 "数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。对于 `Flamer=true` 默认为 `1.0,0.5`，否则为 "
 "`1.0`。"
 
-#: ../../Fixed-or-Improved-Logics.md:403
+#: ../../Fixed-or-Improved-Logics.md:404
 msgid ""
 "`SmallFireDistances` is a list of distances in cells for the animations "
 "to spawn at from the parent animation's coordinates, up to "
@@ -2129,19 +2131,19 @@ msgstr ""
 "数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。对于 `Flamer=true` 默认为 `0.25,0.625`，否则为 "
 "`0.0`。"
 
-#: ../../Fixed-or-Improved-Logics.md:404
+#: ../../Fixed-or-Improved-Logics.md:405
 msgid ""
 "`LargeFireCount` determines number of large fire animations to spawn by "
 "`Flamer=true` animations only."
 msgstr "`LargeFireCount` 决定仅由 `Flamer=true` 动画生成的大火焰动画的数量。"
 
-#: ../../Fixed-or-Improved-Logics.md:405
+#: ../../Fixed-or-Improved-Logics.md:406
 msgid ""
 "`LargeFireAnims` can be used to set the animation types, defaults to "
 "`[AudioVisual] -> LargeFire` (single animation)."
 msgstr "`LargeFireAnims` 可以用于设置动画类型，默认为 `[AudioVisual] -> LargeFire`（单个动画）。"
 
-#: ../../Fixed-or-Improved-Logics.md:406
+#: ../../Fixed-or-Improved-Logics.md:407
 msgid ""
 "`LargeFireChances` is a list of probabilities for the animations to "
 "spawn, up to `LargeFireCount` amount of items are read. Last item listed "
@@ -2150,7 +2152,7 @@ msgstr ""
 "`LargeFireChances` 是一个用于动画生成的概率列表，最多读取前 `LargeFireCount` "
 "数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。"
 
-#: ../../Fixed-or-Improved-Logics.md:407
+#: ../../Fixed-or-Improved-Logics.md:408
 msgid ""
 "`LargeFireDistances` is a list of distances in cells for the animations "
 "to spawn at from the parent animation's coordinates, up to "
@@ -2160,7 +2162,7 @@ msgstr ""
 "`SmallFireDistances` 是一个用于动画相对父动画坐标生成位置单元格距离的列表，最多读取前 `LargeFireCount` "
 "数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。"
 
-#: ../../Fixed-or-Improved-Logics.md:410
+#: ../../Fixed-or-Improved-Logics.md:411
 msgid ""
 "[SOMEANIM]                          ; AnimationType\n"
 "ConstrainFireAnimsToCellSpots=true  ; boolean\n"
@@ -2200,25 +2202,25 @@ msgstr ""
 "LargeFireDistances=0.4375           ; List of floating point values, "
 "distance in cells\n"
 
-#: ../../Fixed-or-Improved-Logics.md:426
+#: ../../Fixed-or-Improved-Logics.md:427
 msgid ""
 "Save for the change that `Flamer` does not spawn animations if the parent"
 " animation is in air, the default settings should provide identical "
 "results to similar feature from Ares."
 msgstr "除了 `Flamer` 在父动画位于空中时不生成这一更改外，默认设置应该与 Ares 中类似功能拥有相同的效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:429
+#: ../../Fixed-or-Improved-Logics.md:430
 msgid "Layer on animations attached to objects"
 msgstr "附加动画的图层"
 
-#: ../../Fixed-or-Improved-Logics.md:431
+#: ../../Fixed-or-Improved-Logics.md:432
 msgid ""
 "You can now customize whether or not animations attached to objects "
 "follow the object's layer or respect their own `Layer` setting. If this "
 "is unset, attached animations use `ground` layer."
 msgstr "现在你可以自定义让附加于对象的动画跟随对象的图层还是遵循它们自身的 `Layer` 设置。如果不设置，附加的动画会使用 `ground` 图层。"
 
-#: ../../Fixed-or-Improved-Logics.md:434
+#: ../../Fixed-or-Improved-Logics.md:435
 msgid ""
 "[SOMEANIM]             ; AnimationType\n"
 "Layer.UseObjectLayer=  ; boolean\n"
@@ -2226,11 +2228,11 @@ msgstr ""
 "[SOMEANIM]             ; AnimationType\n"
 "Layer.UseObjectLayer=  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:439
+#: ../../Fixed-or-Improved-Logics.md:440
 msgid "Ore stage threshold for `HideIfNoOre`"
 msgstr "`HideIfNoOre` 的矿石阶段阈值"
 
-#: ../../Fixed-or-Improved-Logics.md:441
+#: ../../Fixed-or-Improved-Logics.md:442
 msgid ""
 "You can now customize which growth stage should an ore/tiberium cell have"
 " to have animation with `HideIfNoOre` displayed. Cells with growth stage "
@@ -2239,7 +2241,7 @@ msgstr ""
 "现在你可以自定义一个矿石／泰伯利亚所在的单元格至少需要到哪个生长阶段才能显示带有 `HideIfNoOre` "
 "的动画。生长阶段低于指定值的单元格将不允许动画显示。"
 
-#: ../../Fixed-or-Improved-Logics.md:444
+#: ../../Fixed-or-Improved-Logics.md:445
 msgid ""
 "[SOMEANIM]               ; AnimationType\n"
 "HideIfNoOre.Threshold=0  ; integer, minimal ore growth stage\n"
@@ -2247,15 +2249,15 @@ msgstr ""
 "[SOMEANIM]               ; AnimationType\n"
 "HideIfNoOre.Threshold=0  ; integer, minimal ore growth stage\n"
 
-#: ../../Fixed-or-Improved-Logics.md:449
+#: ../../Fixed-or-Improved-Logics.md:450
 msgid "Buildings"
 msgstr "建筑类型"
 
-#: ../../Fixed-or-Improved-Logics.md:451
+#: ../../Fixed-or-Improved-Logics.md:452
 msgid "Aircraft docking direction"
 msgstr "战机停靠方向"
 
-#: ../../Fixed-or-Improved-Logics.md:453
+#: ../../Fixed-or-Improved-Logics.md:454
 msgid ""
 "It is now possible to customize the landing direction for docking "
 "aircraft via `AircraftDockingDir(N)` (`N` optionally replaced by 0-based "
@@ -2270,7 +2272,7 @@ msgstr ""
 "是没有为特定偏移设置方向时将使用的同义词）来设置停靠战机的降落方向。这会覆盖战机自己的[降落方向](#landing-"
 "direction)设置并默认为 `[AudioVisual] -> PoseDir`。"
 
-#: ../../Fixed-or-Improved-Logics.md:456
+#: ../../Fixed-or-Improved-Logics.md:457
 msgid ""
 "[SOMEBUILDING]          ; BuildingType\n"
 "AircraftDockingDir(N)=  ; Direction type (integers from 0-255)\n"
@@ -2278,11 +2280,30 @@ msgstr ""
 "[SOMEBUILDING]          ; BuildingType\n"
 "AircraftDockingDir(N)=  ; Direction type (integers from 0-255)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:461
+#: ../../Fixed-or-Improved-Logics.md:462
+msgid "Allows refineries to use multiple ActiveAnim simultaneously"
+msgstr "允许矿场同时播放多个 `ActiveAnim` 动画"
+
+#: ../../Fixed-or-Improved-Logics.md:464
+msgid ""
+"In vanilla, the refinery uses different ActiveAnims depending on the "
+"storage. You can now make it use multiple ActiveAnims simultaneously like"
+" any other building."
+msgstr "在原版中矿场会根据其矿石存储量的不同播放不同的 `ActiveAnim`。现在你可以让它像其他建筑一样同时播放多个 `ActiveAnim`。"
+
+#: ../../Fixed-or-Improved-Logics.md:467
+msgid ""
+"[SOMEBUILDING]                         ; BuildingType\n"
+"Refinery.UseNormalActiveAnim=false     ; boolean\n"
+msgstr ""
+"[SOMEBUILDING]                         ; BuildingType\n"
+"Refinery.UseNormalActiveAnim=false     ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:472
 msgid "Allowed / disallowed types for FactoryPlant"
 msgstr "工业工厂的类型限制"
 
-#: ../../Fixed-or-Improved-Logics.md:463
+#: ../../Fixed-or-Improved-Logics.md:474
 msgid ""
 "It is now possible to customize which TechnoTypes benefit from bonuses of"
 " a `FactoryPlant=true` building by listing them on "
@@ -2291,13 +2312,13 @@ msgstr ""
 "现在可以通过在 `FactoryPlant.AllowTypes` 和／或 `FactoryPlant.DisallowTypes` "
 "中列出有哪些科技类型受到 `FactoryPlant=true` 建筑的加成。"
 
-#: ../../Fixed-or-Improved-Logics.md:464
+#: ../../Fixed-or-Improved-Logics.md:475
 msgid ""
 "`FactoryPlant.Multiplier` *(Ares feature)* is still applied on the "
 "bonuses if they are in effect."
 msgstr "`FactoryPlant.Multiplier`（*Ares 功能*）仍然会应用于加成。"
 
-#: ../../Fixed-or-Improved-Logics.md:467
+#: ../../Fixed-or-Improved-Logics.md:478
 msgid ""
 "[SOMEBUILDING]               ; BuildingType\n"
 "FactoryPlant.AllowTypes=     ; List of TechnoTypes\n"
@@ -2307,11 +2328,11 @@ msgstr ""
 "FactoryPlant.AllowTypes=     ; List of TechnoTypes\n"
 "FactoryPlant.DisallowTypes=  ; List of TechnoTypes\n"
 
-#: ../../Fixed-or-Improved-Logics.md:473
+#: ../../Fixed-or-Improved-Logics.md:484
 msgid "Apply ZShapePointMove during buildups"
 msgstr "在拔起期间应用 ZShapePointMove"
 
-#: ../../Fixed-or-Improved-Logics.md:475
+#: ../../Fixed-or-Improved-Logics.md:486
 msgid ""
 "By default buildings do not apply `ZShapePointMove` (which offsets the 'z"
 " shape' applied on buildings which is used to adjust them in depth buffer"
@@ -2323,7 +2344,7 @@ msgstr ""
 "以在深度缓冲区中调整它们并用于修复与此相关的例如建筑缺角等问题）。现在可以通过设置 `ZShapePointMove.OnBuildup` "
 "来开关此行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:478
+#: ../../Fixed-or-Improved-Logics.md:489
 msgid ""
 "[SOMEBUILDING]                   ; BuildingType\n"
 "ZShapePointMove.OnBuildup=false  ; boolean\n"
@@ -2331,11 +2352,11 @@ msgstr ""
 "[SOMEBUILDING]                   ; BuildingType\n"
 "ZShapePointMove.OnBuildup=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:483
+#: ../../Fixed-or-Improved-Logics.md:494
 msgid "Buildings considered as vehicles"
 msgstr "被视为载具的建筑"
 
-#: ../../Fixed-or-Improved-Logics.md:485
+#: ../../Fixed-or-Improved-Logics.md:496
 msgid ""
 "By default game considers buildings with both `UndeploysInto` set and "
 "`Foundation` equaling `1x1` as vehicles, in a manner of speaking. This "
@@ -2347,13 +2368,13 @@ msgstr ""
 "总的来说默认情况下游戏将同时设置了 `UndeploysInto` 且 `Foundation=1x1` 的建筑视为载具。现在可以通过设置 "
 "`ConsideredVehicle` 来开关此行为。这些建筑在单位计数追踪中被视为载具，受损时不会被视为基地受到攻击，并且默认可以进行批量选择。"
 
-#: ../../Fixed-or-Improved-Logics.md:486
+#: ../../Fixed-or-Improved-Logics.md:497
 msgid ""
 "When capturing such \"buildings\", the player won't be notified by EVA "
 "capture event."
 msgstr "当占领此类 “建筑” 时，玩家不会收到 EVA 占领事件的播报。"
 
-#: ../../Fixed-or-Improved-Logics.md:489
+#: ../../Fixed-or-Improved-Logics.md:500
 msgid ""
 "[SOMEBUILDING]      ; BuildingType\n"
 "ConsideredVehicle=  ; boolean\n"
@@ -2361,11 +2382,11 @@ msgstr ""
 "[SOMEBUILDING]      ; BuildingType\n"
 "ConsideredVehicle=  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:494
+#: ../../Fixed-or-Improved-Logics.md:505
 msgid "Custom exit cell for infantry factory"
 msgstr "兵营自定义出口"
 
-#: ../../Fixed-or-Improved-Logics.md:496
+#: ../../Fixed-or-Improved-Logics.md:507
 msgid ""
 "By default `Factory=InfantryType` buildings use exit cell for the created"
 " infantry based on hardcoded settings if any of `GDIBarracks`, "
@@ -2377,39 +2398,39 @@ msgstr ""
 "`Factory=InfantryType` 的建筑将会根据硬编码设置为创建的步兵设置出口单元格。现在可以通过 "
 "`BarracksExitCell` 为这类建筑定义任意单元格为出口。以下是硬编码值的单元格偏移量参考值。"
 
-#: ../../Fixed-or-Improved-Logics.md:425
+#: ../../Fixed-or-Improved-Logics.md:426
 msgid "Key"
 msgstr "标签"
 
-#: ../../Fixed-or-Improved-Logics.md:425
+#: ../../Fixed-or-Improved-Logics.md:426
 msgid "Cell Offset"
 msgstr "单元格偏移"
 
-#: ../../Fixed-or-Improved-Logics.md:425
+#: ../../Fixed-or-Improved-Logics.md:426
 msgid "`GDIBarracks`"
 msgstr "`GDIBarracks`"
 
-#: ../../Fixed-or-Improved-Logics.md:425
+#: ../../Fixed-or-Improved-Logics.md:426
 msgid "1,2"
 msgstr "1,2"
 
-#: ../../Fixed-or-Improved-Logics.md:425
+#: ../../Fixed-or-Improved-Logics.md:426
 msgid "`NODBarracks`"
 msgstr "`NODBarracks`"
 
-#: ../../Fixed-or-Improved-Logics.md:425
+#: ../../Fixed-or-Improved-Logics.md:426
 msgid "2,2"
 msgstr "2,2"
 
-#: ../../Fixed-or-Improved-Logics.md:425
+#: ../../Fixed-or-Improved-Logics.md:426
 msgid "`YuriBarracks`"
 msgstr "`YuriBarracks`"
 
-#: ../../Fixed-or-Improved-Logics.md:425
+#: ../../Fixed-or-Improved-Logics.md:426
 msgid "2,1"
 msgstr "2,1"
 
-#: ../../Fixed-or-Improved-Logics.md:505
+#: ../../Fixed-or-Improved-Logics.md:516
 msgid ""
 "[SOMEBUILDING]     ; BuildingType\n"
 "BarracksExitCell=  ; X,Y - cell offset\n"
@@ -2417,21 +2438,21 @@ msgstr ""
 "[SOMEBUILDING]     ; BuildingType\n"
 "BarracksExitCell=  ; X,Y - cell offset\n"
 
-#: ../../Fixed-or-Improved-Logics.md:510
+#: ../../Fixed-or-Improved-Logics.md:521
 msgid "Customizable garrison and bunker properties"
 msgstr "自定义驻军建筑与坦克碉堡属性"
 
-#: ../../Fixed-or-Improved-Logics.md:512
+#: ../../Fixed-or-Improved-Logics.md:523
 msgid ""
 "You can now customize damage or ROF multipliers of a garrison or tank "
 "bunker building."
 msgstr "现在可以自定义驻军建筑或坦克堡垒的 Damage 或 ROF 倍率。"
 
-#: ../../Fixed-or-Improved-Logics.md:513
+#: ../../Fixed-or-Improved-Logics.md:524
 msgid "You can now customize enter or exit sound of a tank bunker building."
 msgstr "现在可以自定义坦克碉堡建筑进入和离开时的音效。"
 
-#: ../../Fixed-or-Improved-Logics.md:516
+#: ../../Fixed-or-Improved-Logics.md:527
 msgid ""
 "[SOMEBUILDING]              ; BuildingType\n"
 "OccupyDamageMultiplier=     ; floating point value, default to "
@@ -2461,13 +2482,13 @@ msgstr ""
 "BunkerWallsDownSound=       ; Sound entry, default to [AudioVisual] -> "
 "BunkerWallsDownSound\n"
 
-#: ../../Fixed-or-Improved-Logics.md:526
+#: ../../Fixed-or-Improved-Logics.md:537
 msgid ""
 "Customizable selling buildup sequence length for buildings that can "
 "undeploy"
 msgstr "自定义可反部署建筑出售序列动画长度"
 
-#: ../../Fixed-or-Improved-Logics.md:528
+#: ../../Fixed-or-Improved-Logics.md:539
 msgid ""
 "By default buildings with `UndeploysInto` will only play 23 frames of "
 "their buildup sequence (in reverse starting from last frame) when being "
@@ -2477,7 +2498,7 @@ msgstr ""
 "默认情况下拥有 `UndeploysInto` 的建筑在出售时只会播放其建造动画序列的前 23 帧（从最后一帧开始反向播放）。现在可以通过 "
 "`SellBuildupLength` 自定义。"
 
-#: ../../Fixed-or-Improved-Logics.md:531
+#: ../../Fixed-or-Improved-Logics.md:542
 msgid ""
 "[SOMEBUILDING]        ; BuildingType\n"
 "SellBuildupLength=23  ; integer, number of buildup frames to play\n"
@@ -2485,11 +2506,11 @@ msgstr ""
 "[SOMEBUILDING]        ; BuildingType\n"
 "SellBuildupLength=23  ; integer, number of buildup frames to play\n"
 
-#: ../../Fixed-or-Improved-Logics.md:536
+#: ../../Fixed-or-Improved-Logics.md:547
 msgid "Customizable & new grinder properties"
 msgstr "自定义 & 新的部队回收站特性"
 
-#: ../../Fixed-or-Improved-Logics.md:538
+#: ../../Fixed-or-Improved-Logics.md:549
 msgid ""
 "![image](_static/images/grinding.gif) *Using ally grinder, restricting to"
 " vehicles only and refund display ([Project "
@@ -2498,38 +2519,38 @@ msgstr ""
 "![image](_static/images/grinding.gif) *[幽灵计划](https://www.moddb.com/mods"
 "/project-phantom) 中使用友军的部队回收站、仅限载具以及显示资金*"
 
-#: ../../Fixed-or-Improved-Logics.md:541
+#: ../../Fixed-or-Improved-Logics.md:552
 msgid ""
 "You can now customize which types of objects a building with `Grinding` "
 "set can grind as well as the grinding sound."
 msgstr "现在你可以自定义具有 `Grinding` 设置的建筑可回收的对象类别以及回收使用的音效。"
 
-#: ../../Fixed-or-Improved-Logics.md:542
+#: ../../Fixed-or-Improved-Logics.md:553
 msgid ""
 "`Grinding.AllowAllies` changes whether or not to allow units to enter "
 "allies' buildings."
 msgstr "`Grinding.AllowAllies` 决定是否允许单位进入友军的这座建筑。"
 
-#: ../../Fixed-or-Improved-Logics.md:543
+#: ../../Fixed-or-Improved-Logics.md:554
 msgid ""
 "`Grinding.AllowOwner` changes whether or not to allow units to enter your"
 " own buildings."
 msgstr "`Grinding.AllowOwner` 决定是否允许单位进入己方的这座建筑。"
 
-#: ../../Fixed-or-Improved-Logics.md:544
+#: ../../Fixed-or-Improved-Logics.md:555
 msgid ""
 "`Grinding.AllowTypes` can be used to define InfantryTypes and "
 "VehicleTypes that can be grinded by the building. Listing any will "
 "disable grinding for all types except those listed."
 msgstr "`Grinding.AllowTypes` 可以用于定义可以被这座建筑回收的步兵和载具。只要设置列表就会导致其他不在表中的任何类型无法被回收。"
 
-#: ../../Fixed-or-Improved-Logics.md:545
+#: ../../Fixed-or-Improved-Logics.md:556
 msgid ""
 "`Grinding.DisallowTypes` can be used to exclude InfantryTypes or "
 "VehicleTypes from being able to enter the grinder building."
 msgstr "`Grinding.DisallowTypes` 可以定义不可被这座建筑回收的步兵和载具。"
 
-#: ../../Fixed-or-Improved-Logics.md:546
+#: ../../Fixed-or-Improved-Logics.md:557
 msgid ""
 "`Grinding.PlayDieSound` controls if the units' `DieSound` and `VoiceDie` "
 "are played when entering the grinder. Default to `yes`."
@@ -2537,7 +2558,7 @@ msgstr ""
 "`Grinding.PlayDieSound` 控制单位的 `DieSound` 和 `VoiceDie` 是否都会在进入回收站时播放。默认为 "
 "`yes`。"
 
-#: ../../Fixed-or-Improved-Logics.md:547
+#: ../../Fixed-or-Improved-Logics.md:558
 msgid ""
 "`Grinding.Sound` is a sound played by when object is grinded by the "
 "building. If not set, defaults to `[AudioVisual] -> EnterGrinderSound`."
@@ -2545,7 +2566,7 @@ msgstr ""
 "`Grinding.Sound` 用于定义物体被这座建筑回收时所播放的音效。如果不设置，默认为 `[AudioVisual] -> "
 "EnterGrinderSound`。"
 
-#: ../../Fixed-or-Improved-Logics.md:548
+#: ../../Fixed-or-Improved-Logics.md:559
 msgid ""
 "`Grinding.Weapon` is a weapon fired at the building & by the building "
 "when it grinds an object. Will only be fired if at least weapon's `ROF` "
@@ -2554,14 +2575,14 @@ msgstr ""
 "`Grinding.Weapon` 用于定义当建筑回收物体时由建筑向该建筑发射的武器。只有在其上次开火以来至少经过了武器 `ROF` "
 "设置的帧数后才能被发射。"
 
-#: ../../Fixed-or-Improved-Logics.md:549
+#: ../../Fixed-or-Improved-Logics.md:560
 msgid ""
 "`Grinding.Weapon.RequiredCredits` can be set to have the weapon require "
 "accumulated credits from grinding to fire. Accumulated credits for this "
 "purpose are reset every time when the weapon fires."
 msgstr "`Grinding.Weapon.RequiredCredits` 可以设置武器开火所需的资金。为此目的积累的资金会在每次武器开火时重置。"
 
-#: ../../Fixed-or-Improved-Logics.md:550
+#: ../../Fixed-or-Improved-Logics.md:561
 msgid ""
 "For money string indication upon grinding, please refer to "
 "[`DisplayIncome`](User-Interface.md#visual-indication-of-income-from-"
@@ -2570,7 +2591,7 @@ msgstr ""
 "关于回收时的资金字符串提示，请参考 [`DisplayIncome`](User-Interface.md#visual-indication-"
 "of-income-from-grinders-and-refineries)。"
 
-#: ../../Fixed-or-Improved-Logics.md:553
+#: ../../Fixed-or-Improved-Logics.md:564
 msgid ""
 "[SOMEBUILDING]                     ; BuildingType\n"
 "Grinding.AllowAllies=false         ; boolean\n"
@@ -2596,35 +2617,35 @@ msgstr ""
 "Grinding.Weapon=                   ; WeaponType\n"
 "Grinding.Weapon.RequiredCredits=0  ; integer\n"
 
-#: ../../Fixed-or-Improved-Logics.md:565
+#: ../../Fixed-or-Improved-Logics.md:576
 msgid "Customize overpower logic"
 msgstr "自定义磁暴线圈充能"
 
-#: ../../Fixed-or-Improved-Logics.md:567
+#: ../../Fixed-or-Improved-Logics.md:578
 msgid "Now you can specific how building can be overpowerd."
 msgstr "现在你可以设定建筑什么情形下才会过载。"
 
-#: ../../Fixed-or-Improved-Logics.md:570
+#: ../../Fixed-or-Improved-Logics.md:581
 msgid ""
-"[SOMEWARHEAD]\n"
+"[SOMEWARHEAD]             ; WarheadType\n"
 "ElectricAssaultLevel=1    ; integer\n"
 "\n"
-"[SOMEBUILDING]\n"
+"[SOMEBUILDING]            ; BuildingType\n"
 "Overpower.KeepOnline=2    ; integer, negative values mean that cannot "
 "keep online\n"
 "Overpower.ChargeWeapon=1  ; integer, negative values mean that weapons "
 "can never be switched\n"
 msgstr ""
-"[SOMEWARHEAD]\n"
+"[SOMEWARHEAD]             ; WarheadType\n"
 "ElectricAssaultLevel=1    ; integer\n"
 "\n"
-"[SOMEBUILDING]\n"
+"[SOMEBUILDING]            ; BuildingType\n"
 "Overpower.KeepOnline=2    ; integer, negative values mean that cannot "
 "keep online\n"
 "Overpower.ChargeWeapon=1  ; integer, negative values mean that weapons "
 "can never be switched\n"
 
-#: ../../Fixed-or-Improved-Logics.md:580
+#: ../../Fixed-or-Improved-Logics.md:591
 msgid ""
 "Ares' [Battery Super Weapon](https://ares-developers.github.io/Ares-"
 "docs/new/superweapons/types/battery.html) won't be affected by this."
@@ -2632,15 +2653,15 @@ msgstr ""
 "Ares 的 [电池超武](https://ares-developers.github.io/Ares-"
 "docs/new/superweapons/types/battery.html) 不受此影响。"
 
-#: ../../Fixed-or-Improved-Logics.md:583
+#: ../../Fixed-or-Improved-Logics.md:594
 msgid "Disable `DamageSound`"
 msgstr "禁用 `DamageSound`"
 
-#: ../../Fixed-or-Improved-Logics.md:585
+#: ../../Fixed-or-Improved-Logics.md:596
 msgid "Now you can disable `DamageSound` of a building."
 msgstr "现在你可以禁用一个建筑的 `DamageSound`。"
 
-#: ../../Fixed-or-Improved-Logics.md:588
+#: ../../Fixed-or-Improved-Logics.md:599
 msgid ""
 "[SOMEBUILDING]            ; BuildingType\n"
 "DisableDamageSound=false  ; boolean\n"
@@ -2648,17 +2669,17 @@ msgstr ""
 "[SOMEBUILDING]            ; BuildingType\n"
 "DisableDamageSound=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:593
+#: ../../Fixed-or-Improved-Logics.md:604
 msgid "Exclude Factory from providing multiple factory bonus"
 msgstr "排除特定工厂的多工厂加成"
 
-#: ../../Fixed-or-Improved-Logics.md:595
+#: ../../Fixed-or-Improved-Logics.md:606
 msgid ""
 "It is now possible to exclude a building with `Factory` from counting "
 "towards `MultipleFactory` bonus."
 msgstr "现在可以将某个具有 `Factory` 的建筑排除在 `MultipleFactory` 之外"
 
-#: ../../Fixed-or-Improved-Logics.md:598
+#: ../../Fixed-or-Improved-Logics.md:609
 msgid ""
 "[SOMEBUILDING]                         ; BuildingType\n"
 "ExcludeFromMultipleFactoryBonus=false  ; boolean\n"
@@ -2666,11 +2687,11 @@ msgstr ""
 "[SOMEBUILDING]                         ; BuildingType\n"
 "ExcludeFromMultipleFactoryBonus=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:603
+#: ../../Fixed-or-Improved-Logics.md:614
 msgid "Power plant damage factor"
 msgstr "伤残电厂电量系数"
 
-#: ../../Fixed-or-Improved-Logics.md:605
+#: ../../Fixed-or-Improved-Logics.md:616
 msgid ""
 "It is possible to customize the power decrement of a power plant when "
 "it's damaged. The actual power output for this plant will be: `Power` "
@@ -2681,13 +2702,13 @@ msgstr ""
 "时损失的发电量，即 `损失发电量 = [1 - (当前血量 / 最大血量)] * PowerPlant.DamageFactor * "
 "Power=`；发电功率无法低于 0。"
 
-#: ../../Fixed-or-Improved-Logics.md:606
+#: ../../Fixed-or-Improved-Logics.md:617
 msgid ""
 "Specifically, if the factor is set to 0.0, power output won't be "
 "decreased by losing health for this power plant."
 msgstr "具体来说，如果该系数设为 0.0，则电厂的发电功率不受血量影响。"
 
-#: ../../Fixed-or-Improved-Logics.md:609
+#: ../../Fixed-or-Improved-Logics.md:620
 msgid ""
 "[SOMEBUILDING]                     ; BuildingType\n"
 "PowerPlant.DamageFactor=1.0        ; floating point value\n"
@@ -2695,22 +2716,22 @@ msgstr ""
 "[SOMEBUILDING]                     ; BuildingType\n"
 "PowerPlant.DamageFactor=1.0        ; floating point value\n"
 
-#: ../../Fixed-or-Improved-Logics.md:614
+#: ../../Fixed-or-Improved-Logics.md:625
 msgid "Skip anim delay for burst fire"
 msgstr "跳过 `DelayedFireDelay`"
 
-#: ../../Fixed-or-Improved-Logics.md:616
+#: ../../Fixed-or-Improved-Logics.md:627
 msgid ""
 "In Red Alert 1, the tesla coil will attack multiple times after charging "
 "animation. This is not possible in Red Alert 2, where the building must "
 "play the charge animation every time it fires."
 msgstr "《红色警戒 1》中的磁暴线圈会在充能后多次攻击。这在《红色警戒 2》中是不可能的，因为建筑必须每次发射时都播放充能动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:617
+#: ../../Fixed-or-Improved-Logics.md:628
 msgid "Now you can implement the above logic using the following flag."
 msgstr "现在你可以使用下面的标签实现上述逻辑。"
 
-#: ../../Fixed-or-Improved-Logics.md:620
+#: ../../Fixed-or-Improved-Logics.md:631
 msgid ""
 "[SOMEBUILDING]                     ; BuildingType\n"
 "IsAnimDelayedBurst=true            ; boolean\n"
@@ -2718,17 +2739,17 @@ msgstr ""
 "[SOMEBUILDING]                     ; BuildingType\n"
 "IsAnimDelayedBurst=true            ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:626
+#: ../../Fixed-or-Improved-Logics.md:637
 msgid ""
 "The prism towers' fire is hardcoded to be delayed. Their fire will ignore"
 " this flag, just as they ignore `IsAnimDelayedFire`."
 msgstr "光棱塔开火硬编码延迟。就像无视 `IsAnimDelayedFire` 那样，它们同样无视该语句。"
 
-#: ../../Fixed-or-Improved-Logics.md:629
+#: ../../Fixed-or-Improved-Logics.md:640
 msgid "Unit repair customization"
 msgstr "在建筑上自定义单位维修参数"
 
-#: ../../Fixed-or-Improved-Logics.md:631
+#: ../../Fixed-or-Improved-Logics.md:642
 msgid ""
 "It is now possible to customize the repairing of units by "
 "`UnitRepair=true`, `UnitReload=true` and `Hospital=true` buildings."
@@ -2736,7 +2757,7 @@ msgstr ""
 "现在可以通过 `UnitRepair=true`、`UnitReload=true` 和 `Hospital=true` "
 "的建筑来自定义单位的维修参数。"
 
-#: ../../Fixed-or-Improved-Logics.md:632
+#: ../../Fixed-or-Improved-Logics.md:643
 msgid ""
 "`Units.RepairRate` customizes the rate at which the units are repaired. "
 "This defaults to `[General] -> ReloadRate` if `UnitReload=true` and if "
@@ -2748,19 +2769,19 @@ msgstr ""
 "ReloadRate` 并覆盖每个战机类型独立的时间设置（*Ares 功能*）。对于 `UnitRepair=true` 的建筑则默认为 "
 "`[General] -> URepairRate`。"
 
-#: ../../Fixed-or-Improved-Logics.md:633
+#: ../../Fixed-or-Improved-Logics.md:644
 msgid ""
 "On `UnitReload=true` building setting this to negative value will fully "
 "disable the repair functionality."
 msgstr "在 `UnitReload=true` 的建筑上将此值设置为负数将完全禁用维修功能。"
 
-#: ../../Fixed-or-Improved-Logics.md:634
+#: ../../Fixed-or-Improved-Logics.md:645
 msgid ""
 "`Units.RepairStep` how much `Strength` is restored per repair tick. "
 "Defaults to `[General] -> RepairStep`."
 msgstr "`Units.RepairStep` 设置每次维修时恢复多少点 `Strength`。默认为 `[General] -> RepairStep`。"
 
-#: ../../Fixed-or-Improved-Logics.md:635
+#: ../../Fixed-or-Improved-Logics.md:646
 msgid ""
 "`Units.RepairPercent` is a multiplier to cost of repairing (cost / "
 "(maximum health / repair step)). Defaults to `[General] -> "
@@ -2770,13 +2791,13 @@ msgstr ""
 "`Units.RepairPercent` 是维修成本的倍率［`Cost`/(`Strength`/`RepairStep`)］。默认为 "
 "`[General] -> RepairPercent`。注意如果最终的成本低于 1 那么会设为 1。"
 
-#: ../../Fixed-or-Improved-Logics.md:636
+#: ../../Fixed-or-Improved-Logics.md:647
 msgid ""
 "`Units.UseRepairCost` can be used to customize if repair cost is applied "
 "at all. Defaults to false for infantry, true for everything else."
 msgstr "`Units.UseRepairCost` 可以用于自定义是否使用维修成本。步兵默认为 false，其他默认为 true。"
 
-#: ../../Fixed-or-Improved-Logics.md:639
+#: ../../Fixed-or-Improved-Logics.md:650
 msgid ""
 "[SOMEBUILDING]        ; BuildingType\n"
 "Units.RepairRate=     ; floating point value, ingame minutes\n"
@@ -2790,17 +2811,17 @@ msgstr ""
 "Units.RepairPercent=  ; floating point value, percents or absolute\n"
 "Units.UseRepairCost=  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:647
+#: ../../Fixed-or-Improved-Logics.md:658
 msgid "Waypoints for buildings"
 msgstr "建筑路径点"
 
-#: ../../Fixed-or-Improved-Logics.md:649
+#: ../../Fixed-or-Improved-Logics.md:660
 msgid ""
 "In vanilla, buildings are forbidden to use waypoints. Now you can allow "
 "that using the following flag."
 msgstr "在原版中，建筑被禁止使用路径点。现在你可以使用以下标签来允许使用。"
 
-#: ../../Fixed-or-Improved-Logics.md:652
+#: ../../Fixed-or-Improved-Logics.md:663
 msgid ""
 "[General]\n"
 "BuildingWaypoints=false  ; boolean\n"
@@ -2808,19 +2829,19 @@ msgstr ""
 "[General]\n"
 "BuildingWaypoints=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:657
+#: ../../Fixed-or-Improved-Logics.md:668
 msgid "Infantry"
 msgstr "步兵"
 
-#: ../../Fixed-or-Improved-Logics.md:659
+#: ../../Fixed-or-Improved-Logics.md:670
 msgid "Prone speed customization"
 msgstr "自定义匍匐速度"
 
-#: ../../Fixed-or-Improved-Logics.md:661
+#: ../../Fixed-or-Improved-Logics.md:672
 msgid "In vanilla, infantry has hardcoded prone speed. Now you can customize it."
 msgstr "原版中步兵匍匐前进的速度是硬编码的。现在你可以自由定义了。"
 
-#: ../../Fixed-or-Improved-Logics.md:664
+#: ../../Fixed-or-Improved-Logics.md:675
 msgid ""
 "[General]\n"
 "ProneSpeed.Crawls=0.67        ; floating point value, multiplier\n"
@@ -2838,15 +2859,15 @@ msgstr ""
 "ProneSpeed=                   ; floating point value, multiplier, by "
 "default, use the corresponding global value according to Crawls\n"
 
-#: ../../Fixed-or-Improved-Logics.md:673
+#: ../../Fixed-or-Improved-Logics.md:684
 msgid "Particle systems"
 msgstr "粒子系统"
 
-#: ../../Fixed-or-Improved-Logics.md:675
+#: ../../Fixed-or-Improved-Logics.md:686
 msgid "Fire particle target coordinate adjustment when firer rotates"
 msgstr "开火者旋转时火焰粒子目标坐标调整"
 
-#: ../../Fixed-or-Improved-Logics.md:677
+#: ../../Fixed-or-Improved-Logics.md:688
 msgid ""
 "By default particle systems with `BehavesLike=Fire` shift their target "
 "coordinates if the object that created the particle system (e.g firer of "
@@ -2856,7 +2877,7 @@ msgstr ""
 "默认情况下拥有 `BehavesLike=Fire` "
 "的粒子系统会根据创建粒子系统的对象（例如武器的开火者）是否旋转来调整其坐标。现在可以为每个粒子系统禁用这一行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:680
+#: ../../Fixed-or-Improved-Logics.md:691
 msgid ""
 "[SOMEPARTICLESYSTEM]               ; ParticleSystemType\n"
 "AdjustTargetCoordsOnRotation=true  ; boolean\n"
@@ -2864,19 +2885,19 @@ msgstr ""
 "[SOMEPARTICLESYSTEM]               ; ParticleSystemType\n"
 "AdjustTargetCoordsOnRotation=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:685
+#: ../../Fixed-or-Improved-Logics.md:696
 msgid "Particles"
 msgstr "粒子"
 
-#: ../../Fixed-or-Improved-Logics.md:687
+#: ../../Fixed-or-Improved-Logics.md:698
 msgid "Customizable gas particle speed"
 msgstr "自定义 gas 粒子速度"
 
-#: ../../Fixed-or-Improved-Logics.md:689
+#: ../../Fixed-or-Improved-Logics.md:700
 msgid "Gas particles can now drift at a custom speed."
 msgstr "Gas 类的粒子现在可以自定义漂浮速度。"
 
-#: ../../Fixed-or-Improved-Logics.md:692
+#: ../../Fixed-or-Improved-Logics.md:703
 msgid ""
 "[GASPARTICLE]          ; Particle with BehavesLike=Gas\n"
 "Gas.MaxDriftSpeed=2    ; integer (TS default is 5)\n"
@@ -2884,53 +2905,53 @@ msgstr ""
 "[GASPARTICLE]          ; Particle with BehavesLike=Gas\n"
 "Gas.MaxDriftSpeed=2    ; integer (TS default is 5)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:697
+#: ../../Fixed-or-Improved-Logics.md:708
 msgid "Projectiles"
 msgstr "抛射体"
 
-#: ../../Fixed-or-Improved-Logics.md:699
+#: ../../Fixed-or-Improved-Logics.md:710
 msgid "Airburst & Splits"
 msgstr "空爆与分裂"
 
-#: ../../Fixed-or-Improved-Logics.md:701
+#: ../../Fixed-or-Improved-Logics.md:712
 msgid ""
 "`AirburstWeapon` logic has been reimplemented and thus there are several "
 "additions & changes to it."
 msgstr "`AirburstWeapon` 逻辑已被重新实现从而对其进行了一些添加和更改。"
 
-#: ../../Fixed-or-Improved-Logics.md:702
+#: ../../Fixed-or-Improved-Logics.md:713
 msgid ""
 "`Splits` can be set to true to use projectile splitting logic from "
 "Firestorm, with the number of split projectiles defined by `Cluster`."
 msgstr "`Splits` 可以设置为 true 以使用 《火风暴》 中的抛射体分裂逻辑，分裂抛射体的数量由 `Cluster` 决定。"
 
-#: ../../Fixed-or-Improved-Logics.md:703
+#: ../../Fixed-or-Improved-Logics.md:714
 msgid ""
 "`RetargetAccuracy` defines the probability that the splitted projectiles "
 "head to the same target as the original projectile."
 msgstr "`RetargetAccuracy` 决定了分裂抛射体与原抛射体瞄准同一目标的概率。"
 
-#: ../../Fixed-or-Improved-Logics.md:704
+#: ../../Fixed-or-Improved-Logics.md:715
 msgid ""
 "`RetargetSelf` determines if it is possible for the splitted projectiles "
 "to aim at the firer of the original projectile."
 msgstr "`RetargetSelf` 决定了分裂抛射体是否可以将原抛射体的发射至视为目标。"
 
-#: ../../Fixed-or-Improved-Logics.md:705
+#: ../../Fixed-or-Improved-Logics.md:716
 msgid ""
 "`RetargetSelf.Probability` is the probability that if the original firer "
 "is chosen as a target, it is kept as the target instead of rerolled to "
 "another."
 msgstr "`RetargetSelf.Probability` 是选择了原本的开火者为目标时它将保留其为目标而不是去重新随机另一个目标的概率。"
 
-#: ../../Fixed-or-Improved-Logics.md:706
+#: ../../Fixed-or-Improved-Logics.md:717
 msgid ""
 "`Splits.TargetingDistance` is the distance in cells that any potential "
 "target has to be within from the original target coordinates to be "
 "eligible for targeting by the splitted projectiles."
 msgstr "`Splits.TargetingDistance` 是以单元格为单位的距离，任何潜在目标都必须在原始目标坐标的这个范围内才能够被分裂的抛射体瞄准。"
 
-#: ../../Fixed-or-Improved-Logics.md:707
+#: ../../Fixed-or-Improved-Logics.md:718
 msgid ""
 "`Splits.TargetCellRange` is the distance in whole cells from the original"
 " target cell from which the splitted projectiles can pick new target "
@@ -2939,7 +2960,7 @@ msgstr ""
 "`Splits.TargetCellRange` "
 "是以完整单元格数为单位的距离，用于附近没有发现足够的科技类型目标时分裂的抛射体从该范围选取新的目标单元格。"
 
-#: ../../Fixed-or-Improved-Logics.md:708
+#: ../../Fixed-or-Improved-Logics.md:719
 msgid ""
 "`Splits.UseWeaponTargeting`, if set to true, enables weapon targeting "
 "filter for when checking targets for splitted projectiles. Target's "
@@ -2953,7 +2974,7 @@ msgstr ""
 "[武器瞄准筛选](New-or-Enhanced-Logics.md#weapon-targeting-filter) 和 "
 "[AttachEffect 筛选](New-or-Enhanced-Logics.md#attached-effects) 都将被检查。"
 
-#: ../../Fixed-or-Improved-Logics.md:709
+#: ../../Fixed-or-Improved-Logics.md:720
 msgid ""
 "Do note that this overrides checking Warhead for "
 "`AffectsAllies/Owner/Enemies` for targeting. You can use "
@@ -2963,31 +2984,31 @@ msgstr ""
 "注意这会在瞄准时覆盖弹头对 `AffectsAllies/Owner/Enemies` 的检查。不过，你可以通过在 "
 "`AirburstWeapon` 设置的武器上使用 `CanTargetHouses` 来实现类似的行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:710
+#: ../../Fixed-or-Improved-Logics.md:721
 msgid "Behaviour for if `Airburst` is set to true can also be customized."
 msgstr "如果将 `Airburst` 设为 true 其行为也同样可以自定义。"
 
-#: ../../Fixed-or-Improved-Logics.md:711
+#: ../../Fixed-or-Improved-Logics.md:722
 msgid ""
 "`AirburstSpread` is the distance in cells that the effect covers, with "
 "each cell in range being targeted by `AirburstWeapon` by default."
 msgstr "`AirburstSpread` 是以单元格为单位的效果所覆盖范围，默认情况下范围内的每个单元格都会被 `AirburstWeapon` 瞄准。"
 
-#: ../../Fixed-or-Improved-Logics.md:712
+#: ../../Fixed-or-Improved-Logics.md:723
 msgid ""
 "`Airburst.UseCluster`, if set to true, makes it so that only number of "
 "cells in the affected area dictated by `Cluster` will be affected, "
 "instead of all of them."
 msgstr "`Airburst.UseCluster` 如果设为 true，则只有 `Cluster` 所指定数量的单元格会被影响，而不是所有单元格。"
 
-#: ../../Fixed-or-Improved-Logics.md:713
+#: ../../Fixed-or-Improved-Logics.md:724
 msgid ""
 "If `Airburst.RandomClusters` is set to true, the cells affected will be "
 "picked by random. Otherwise they will be evenly spaced (counting from "
 "center to edges of affected area)."
 msgstr "`Airburst.RandomClusters` 如果设为 true，则受影响的单元格将随机选取。否则它们将均匀分布（从受影响区域的中心到边缘）。"
 
-#: ../../Fixed-or-Improved-Logics.md:714
+#: ../../Fixed-or-Improved-Logics.md:725
 msgid ""
 "`Airburst.TargetAsSource` can be used to override source or 'firing' "
 "coordinate to match that of the intended target instead of projectile's "
@@ -2996,13 +3017,13 @@ msgstr ""
 "`Airburst.TargetAsSource` 可用于令空爆中心坐标跟随目标坐标而非使用抛射体当前位置。例如原先会在爆点生成根据 "
 "`[Projectile] -> AroundTarget` 决定飞向原点或目标位置，现在会直接以目标为中心爆开。"
 
-#: ../../Fixed-or-Improved-Logics.md:715
+#: ../../Fixed-or-Improved-Logics.md:726
 msgid ""
 "If `Airburst.TargetAsSource.SkipHeight` is also set, then projectile's "
 "current height will be used instead of target's height still."
 msgstr "如果还设置了 `Airburst.TargetAsSource.SkipHeight` 则仍然使用抛射体当前高度而非目标高度。"
 
-#: ../../Fixed-or-Improved-Logics.md:716
+#: ../../Fixed-or-Improved-Logics.md:727
 msgid ""
 "`AroundTarget` controls whether or not targets for projectiles created by"
 " `Airburst` or `Splits` are checked for in area around the original "
@@ -3012,7 +3033,7 @@ msgstr ""
 "`AroundTarget` 控制由 `Airburst` 或 `Splits` "
 "创建的抛射体的目标是否在原抛射体目标周围的区域检查获取，否则从原抛射体爆炸的位置。默认为 `Splits` 值。"
 
-#: ../../Fixed-or-Improved-Logics.md:717
+#: ../../Fixed-or-Improved-Logics.md:728
 msgid ""
 "`AirburstWeapon.ApplyFirepowerMult` determines whether or not firepower "
 "modifiers from the firer of the original projectile are applied on the "
@@ -3021,7 +3042,7 @@ msgstr ""
 "`AirburstWeapon.ApplyFirepowerMult` 决定是否将原抛射体发射者的火力加成应用于由 "
 "`AirburstWeapon` 创建的抛射体。"
 
-#: ../../Fixed-or-Improved-Logics.md:718
+#: ../../Fixed-or-Improved-Logics.md:729
 msgid ""
 "`AirburstWeapon.SourceScatterMin` and `AirburstWeapon.SourceScatterMax` "
 "can be used to scatter the source or 'firing' coordinate around the "
@@ -3030,7 +3051,7 @@ msgstr ""
 "`AirburstWeapon.SourceScatterMin` 和 `AirburstWeapon.SourceScatterMax` "
 "可用于令空爆中心坐标产生散布。"
 
-#: ../../Fixed-or-Improved-Logics.md:721
+#: ../../Fixed-or-Improved-Logics.md:732
 msgid ""
 "[SOMEPROJECTILE]                          ; Projectile\n"
 "Splits=                                   ; boolean\n"
@@ -3080,7 +3101,7 @@ msgstr ""
 "AirburstWeapon.SourceScatterMax=0.0       ; floating point value, "
 "distance in cells\n"
 
-#: ../../Fixed-or-Improved-Logics.md:742
+#: ../../Fixed-or-Improved-Logics.md:753
 msgid ""
 "`Splits`, `AirburstSpread`, `RetargetAccuracy`, `RetargetSelf` and "
 "`AroundTarget`, beyond the other additions, should function similarly to "
@@ -3091,15 +3112,15 @@ msgstr ""
 "`AroundTarget`，除了其他新增功能外，应该与 Ares 所引入的类似功能拥有相同效果并且如果 Phobos 与 Ares "
 "一起使用则优先于 Ares 的。"
 
-#: ../../Fixed-or-Improved-Logics.md:745
+#: ../../Fixed-or-Improved-Logics.md:756
 msgid "Bomb parachute anim deglobalization"
 msgstr "自定义抛射体降落伞动画"
 
-#: ../../Fixed-or-Improved-Logics.md:747
+#: ../../Fixed-or-Improved-Logics.md:758
 msgid "Now you can define `BombParachute` per projectile."
 msgstr "现在你可以为每一个抛射体使用 `BombParachute` 单独定义。"
 
-#: ../../Fixed-or-Improved-Logics.md:750
+#: ../../Fixed-or-Improved-Logics.md:761
 msgid ""
 "[SOMEPROJECTILE]        ; Projectile\n"
 "BombParachute=          ; AnimationType, default to [General] -> "
@@ -3109,11 +3130,11 @@ msgstr ""
 "BombParachute=          ; AnimationType, default to [General] -> "
 "BombParachute\n"
 
-#: ../../Fixed-or-Improved-Logics.md:755
+#: ../../Fixed-or-Improved-Logics.md:766
 msgid "Cluster scatter distance customization"
 msgstr "自定义 Cluster 散布距离"
 
-#: ../../Fixed-or-Improved-Logics.md:757
+#: ../../Fixed-or-Improved-Logics.md:768
 msgid ""
 "`ClusterScatter.Min` and `ClusterScatter.Max` can be used to set minimum "
 "and maximum distance, respectively, in cells from the original detonation"
@@ -3123,7 +3144,7 @@ msgstr ""
 "`ClusterScatter.Min` 和 `ClusterScatter.Max` 可各自用于设置最小和最大距离，用于当 `Cluster` "
 "设为一个大于 1 的值时任何额外爆炸可出现的位置相对原爆炸坐标以单元格为单位的距离。"
 
-#: ../../Fixed-or-Improved-Logics.md:760
+#: ../../Fixed-or-Improved-Logics.md:771
 msgid ""
 "[SOMEPROJECTILE]        ; Projectile\n"
 "ClusterScatter.Min=1.0  ; floating point value, distance in cells\n"
@@ -3133,15 +3154,15 @@ msgstr ""
 "ClusterScatter.Min=1.0  ; floating point value, distance in cells\n"
 "ClusterScatter.Max=2.0  ; floating point value, distance in cells\n"
 
-#: ../../Fixed-or-Improved-Logics.md:766
+#: ../../Fixed-or-Improved-Logics.md:777
 msgid "Customizable projectile gravity"
 msgstr "自定义抛射体重力"
 
-#: ../../Fixed-or-Improved-Logics.md:768
+#: ../../Fixed-or-Improved-Logics.md:779
 msgid "You can now specify individual projectile gravity."
 msgstr "现在你可以为特定抛射体指定其重力。"
 
-#: ../../Fixed-or-Improved-Logics.md:769
+#: ../../Fixed-or-Improved-Logics.md:780
 msgid ""
 "Setting `Gravity=0` is not recommended as it will cause the projectile to"
 " fly backwards and be unable to hit the target which is not at the same "
@@ -3151,7 +3172,7 @@ msgstr ""
 "由于 `Gravity=0` 会导致抛射体向后飞行并且无法击中不在相同高度的目标因此不推荐设置 `Gravity=0` 。我们建议使用 "
 "`Straight` 轨迹替代。见[这里](New-or-Enhanced-Logics.md#projectile-trajectories)。"
 
-#: ../../Fixed-or-Improved-Logics.md:772
+#: ../../Fixed-or-Improved-Logics.md:783
 msgid ""
 "[SOMEPROJECTILE]        ; Projectile\n"
 "Gravity=6.0             ; floating point value\n"
@@ -3159,11 +3180,11 @@ msgstr ""
 "[SOMEPROJECTILE]        ; Projectile\n"
 "Gravity=6.0             ; floating point value\n"
 
-#: ../../Fixed-or-Improved-Logics.md:777
+#: ../../Fixed-or-Improved-Logics.md:788
 msgid "FlakScatter distance customization"
 msgstr "自定义 FlakScatter 距离"
 
-#: ../../Fixed-or-Improved-Logics.md:779
+#: ../../Fixed-or-Improved-Logics.md:790
 msgid ""
 "By default `FlakScatter=true` makes `Inviso=true` projectiles scatter by "
 "random distance (in cells) from 0 to `[CombatDamage] -> "
@@ -3175,7 +3196,7 @@ msgstr ""
 "BallisticScatter` 的随机距离（以单元格为单位）进行散布。现在可以通过在抛射体上设置 `BallisticScatter.Min`"
 " 与 `BallisticScatter.Max` 来自定义这个距离的范围。如果没有设置则使用默认值。"
 
-#: ../../Fixed-or-Improved-Logics.md:782
+#: ../../Fixed-or-Improved-Logics.md:793
 msgid ""
 "[SOMEPROJECTILE]      ; Projectile\n"
 "BallisticScatter.Min= ; floating point value, distance in cells\n"
@@ -3185,11 +3206,11 @@ msgstr ""
 "BallisticScatter.Min= ; floating point value, distance in cells\n"
 "BallisticScatter.Max= ; floating point value, distance in cells\n"
 
-#: ../../Fixed-or-Improved-Logics.md:788
+#: ../../Fixed-or-Improved-Logics.md:799
 msgid "Shrapnel enhancements"
 msgstr "溅射增强"
 
-#: ../../Fixed-or-Improved-Logics.md:790
+#: ../../Fixed-or-Improved-Logics.md:801
 msgid ""
 "![image](_static/images/shrapnel.gif) *Shrapnel appearing against ground "
 "& buildings in [Project Phantom](https://www.moddb.com/mods/project-"
@@ -3198,13 +3219,13 @@ msgstr ""
 "![image](_static/images/shrapnel.gif) *[幽灵计划](https://www.moddb.com/mods"
 "/project-phantom) 中击中地面和建筑的溅射*"
 
-#: ../../Fixed-or-Improved-Logics.md:793
+#: ../../Fixed-or-Improved-Logics.md:804
 msgid ""
 "`ShrapnelWeapon` can now be triggered against ground & buildings via "
 "`Shrapnel.AffectsGround` and `Shrapnel.AffectsBuildings`."
 msgstr "现在可以通过 `Shrapnel.AffectsGround` 和 `Shrapnel.AffectsBuildings` 触发对地面和建筑的溅射。"
 
-#: ../../Fixed-or-Improved-Logics.md:794
+#: ../../Fixed-or-Improved-Logics.md:805
 msgid ""
 "Setting `Shrapnel.UseWeaponTargeting` now allows weapon target filtering "
 "to be enabled for `ShrapnelWeapon`. Target's `LegalTarget` setting, "
@@ -3216,14 +3237,14 @@ msgstr ""
 "`LegalTarget` 设置、弹头的 `Verses` 对 `Armor` 以及 `ShrapnelWeapon` [武器目标筛选"
 "](#weapon-targeting-filter) 和 [AE 武器过滤](#attached-effects) 将被检查。"
 
-#: ../../Fixed-or-Improved-Logics.md:795
+#: ../../Fixed-or-Improved-Logics.md:806
 msgid ""
 "Do note that this overrides the normal check of only allowing shrapnels "
 "to hit non-allied objects. Use `CanTargetHouses=enemies` to manually "
 "enable this behaviour again."
 msgstr "注意这会覆盖允许溅射武器选择非盟友对象的默认检查。使用 `CanTargetHouses=enemies` 可手动重新启用此行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:798
+#: ../../Fixed-or-Improved-Logics.md:809
 msgid ""
 "[SOMEPROJECTILE]                   ; Projectile\n"
 "Shrapnel.AffectsGround=false       ; boolean\n"
@@ -3235,22 +3256,22 @@ msgstr ""
 "Shrapnel.AffectsBuildings=false    ; boolean\n"
 "Shrapnel.UseWeaponTargeting=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:805
+#: ../../Fixed-or-Improved-Logics.md:816
 msgid "Technos"
 msgstr "科技类型"
 
-#: ../../Fixed-or-Improved-Logics.md:807
+#: ../../Fixed-or-Improved-Logics.md:818
 msgid "Airstrike flare visual customizations"
 msgstr "自定义空袭引导效果"
 
-#: ../../Fixed-or-Improved-Logics.md:809
+#: ../../Fixed-or-Improved-Logics.md:820
 msgid ""
 "It is now possible to customize color of airstrike flare tint on target "
 "on the TechnoType calling in the airstrike as well as customize the color"
 " of the line drawn to target."
 msgstr "现在可以在召唤空袭的单位上自定义目标染色效果及引导激光颜色。"
 
-#: ../../Fixed-or-Improved-Logics.md:810
+#: ../../Fixed-or-Improved-Logics.md:821
 msgid ""
 "`LaserTargetColor` can be used to set the index of color from "
 "`[ColorAdd]`, defaults to `[AudioVisual] -> LaserTargetColor`."
@@ -3258,7 +3279,7 @@ msgstr ""
 "`LaserTargetColor` 用于填写颜色在 `[ColorAdd]` 中的索引序号，默认为 `[AudioVisual] -> "
 "LaserTargetColor`。"
 
-#: ../../Fixed-or-Improved-Logics.md:811
+#: ../../Fixed-or-Improved-Logics.md:822
 msgid ""
 "`AirstrikeLineColor` sets the color of the line and dot drawn from firer "
 "to target, defaults to `[AudioVisual] -> AirstrikeLineColor`."
@@ -3266,7 +3287,7 @@ msgstr ""
 "`AirstrikeLineColor` 用于填写引导激光的颜色，默认为 `[AudioVisual] -> "
 "AirstrikeLineColor`。"
 
-#: ../../Fixed-or-Improved-Logics.md:814
+#: ../../Fixed-or-Improved-Logics.md:825
 msgid ""
 "[AudioVisual]\n"
 "AirstrikeLineColor=255,0,0  ; integer - Red,Green,Blue\n"
@@ -3282,11 +3303,11 @@ msgstr ""
 "LaserTargetColor=           ; integer - [ColorAdd] index\n"
 "AirstrikeLineColor=         ; integer - Red,Green,Blue\n"
 
-#: ../../Fixed-or-Improved-Logics.md:823
+#: ../../Fixed-or-Improved-Logics.md:834
 msgid "Airstrike target eligibility"
 msgstr "空袭目标筛选"
 
-#: ../../Fixed-or-Improved-Logics.md:825
+#: ../../Fixed-or-Improved-Logics.md:836
 msgid ""
 "By default whether or not a building can be targeted by airstrikes "
 "depends on value of `CanC4`, which also affects other things. This can "
@@ -3296,21 +3317,21 @@ msgstr ""
 "默认情况下建筑能否作为空袭目标取决于 `CanC4` 的值，这也会影响其他方面。现在可以通过设置 `AllowAirstrike` "
 "来独立更改这一点，如果未设置，默认为 `CanC4` 的值。"
 
-#: ../../Fixed-or-Improved-Logics.md:826
+#: ../../Fixed-or-Improved-Logics.md:837
 msgid "For non building situations, the default value is true."
 msgstr "对非建筑单位默认为 true。"
 
-#: ../../Fixed-or-Improved-Logics.md:827
+#: ../../Fixed-or-Improved-Logics.md:838
 msgid "Now it is possible to designate air strikes against non building targets."
 msgstr "现在可以对非建筑类目标进行空袭引导。"
 
-#: ../../Fixed-or-Improved-Logics.md:828
+#: ../../Fixed-or-Improved-Logics.md:839
 msgid ""
 "The airstrike aircraft will now aim at the target itself rather than the "
 "cell beneath its feet."
 msgstr "空袭的战机会将目标设为单位而不再是单位脚下的单元格。"
 
-#: ../../Fixed-or-Improved-Logics.md:831
+#: ../../Fixed-or-Improved-Logics.md:842
 msgid ""
 "[SOMETECHNO]               ; TechnoType\n"
 "AllowAirstrike=            ; boolean\n"
@@ -3326,11 +3347,11 @@ msgstr ""
 "AirstrikeTargets=building  ; List of Affected Target Enumeration "
 "(none|infantry|units|buildings|all)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:839
+#: ../../Fixed-or-Improved-Logics.md:850
 msgid "Alternate FLH customizations"
 msgstr "跟随炮塔旋转的 `AlternateFLH`"
 
-#: ../../Fixed-or-Improved-Logics.md:841
+#: ../../Fixed-or-Improved-Logics.md:852
 msgid ""
 "`AlternateFLH.OnTurret` can be used to customize whether or not "
 "`AlternateFLHN` used for `OpenTopped` transport firing coordinates, "
@@ -3340,7 +3361,7 @@ msgstr ""
 "`AlternateFLH.OnTurret` 可自定义 `AlternateFLHN` 用于 `OpenTopped` "
 "运输工具的开火坐标、多重心控链接偏移等逻辑时其位置是否相对于炮塔而非车体。"
 
-#: ../../Fixed-or-Improved-Logics.md:844
+#: ../../Fixed-or-Improved-Logics.md:855
 msgid ""
 "[SOMETECHNO]                ; TechnoType\n"
 "AlternateFLH.OnTurret=true  ; boolean\n"
@@ -3348,11 +3369,11 @@ msgstr ""
 "[SOMETECHNO]                ; TechnoType\n"
 "AlternateFLH.OnTurret=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:849
+#: ../../Fixed-or-Improved-Logics.md:860
 msgid "Building-provided self-healing customization"
 msgstr "自定义建筑提供的自愈"
 
-#: ../../Fixed-or-Improved-Logics.md:851
+#: ../../Fixed-or-Improved-Logics.md:862
 msgid ""
 "It is now possible to set a global cap for the effects of "
 "`InfantryGainSelfHeal` and `UnitsGainSelfHeal` by setting "
@@ -3363,7 +3384,7 @@ msgstr ""
 "`UnitsGainSelfHealCap` 来为 `InfantryGainSelfHeal` 和 `UnitsGainSelfHeal` "
 "的效果设置全局上限。"
 
-#: ../../Fixed-or-Improved-Logics.md:852
+#: ../../Fixed-or-Improved-Logics.md:863
 msgid ""
 "Whether or not `MultiplayPassive=true` houses benefit from these effects "
 "can be controlled via `GainSelfHealAllowMultiplayPassive`."
@@ -3371,7 +3392,7 @@ msgstr ""
 "`MultiplayPassive=true` 的所属方是否受益于这些效果可以通过 "
 "`GainSelfHealAllowMultiplayPassive` 加以控制。"
 
-#: ../../Fixed-or-Improved-Logics.md:853
+#: ../../Fixed-or-Improved-Logics.md:864
 msgid ""
 "In campaign, whether or not these effects for player can be benefited by "
 "houses with `PlayerControl=true` can be controlled via "
@@ -3380,13 +3401,13 @@ msgstr ""
 "玩家能否通过带有 `PlayerControl=true` 的所属方获得这些受益可以通过 "
 "`GainSelfHealFromPlayerControl` 控制。"
 
-#: ../../Fixed-or-Improved-Logics.md:854
+#: ../../Fixed-or-Improved-Logics.md:865
 msgid ""
 "Whether or not these effects can be benefited by allied houses can be "
 "controlled via `GainSelfHealFromAllies`."
 msgstr "玩家能否通过盟友所属获得这些受益效果可以由 `GainSelfHealFromAllies` 控制。"
 
-#: ../../Fixed-or-Improved-Logics.md:855
+#: ../../Fixed-or-Improved-Logics.md:866
 msgid ""
 "It is also possible to change the pip frames displayed from `pips.shp` "
 "individually for infantry, units and buildings by setting the frames for "
@@ -3397,7 +3418,7 @@ msgstr ""
 "还可以分别为步兵、载具和建筑在 `[AudioVisual]` 中使用 "
 "`Pips.SelfHeal.(Infantry/Units/Buildings)` 设置各自 `pips.shp` 中用于显示的 pip 帧。"
 
-#: ../../Fixed-or-Improved-Logics.md:856
+#: ../../Fixed-or-Improved-Logics.md:867
 msgid ""
 "`Pips.SelfHeal.(Infantry/Units/Buildings).Offset` can be used to "
 "customize the pixel offsets for the displayed pips, individually for "
@@ -3406,7 +3427,7 @@ msgstr ""
 "`Pips.SelfHeal.(Infantry/Units/Buildings).Offset` 可以被用于分别自定义步兵、载具和建筑显示 "
 "pip 使用的像素偏移量。"
 
-#: ../../Fixed-or-Improved-Logics.md:857
+#: ../../Fixed-or-Improved-Logics.md:868
 msgid ""
 "Whether or not a TechnoType benefits from effects of "
 "`InfantryGainSelfHeal` or `UnitsGainSelfHeal` buildings or neither can "
@@ -3415,7 +3436,7 @@ msgstr ""
 "通过设置 `SelfHealGainType` 可以控制科技类型是否受到 `InfantryGainSelfHeal` 或 "
 "`UnitsGainSelfHeal` 建筑的增益效果或者对两者都不享有。"
 
-#: ../../Fixed-or-Improved-Logics.md:858
+#: ../../Fixed-or-Improved-Logics.md:869
 msgid ""
 "If `SelfHealGainType` is not set, InfantryTypes and VehicleTypes with "
 "`Organic` set to true gain self-healing from `InfantryGainSelfHeal`, "
@@ -3426,7 +3447,7 @@ msgstr ""
 "`InfantryGainSelfHeal` 获得自愈，其他载具类型从 `UnitsGainSelfHeal` "
 "获得以及战机类型和建筑类型永远不会获得自愈。"
 
-#: ../../Fixed-or-Improved-Logics.md:861
+#: ../../Fixed-or-Improved-Logics.md:872
 msgid ""
 "[General]\n"
 "InfantryGainSelfHealCap=                ; integer, maximum amount of "
@@ -3482,11 +3503,11 @@ msgstr ""
 "SelfHealGainType=                       ; Self-Heal Gain Type Enumeration"
 " (noheal|infantry|units)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:881
+#: ../../Fixed-or-Improved-Logics.md:892
 msgid "Chrono sparkle animation customization & improvements"
 msgstr "超时空闪光动画的自定义与改进"
 
-#: ../../Fixed-or-Improved-Logics.md:883
+#: ../../Fixed-or-Improved-Logics.md:894
 msgid ""
 "It is now possible to customize the frame delay between instances of "
 "`[General] -> ChronoSparkle1` animations created on objects being warped "
@@ -3495,7 +3516,7 @@ msgstr ""
 "现在可以通过设置 `[General] -> ChronoSparkleDisplayDelay` 来自定义被结的对象上创建 `[General]"
 " -> ChronoSparkle1` 动画之间的帧间隔。"
 
-#: ../../Fixed-or-Improved-Logics.md:884
+#: ../../Fixed-or-Improved-Logics.md:895
 msgid ""
 "By default on buildings with `MaxNumberOccupants` higher than 0, chrono "
 "sparkle animation would be shown at each of the `MuzzleFlashX` "
@@ -3505,7 +3526,7 @@ msgstr ""
 "默认情况下对于 `MaxNumberOccupants` 大于 0 的建筑，超时空闪烁动画会在每个 `MuzzleFlashX` "
 "坐标处显示。现在这种行为可以自定义，并且支持大于 10 的 `MuzzleFlashX` 索引。"
 
-#: ../../Fixed-or-Improved-Logics.md:885
+#: ../../Fixed-or-Improved-Logics.md:896
 msgid ""
 "`[General] -> ChronoSparkleBuildingDisplayPositions` can be set to show "
 "the sparkle animation on the building (`building`), muzzle flash "
@@ -3516,7 +3537,7 @@ msgstr ""
 "(`building`)、在当前驻军的枪口坐标闪烁 (`occupants`)、所有驻军的枪口闪烁坐标 (`occupantslots`) "
 "或这些中任意组合的情况下显示。"
 
-#: ../../Fixed-or-Improved-Logics.md:886
+#: ../../Fixed-or-Improved-Logics.md:897
 msgid ""
 "If `occupants` or `occupantslots` is listed without `building`, a single "
 "chrono sparkle animation is still displayed on building if it doesn't "
@@ -3526,14 +3547,14 @@ msgstr ""
 "如果列出了 `occupants` 或 `occupantslots` 而没有 `building`，那么在建筑没有任何驻军或其 "
 "`MaxNumberOccupants` 小于 1 的情况下仍会在建筑上显示一个超时空闪烁动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:887
+#: ../../Fixed-or-Improved-Logics.md:898
 msgid ""
 "The chrono sparkle animation that is displayed on building itself is also"
 " now displayed at the center of it rather than at center of its topmost "
 "cell."
 msgstr "现在显示在建筑自身的超时空闪烁动画位于其正中心而不再是其最顶端单元格的中心。"
 
-#: ../../Fixed-or-Improved-Logics.md:890
+#: ../../Fixed-or-Improved-Logics.md:901
 msgid ""
 "[General]\n"
 "ChronoSparkleDisplayDelay=24                         ; integer, game "
@@ -3547,18 +3568,18 @@ msgstr ""
 "ChronoSparkleBuildingDisplayPositions=occupantslots  ; List of chrono "
 "sparkle position enum (building | occupants | occupantslots | all)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:896
+#: ../../Fixed-or-Improved-Logics.md:907
 msgid "Customizable ChronoSphere teleport delays for units"
 msgstr "单位自定义 ChronoSphere 传送延迟"
 
-#: ../../Fixed-or-Improved-Logics.md:898
+#: ../../Fixed-or-Improved-Logics.md:909
 msgid ""
 "It is now possible to customize (globally and per TechnoType) the warp-in"
 " delay for units teleporting through `Type=ChronoSphere/Warp` "
 "Superweapon, both before and after the jump."
 msgstr "现在可以自定义（全局和所有科技类型）单位通过 `Type=ChronoSphere/Warp` 超级武器传送前后的延迟。"
 
-#: ../../Fixed-or-Improved-Logics.md:901
+#: ../../Fixed-or-Improved-Logics.md:912
 msgid ""
 "[General]\n"
 "ChronoSphereDelay=60    ; integer, game frames\n"
@@ -3576,7 +3597,7 @@ msgstr ""
 "ChronoSphereDelay=      ; integer, game frames\n"
 "ChronoSpherePreDelay=   ; integer, game frames\n"
 
-#: ../../Fixed-or-Improved-Logics.md:912
+#: ../../Fixed-or-Improved-Logics.md:923
 msgid ""
 "Due to technical constraints, these settings do not apply to buildings "
 "teleported by Ares' customizable ChronoSphere SW. They only have a pre-"
@@ -3585,11 +3606,11 @@ msgstr ""
 "由于技术限制，这些设置不适用于 Ares 的自定义 ChronoSphere 超级武器传送的建筑。它们仅有一个共用的 `[General] -> "
 "ChronoDelay`。"
 
-#: ../../Fixed-or-Improved-Logics.md:915
+#: ../../Fixed-or-Improved-Logics.md:926
 msgid "Customizable harvester ore gathering animation"
 msgstr "自定义采矿动画"
 
-#: ../../Fixed-or-Improved-Logics.md:917
+#: ../../Fixed-or-Improved-Logics.md:928
 msgid ""
 "![image](_static/images/oregath.gif) *Custom ore gathering anims in "
 "[Project Phantom](https://www.moddb.com/mods/project-phantom)*"
@@ -3597,13 +3618,13 @@ msgstr ""
 "![image](_static/images/oregath.gif) *在 [幽灵计划](https://www.moddb.com/mods"
 "/project-phantom) 中的自定义矿石采集动画*"
 
-#: ../../Fixed-or-Improved-Logics.md:920
+#: ../../Fixed-or-Improved-Logics.md:931
 msgid ""
 "You can now specify which anim should be drawn when a harvester of "
 "specified type is gathering specified type of ore."
 msgstr "现在你可以在设定特定矿车在采集特定类型的矿石时哪些动画应当被绘制。"
 
-#: ../../Fixed-or-Improved-Logics.md:923
+#: ../../Fixed-or-Improved-Logics.md:934
 msgid ""
 "[SOMETECHNO]                     ; TechnoType\n"
 "OreGathering.Anims=              ; List of AnimationTypes\n"
@@ -3615,11 +3636,11 @@ msgstr ""
 "OreGathering.FramesPerDir=15     ; List of integers\n"
 "OreGathering.Tiberiums=0         ; List of Tiberium IDs\n"
 
-#: ../../Fixed-or-Improved-Logics.md:930
+#: ../../Fixed-or-Improved-Logics.md:941
 msgid "Customizable target evaluation map zone check behaviour"
 msgstr "自定义目标评估地图区域检查行为"
 
-#: ../../Fixed-or-Improved-Logics.md:932
+#: ../../Fixed-or-Improved-Logics.md:943
 msgid ""
 "By default, any non-AircraftType units seeking targets via ScriptType "
 "team mission (action) `0 Attack Target Type` or any [attack team missions"
@@ -3635,7 +3656,7 @@ msgstr ""
 "(`TargetZoneScanType=any`) 或者仅当目标在武器射程内时才允许选择 "
 "(`TargetZoneScanType=inrange`)。"
 
-#: ../../Fixed-or-Improved-Logics.md:935
+#: ../../Fixed-or-Improved-Logics.md:946
 msgid ""
 "[SOMETECHNO]             ; TechnoType\n"
 "TargetZoneScanType=same  ; target zone scan enumeration "
@@ -3645,11 +3666,11 @@ msgstr ""
 "TargetZoneScanType=same  ; target zone scan enumeration "
 "(same|any|inrange)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:940
+#: ../../Fixed-or-Improved-Logics.md:951
 msgid "Customizable Teleport/Chrono Locomotor settings per TechnoType"
 msgstr "自定义超时空运动设置"
 
-#: ../../Fixed-or-Improved-Logics.md:942
+#: ../../Fixed-or-Improved-Logics.md:953
 msgid ""
 "![image](_static/images/cust-Chrono.gif) *Chrono Legionnaire and Ronco "
 "using different teleportation settings in [YR: New "
@@ -3659,18 +3680,18 @@ msgstr ""
 "War](https://www.moddb.com/mods/yuris-revenge-new-war) 中的超时空军团兵与 Ronco "
 "使用不同的超时空设置*"
 
-#: ../../Fixed-or-Improved-Logics.md:945
+#: ../../Fixed-or-Improved-Logics.md:956
 msgid ""
 "You can now specify Teleport/Chrono Locomotor settings per TechnoType to "
 "override default rules values. Unfilled values default to values in "
 "`[General]`."
 msgstr "现在你可以为每个科技类型指定其超时空运动方式设置以覆盖默认规则的值。未填充值则默认使用 `[General]` 中的值。"
 
-#: ../../Fixed-or-Improved-Logics.md:946
+#: ../../Fixed-or-Improved-Logics.md:957
 msgid "Only applicable to Techno that have Teleport/Chrono Locomotor attached."
 msgstr "仅对使用超时空运动方式的科技类型有效。"
 
-#: ../../Fixed-or-Improved-Logics.md:949
+#: ../../Fixed-or-Improved-Logics.md:960
 msgid ""
 "[SOMETECHNO]            ; TechnoType\n"
 "WarpOut=                ; Anim (played when Techno warping out), default "
@@ -3706,18 +3727,18 @@ msgstr ""
 "within which the delay is constant\n"
 "ChronoDelay=            ; integer, delay after teleport for chronosphere\n"
 
-#: ../../Fixed-or-Improved-Logics.md:961
+#: ../../Fixed-or-Improved-Logics.md:972
 msgid "Customizable unit image in art"
 msgstr "在 art 中自定义单位图像"
 
-#: ../../Fixed-or-Improved-Logics.md:963
+#: ../../Fixed-or-Improved-Logics.md:974
 msgid ""
 "`Image` tag in art INI is no longer limited to AnimationTypes and "
 "BuildingTypes, and can be applied to all TechnoTypes (InfantryTypes, "
 "VehicleTypes, AircraftTypes, BuildingTypes)."
 msgstr "art INI 中的 `Image` 标签不再局限于动画类型和建筑类型，而是作用于所有科技类型（步兵类型、载具类型、战机类型、建筑类型）。"
 
-#: ../../Fixed-or-Improved-Logics.md:964
+#: ../../Fixed-or-Improved-Logics.md:975
 msgid ""
 "The tag specifies **only** the file name (without extension) of the asset"
 " that replaces TechnoType's graphics. If the name in `Image` is also an "
@@ -3726,45 +3747,45 @@ msgstr ""
 "这个标签**仅**指定替代科技类型图像的文件名（无扩展名）。如果 `Image` 中的名称也是 art INI "
 "中的一个条目，那么**不会从中读取任何标签**。"
 
-#: ../../Fixed-or-Improved-Logics.md:965
+#: ../../Fixed-or-Improved-Logics.md:976
 msgid ""
 "**By default this feature is disabled** to remain compatible with YR. To "
 "use this feature, enable it in rules with `ArtImageSwap=true`."
 msgstr "**此功能默认关闭**以保持对 YR 原行为的兼容。为使用该功能，需要在 rules 中使用 `ArtImageSwap=true` 来开启。"
 
-#: ../../Fixed-or-Improved-Logics.md:966
+#: ../../Fixed-or-Improved-Logics.md:977
 msgid ""
 "This feature supports SHP images for InfantryTypes, SHP and VXL images "
 "for VehicleTypes and VXL images for AircraftTypes."
 msgstr "此功能仅支持 Shape 图像用于步兵类型，Shape 与 Voxel 图像用于载具类型以及 Voxel 图像用于战机类型。"
 
-#: ../../Fixed-or-Improved-Logics.md:969
-msgid ""
-"[General]\n"
-"ArtImageSwap=false  ; disabled by default\n"
-msgstr ""
-"[General]\n"
-"ArtImageSwap=false  ; disabled by default\n"
-
-#: ../../Fixed-or-Improved-Logics.md:975
-msgid ""
-"[SOMETECHNO]        ; TechnoType\n"
-"Image=              ; name of the file that will be used as image, "
-"without extension\n"
-msgstr ""
-"[SOMETECHNO]        ; TechnoType\n"
-"Image=              ; name of the file that will be used as image, "
-"without extension\n"
-
 #: ../../Fixed-or-Improved-Logics.md:980
+msgid ""
+"[General]\n"
+"ArtImageSwap=false  ; disabled by default\n"
+msgstr ""
+"[General]\n"
+"ArtImageSwap=false  ; disabled by default\n"
+
+#: ../../Fixed-or-Improved-Logics.md:986
+msgid ""
+"[SOMETECHNO]        ; TechnoType\n"
+"Image=              ; name of the file that will be used as image, "
+"without extension\n"
+msgstr ""
+"[SOMETECHNO]        ; TechnoType\n"
+"Image=              ; name of the file that will be used as image, "
+"without extension\n"
+
+#: ../../Fixed-or-Improved-Logics.md:991
 msgid "Customizable veterancy insignias"
 msgstr "自定义等级军衔"
 
-#: ../../Fixed-or-Improved-Logics.md:982
+#: ../../Fixed-or-Improved-Logics.md:993
 msgid "You can now customize veterancy insignia of TechnoTypes."
 msgstr "现在可以自定义科技类型的等级军衔。"
 
-#: ../../Fixed-or-Improved-Logics.md:983
+#: ../../Fixed-or-Improved-Logics.md:994
 msgid ""
 "`Insignia.(Rookie|Veteran|Elite)` can be used to set a custom insignia "
 "file, optionally for each veterancy stage. Like the original / default "
@@ -3773,7 +3794,7 @@ msgstr ""
 "`Insignia.(Rookie|Veteran|Elite)` 可用于为每个等级设置一个自定义军衔文件。与原本／默认的文件 "
 "`pips.shp` 一样，它们使用 `palette.pal` 作为色盘进行绘制。"
 
-#: ../../Fixed-or-Improved-Logics.md:984
+#: ../../Fixed-or-Improved-Logics.md:995
 msgid ""
 "`InsigniaFrame(.Rookie|Veteran|Elite)` can be used to set (zero-based) "
 "frame index of the insignia to display, optionally for each veterancy "
@@ -3783,7 +3804,7 @@ msgstr ""
 "`InsigniaFrame(.Rookie|Veteran|Elite)` 可用于为每个等级阶段设置军衔的（从 0 开始的）帧索引。使用 -1 "
 "表示使用默认设置。默认设置对新兵为 -1（无），对老兵为 14，对精英为 15。"
 
-#: ../../Fixed-or-Improved-Logics.md:985
+#: ../../Fixed-or-Improved-Logics.md:996
 msgid ""
 "A shorthand `InsigniaFrames` can be used to list them in order from "
 "rookie, veteran and elite instead as well. "
@@ -3792,7 +3813,7 @@ msgstr ""
 "也可以使用简写 `InsigniaFrames` "
 "按顺序列出新兵、老兵和精英的帧索引。`InsigniaFrame(.Rookie|Veteran|Elite)` 的优先级高于此。"
 
-#: ../../Fixed-or-Improved-Logics.md:986
+#: ../../Fixed-or-Improved-Logics.md:997
 msgid ""
 "These settings will be overriden by the properties set in "
 "[InsigniaType](Miscellanous.md#insignia-type), if `InsigniaType` is set."
@@ -3800,7 +3821,7 @@ msgstr ""
 "如果设置了 `InsigniaType` 则上述设置会被 [InsigniaType](Miscellanous.md#insignia-"
 "type) 中定义的属性覆盖。"
 
-#: ../../Fixed-or-Improved-Logics.md:987
+#: ../../Fixed-or-Improved-Logics.md:998
 msgid ""
 "Normal insignia can be overridden for specific weapon modes of "
 "`Gunner=true` units by setting `Insignia(.Frame/.Frames).WeaponN` where "
@@ -3810,7 +3831,7 @@ msgstr ""
 "可以通过设置 `Insignia(.Frame/.Frames).WeaponN` 来为 `Gunner=true` "
 "的单位使用不同武器时换成不同的军衔，其中 `N` 表示基于 1 的武器模式索引。如果不设置，默认使用非特定模式的军衔设置。"
 
-#: ../../Fixed-or-Improved-Logics.md:988
+#: ../../Fixed-or-Improved-Logics.md:999
 msgid ""
 "These settings will be overriden by the properties set in "
 "[InsigniaType](Miscellanous.md#insignia-type), if `InsigniaType.WeaponN` "
@@ -3819,7 +3840,7 @@ msgstr ""
 "如果设置了 `InsigniaType.WeaponN` 则上述设置会被 [InsigniaType](Miscellanous.md"
 "#insignia-type) 中定义的属性覆盖。"
 
-#: ../../Fixed-or-Improved-Logics.md:989
+#: ../../Fixed-or-Improved-Logics.md:1000
 msgid ""
 "Normal insignia can be overridden when its current passenger size reaches"
 " a certain amount by setting `Insignia(.Frame/.Frames).PassengersN` where"
@@ -3832,7 +3853,7 @@ msgstr ""
 " `N` 表示当前载员数量（从 0 到运输工具 `Passengers` 的值）。如果不设置，默认无载员模式的军衔设置。如果已经设置了 "
 "`Insignia(.Frame/.Frames).WeaponN` 则覆盖该语句的效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:990
+#: ../../Fixed-or-Improved-Logics.md:1001
 msgid ""
 "These settings will be overriden by the properties set in "
 "[InsigniaType](Miscellanous.md#insignia-type), if "
@@ -3841,7 +3862,7 @@ msgstr ""
 "如果设置了 `InsigniaType.PassengersN` 则上述设置会被 [InsigniaType](Miscellanous.md"
 "#insignia-type) 中定义的属性覆盖。"
 
-#: ../../Fixed-or-Improved-Logics.md:991
+#: ../../Fixed-or-Improved-Logics.md:1002
 msgid ""
 "`Insignia.ShowEnemy` controls whether or not the insignia is shown to "
 "enemy players. Defaults to `[General] -> EnemyInsignia`, which in turn "
@@ -3850,13 +3871,13 @@ msgstr ""
 "`Insignia.ShowEnemy` 控制军衔是否对敌方玩家可见。默认为 `[General] -> "
 "EnemyInsignia`，而后者默认为 true。"
 
-#: ../../Fixed-or-Improved-Logics.md:992
+#: ../../Fixed-or-Improved-Logics.md:1003
 msgid ""
 "You can make insignias appear only on selected units using "
 "`DrawInsignia.OnlyOnSelected`."
 msgstr "你可以使用 `DrawInsignia.OnlyOnSelected` 来使军衔仅出现在被选中的单位上。"
 
-#: ../../Fixed-or-Improved-Logics.md:993
+#: ../../Fixed-or-Improved-Logics.md:1004
 msgid ""
 "Position for insignias can be adjusted by setting "
 "`DrawInsignia.AdjustPos.Infantry` for infantry, "
@@ -3867,7 +3888,7 @@ msgstr ""
 "`DrawInsignia.AdjustPos.Buildings`、为其他单位设置 `DrawInsignia.AdjustPos.Units`"
 " 来调整军衔的位置。"
 
-#: ../../Fixed-or-Improved-Logics.md:994
+#: ../../Fixed-or-Improved-Logics.md:1005
 msgid ""
 "`DrawInsignia.AdjustPos.BuildingsAnchor` can be set to an anchor point to"
 " anchor the insignia position relative to the building's selection "
@@ -3877,7 +3898,7 @@ msgstr ""
 "`DrawInsignia.AdjustPos.BuildingsAnchor` "
 "可以设置一个锚点，用于相对建筑选择框锚定军衔位置。默认情况下军衔位置未锚定到选择框。"
 
-#: ../../Fixed-or-Improved-Logics.md:995
+#: ../../Fixed-or-Improved-Logics.md:1006
 msgid ""
 "`DrawInsignia.UsePixelSelectionBracketDelta` can be set to use techno's "
 "`PixelSelectionBracketDelta` to additionally adjust insignias vertically."
@@ -3885,7 +3906,7 @@ msgstr ""
 "`DrawInsignia.UsePixelSelectionBracketDelta` 可以让军衔位置根据单位的 "
 "`PixelSelectionBracketDelta` 在竖直方向上调整位置。"
 
-#: ../../Fixed-or-Improved-Logics.md:998
+#: ../../Fixed-or-Improved-Logics.md:1009
 msgid ""
 "[General]\n"
 "EnemyInsignia=true                                          ; boolean\n"
@@ -4031,7 +4052,7 @@ msgstr ""
 "(zero-based) or -1 for default\n"
 "Insignia.ShowEnemy=                      ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1042
+#: ../../Fixed-or-Improved-Logics.md:1053
 msgid ""
 "Insignia customization besides the `InsigniaFrames` shorthand should "
 "function similarly to the equivalent feature introduced by Ares and takes"
@@ -4040,23 +4061,23 @@ msgstr ""
 "除了使用 `InsigniaFrames` 简写外，自定义军衔功能类似于 Ares 引入的相应功能，并且如果 Phobos 与 Ares "
 "一起使用则优先于 Ares 的。"
 
-#: ../../Fixed-or-Improved-Logics.md:1045
+#: ../../Fixed-or-Improved-Logics.md:1056
 msgid "Customizable wake anim"
 msgstr "自定义水波动画"
 
-#: ../../Fixed-or-Improved-Logics.md:1047
+#: ../../Fixed-or-Improved-Logics.md:1058
 msgid ""
 "You can now specify the `Wake` anim per TechnoType to override default "
 "rules value."
 msgstr "现在你可以为每个科技类型指定 `Wake` 动画以覆盖默认规则值。"
 
-#: ../../Fixed-or-Improved-Logics.md:1048
+#: ../../Fixed-or-Improved-Logics.md:1059
 msgid ""
 "`Wake.Grapple` and `Wake.Sinking` can be used to further customize wake "
 "anim when the techno is being parasited or sunken."
 msgstr "`Wake.Grapple` 和 `Wake.Sinking` 可用于在科技类型被寄生或沉没时进一步自定义水波动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:1051
+#: ../../Fixed-or-Improved-Logics.md:1062
 msgid ""
 "[SOMETECHNO]         ; TechnoType\n"
 "Wake=                ; Anim (played when Techno moving on the water), "
@@ -4074,35 +4095,35 @@ msgstr ""
 "Wake.Sinking=        ; Anim (played when Techno sinking), defaults to "
 "[TechnoType] -> Wake\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1058
+#: ../../Fixed-or-Improved-Logics.md:1069
 msgid "Customize bridge falling down damage"
 msgstr "自定义桥上坠落伤害"
 
-#: ../../Fixed-or-Improved-Logics.md:1060
+#: ../../Fixed-or-Improved-Logics.md:1071
 msgid ""
 "Now you can customize the damage a unit receives when it falls from a "
 "bridge."
 msgstr "现在你可以自定义单位从桥上坠落时受到的伤害。"
 
-#: ../../Fixed-or-Improved-Logics.md:1061
+#: ../../Fixed-or-Improved-Logics.md:1072
 msgid ""
 "`FallingDownDamage` customizes the damage a unit receives at the end of a"
 " fall. It can be a percentage or an integer."
 msgstr "`FallingDownDamage` 用于自定义单位坠落触底时所受到的伤害值，可以是比率或固定整数值。"
 
-#: ../../Fixed-or-Improved-Logics.md:1062
+#: ../../Fixed-or-Improved-Logics.md:1073
 msgid ""
 "`FallingDownDamage.Water` customizes the damage a unit receives when it "
 "falls onto the water. Defaults to `FallingDownDamage`."
 msgstr "`FallingDownDamage.Water` 用于自定义单位坠落到水中时所受的伤害值，默认同 `FallingDownDamage`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1063
+#: ../../Fixed-or-Improved-Logics.md:1074
 msgid ""
 "If it is a negative percentage, corresponding damage will be dealt based "
 "on the current health of the unit."
 msgstr "若设置负百分比则会根据单位当前生命值按比例造成对应伤害。"
 
-#: ../../Fixed-or-Improved-Logics.md:1066
+#: ../../Fixed-or-Improved-Logics.md:1077
 msgid ""
 "[SOMETECHNO]                    ; TechnoType\n"
 "FallingDownDamage=              ; integer / percentage\n"
@@ -4112,11 +4133,11 @@ msgstr ""
 "FallingDownDamage=              ; integer / percentage\n"
 "FallingDownDamage.Water=        ; integer / percentage\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1072
+#: ../../Fixed-or-Improved-Logics.md:1083
 msgid "Customize resource storage"
 msgstr "自定义资源储存"
 
-#: ../../Fixed-or-Improved-Logics.md:1074
+#: ../../Fixed-or-Improved-Logics.md:1085
 msgid ""
 "Now Ares `Storage` feature can set which Tiberium type from `[Tiberiums]`"
 " list should be used for storing resources in structures with "
@@ -4125,11 +4146,11 @@ msgstr ""
 "现在 Ares 的 `Storage` 功能可以设置 `[Tiberiums]` 列表中的哪种类型被用于在拥有 "
 "`Refinery.UseStorage=yes` 且 `Storage` > 0 的结构中存储。"
 
-#: ../../Fixed-or-Improved-Logics.md:1075
+#: ../../Fixed-or-Improved-Logics.md:1086
 msgid "This tag can not be used without Ares."
 msgstr "此标签无法在没有 Ares 的情况下使用。"
 
-#: ../../Fixed-or-Improved-Logics.md:1078
+#: ../../Fixed-or-Improved-Logics.md:1089
 msgid ""
 "[General]\n"
 "Storage.TiberiumIndex=-1  ; integer, [Tiberiums] list index\n"
@@ -4137,18 +4158,18 @@ msgstr ""
 "[General]\n"
 "Storage.TiberiumIndex=-1  ; integer, [Tiberiums] list index\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1083
+#: ../../Fixed-or-Improved-Logics.md:1094
 msgid "Customizing effect of level lighting on air units"
 msgstr "自定义光照等级对空中单位的影响"
 
-#: ../../Fixed-or-Improved-Logics.md:1085
+#: ../../Fixed-or-Improved-Logics.md:1096
 msgid ""
 "It is now possible to customize how air units are affected by level "
 "lighting, separately for AircraftTypes and infantry/vehicles with Jumpjet"
 " `Locomotor`."
 msgstr "现在可以分别针战机类型和使用 `Locomotor=Jumpjet` 的步兵／载具自定义空中单位所受光照等级影响的方式。"
 
-#: ../../Fixed-or-Improved-Logics.md:1086
+#: ../../Fixed-or-Improved-Logics.md:1097
 msgid ""
 "`AircraftLevelLightMultiplier` & `JumpjetLevelLightMultiplier` are direct"
 " multipliers to level lighting applied on the units, for height levels "
@@ -4157,7 +4178,7 @@ msgstr ""
 "`AircraftLevelLightMultiplier` 和 `JumpjetLevelLightMultiplier` "
 "是直接用于单位的光照等级强度倍率，适用于它们所飞掠单元格的高度。"
 
-#: ../../Fixed-or-Improved-Logics.md:1089
+#: ../../Fixed-or-Improved-Logics.md:1100
 msgid ""
 "[AudioVisual]\n"
 "AircraftLevelLightMultiplier=1.0  ; floating point value, percents or "
@@ -4171,23 +4192,23 @@ msgstr ""
 "JumpjetLevelLightMultiplier=0.0   ; floating point value, percents or "
 "absolute\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1095
+#: ../../Fixed-or-Improved-Logics.md:1106
 msgid "Damaged speed customization"
 msgstr "自定义伤残速度"
 
-#: ../../Fixed-or-Improved-Logics.md:1097
+#: ../../Fixed-or-Improved-Logics.md:1108
 msgid ""
 "In vanilla, units using drive/ship loco will has hardcoded speed "
 "multiplier when damaged. Now you can customize it."
 msgstr "原版中 `Locomotor` 使用 `Drive`／`Ship` 的单位在伤残时有一个硬编码的速度倍率。现在你可以自由定义了。"
 
-#: ../../Fixed-or-Improved-Logics.md:1098
+#: ../../Fixed-or-Improved-Logics.md:1109
 msgid ""
 "The max valuebale value is 1.0, you cannot make unit get faster on yellow"
 " condition by it."
 msgstr "最大有效值为 1.0，你无法凭借这个逻辑让单位在黄血时变得更快。"
 
-#: ../../Fixed-or-Improved-Logics.md:1101
+#: ../../Fixed-or-Improved-Logics.md:1112
 msgid ""
 "[General]\n"
 "DamagedSpeed=0.75        ; floating point value, multiplier\n"
@@ -4201,11 +4222,78 @@ msgstr ""
 "[SOMETECHNO]             ; TechnoType\n"
 "DamagedSpeed=            ; floating point value, multiplier\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1109
+#: ../../Fixed-or-Improved-Logics.md:1120
+msgid "Debris voxel animations limitation"
+msgstr "Voxel 碎片数量限制"
+
+#: ../../Fixed-or-Improved-Logics.md:1122
+#: ../../Fixed-or-Improved-Logics.md:1883
+msgid ""
+"Now, the original `DebrisMaximums` can be used in conjunction with new "
+"`DebrisMinimums` to limit the quantity of `DebrisTypes` when "
+"`DebrisTypes.Limit` is enabled."
+msgstr ""
+"当启用 `DebrisTypes.Limit` 时可通过原有的 `DebrisMaximums` 结合新增的 `DebrisMinimums` 共同限制 `DebrisTypes` 的数量。"
+
+#: ../../Fixed-or-Improved-Logics.md:1123
+#: ../../Fixed-or-Improved-Logics.md:1884
+msgid ""
+"The default value of `DebrisTypes.Limit` is whether the number of "
+"`DebrisMaximums` is greater than (not equal to) 1 (for compatibility "
+"reasons)."
+msgstr ""
+"出于兼容目的，若 `DebrisMaximums` 大于（不包括等于）1 则默认启用 `DebrisTypes.Limit`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1126
+msgid ""
+"[SOMETECHNO]        ; TechnoType\n"
+"DebrisTypes.Limit=  ; boolean\n"
+"DebrisMaximums=     ; List of integers\n"
+"DebrisMinimums=     ; List of integers\n"
+msgstr ""
+"[SOMETECHNO]        ; TechnoType\n"
+"DebrisTypes.Limit=  ; boolean\n"
+"DebrisMaximums=     ; List of integers\n"
+"DebrisMinimums=     ; List of integers\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1134
+msgid "How to generate `DebrisTypes` in the game:"
+msgstr "游戏如何生成 `DebrisTypes`："
+
+#: ../../Fixed-or-Improved-Logics.md:1135
+msgid ""
+"Generate the total number of debris through `MaxDebris` and `MinDebris` "
+"first."
+msgstr ""
+"首先通过 `MaxDebris` 与 `MinDebris` 确定所要生成碎片的总量。"
+
+#: ../../Fixed-or-Improved-Logics.md:1136
+msgid ""
+"Traverse `DebrisTypes` and limit the quantity range through "
+"`DebrisMaximums` and `DebrisMinimums`."
+msgstr ""
+"遍历 `DebrisTypes` 列表并通过 `DebrisMaximums` 和 `DebrisMinimums` 限制数量范围。"
+
+#: ../../Fixed-or-Improved-Logics.md:1137
+msgid ""
+"When the number of generated debris will exceeds the total number, limit "
+"the quantity and end the traversal."
+msgstr ""
+"当已生成碎片数量将要超过总量时限制数量并停止遍历。"
+
+#: ../../Fixed-or-Improved-Logics.md:1138
+msgid ""
+"When the number of debris generated after a single traversal is not "
+"enough to exceed the total number, it will end if `DebrisTypes.Limit` is "
+"enabled, otherwise the traversal will restart like vanilla game do."
+msgstr ""
+"当遍历完成但碎片的数量并未达到总量时，若启用 `DebrisTypes.Limit` 则直接结束，否则按原版游戏机制重新进行遍历。"
+
+#: ../../Fixed-or-Improved-Logics.md:1141
 msgid "Exploding object customizations"
 msgstr "爆炸对象的自定义"
 
-#: ../../Fixed-or-Improved-Logics.md:1111
+#: ../../Fixed-or-Improved-Logics.md:1143
 msgid ""
 "By default `Explodes=true` TechnoTypes have all of their passengers "
 "killed when they are destroyed. This behaviour can now be disabled by "
@@ -4214,7 +4302,7 @@ msgstr ""
 "默认情况下 `Explodes=true` 的科技类型被摧毁时它们的所有乘客都会被击杀。现在可以通过设置 "
 "`Explodes.KillPassengers=false` 禁用此行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1112
+#: ../../Fixed-or-Improved-Logics.md:1144
 msgid ""
 "BuildingTypes with `Explodes=true` can by default explode even when they "
 "are still being built or sold. This can be disabled by setting "
@@ -4225,7 +4313,7 @@ msgstr ""
 "`Explodes.DuringBuildup` 为 false 来禁用。这样它们在建造或出售过程中会表现得像是 `Explodes` 被设为 "
 "false 一样。"
 
-#: ../../Fixed-or-Improved-Logics.md:1115
+#: ../../Fixed-or-Improved-Logics.md:1147
 msgid ""
 "[SOMETECHNO]                 ; TechnoType\n"
 "Explodes.KillPassengers=true ; boolean\n"
@@ -4239,30 +4327,30 @@ msgstr ""
 "[SOMEBUILDING]               ; BuildingType\n"
 "Explodes.DuringBuildup=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1123
+#: ../../Fixed-or-Improved-Logics.md:1155
 msgid "Forbid parallel AI queues"
 msgstr "禁止 AI 并行生产队列"
 
-#: ../../Fixed-or-Improved-Logics.md:1125
+#: ../../Fixed-or-Improved-Logics.md:1157
 msgid ""
 "You can now set if specific types of factories do not have AI production "
 "cloning issue instead of Ares' indiscriminate behavior of "
 "`AllowParallelAIQueues=no`."
 msgstr "现在你可以设置特定类型的工厂是否禁用 AI 克隆生产而不是 Ares 的 `AllowParallelAIQueues=no` 那样全部禁用。"
 
-#: ../../Fixed-or-Improved-Logics.md:1126
+#: ../../Fixed-or-Improved-Logics.md:1158
 msgid ""
 "If `AllowParallelAIQueues=no` *(Ares feature)* is set, the tags have no "
 "effect."
 msgstr "如果 `AllowParallelAIQueues=no`（*Ares 功能*）被设置，该标签无效。"
 
-#: ../../Fixed-or-Improved-Logics.md:1127
+#: ../../Fixed-or-Improved-Logics.md:1159
 msgid ""
 "You can also exclude specific TechnoTypes from being built in parallel by"
 " AI by setting `ForbidParallelAIQueues` to true on a TechnoType."
 msgstr "你还可以通过在科技类型上将 `ForbidParallelAIQueues` 设为 true 来禁止特定科技类型被 AI 克隆生产。"
 
-#: ../../Fixed-or-Improved-Logics.md:1130
+#: ../../Fixed-or-Improved-Logics.md:1162
 msgid ""
 "[GlobalControls]\n"
 "AllowParallelAIQueues=yes           ; must be set yes/true unless you "
@@ -4288,11 +4376,11 @@ msgstr ""
 "[SOMETECHNO]                        ; TechnoType\n"
 "ForbidParallelAIQueues=false        ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1143
+#: ../../Fixed-or-Improved-Logics.md:1175
 msgid "Iron Curtain & Force Shield effects on organics customization"
 msgstr "铁幕和力场护盾对有机体效果的自定义"
 
-#: ../../Fixed-or-Improved-Logics.md:1145
+#: ../../Fixed-or-Improved-Logics.md:1177
 msgid ""
 "In vanilla game, when Iron Curtain is applied on `Organic=true` units "
 "like squids or infantry, they could only get killed instantly by "
@@ -4304,24 +4392,24 @@ msgstr ""
 "瞬间击杀。现在此行为已被解除硬编码，并且可以通过全局的 `IronCurtain.EffectOnOrganics` 和每个科技类型的 "
 "`IronCurtain.Effect` 属性来自定义。可接受的值如下："
 
-#: ../../Fixed-or-Improved-Logics.md:1146
+#: ../../Fixed-or-Improved-Logics.md:1178
 msgid ""
 "`kill` : Iron Curtain kills the organic object with a specifc warhead. "
 "This is the default value for `Organic=true` units and infantry if not "
 "otherwise specified."
 msgstr "`kill`：铁幕会用特定的弹头杀死有机体，这是 `Organic=true` 单位和步兵的默认值，除非专门指定。"
 
-#: ../../Fixed-or-Improved-Logics.md:1147
+#: ../../Fixed-or-Improved-Logics.md:1179
 msgid ""
 "`invulnerable` : Iron Curtain makes the organic object invulnerable like "
 "buildings and vehicles."
 msgstr "`invulnerable`：铁幕会使有机体像建筑和载具一样获得无敌效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:1148
+#: ../../Fixed-or-Improved-Logics.md:1180
 msgid "`ignore` : Iron Curtain doesn't give any effect on the organic object."
 msgstr "`ignore`：铁幕不会对有机体造成任何影响。"
 
-#: ../../Fixed-or-Improved-Logics.md:1149
+#: ../../Fixed-or-Improved-Logics.md:1181
 msgid ""
 "`IronCurtain.KillOrganicsWarhead` and `IronCurtain.KillWarhead` can be "
 "used to customize the Warhead used to kill units, globally or per "
@@ -4332,11 +4420,11 @@ msgstr ""
 "可用于自定义击杀单位的弹头，前者用于全局设置，后者用于单独的科技类型基础设置，后者默认为前者，前者默认为 `[CombatDamage] -> "
 "C4Warhead`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1150
+#: ../../Fixed-or-Improved-Logics.md:1182
 msgid "Identical controls are available for Force Shield as well."
 msgstr "力场护盾也有相同的控制选项。"
 
-#: ../../Fixed-or-Improved-Logics.md:1153
+#: ../../Fixed-or-Improved-Logics.md:1185
 msgid ""
 "[CombatDamage]\n"
 "IronCurtain.EffectOnOrganics=kill  ; Iron Curtain effect Enumeration "
@@ -4372,17 +4460,17 @@ msgstr ""
 " | invulnerable | ignore)\n"
 "ForceShield.KillWarhead=           ; WarheadType\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1167
+#: ../../Fixed-or-Improved-Logics.md:1199
 msgid "Iron Curtain & Force Shield extra tint intensity"
 msgstr "铁幕和力场护盾的额外染色强度"
 
-#: ../../Fixed-or-Improved-Logics.md:1169
+#: ../../Fixed-or-Improved-Logics.md:1201
 msgid ""
 "It is now possible to specify additional tint intensity applied to Iron "
 "Curtained and Force Shielded units."
 msgstr "现在可以指定应用于处于铁幕和力场护盾中的单位的额外染色强度。"
 
-#: ../../Fixed-or-Improved-Logics.md:1172
+#: ../../Fixed-or-Improved-Logics.md:1204
 msgid ""
 "[AudioVisual]\n"
 "IronCurtain.ExtraTintIntensity=0.0  ; floating point value\n"
@@ -4392,17 +4480,17 @@ msgstr ""
 "IronCurtain.ExtraTintIntensity=0.0  ; floating point value\n"
 "ForceShield.ExtraTintIntensity=0.0  ; floating point value\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1178
+#: ../../Fixed-or-Improved-Logics.md:1210
 msgid "Jumpjet rotating on crashing toggle"
 msgstr "Jumpjet 旋转着坠毁的开关"
 
-#: ../../Fixed-or-Improved-Logics.md:1180
+#: ../../Fixed-or-Improved-Logics.md:1212
 msgid ""
 "Jumpjet that is going to crash starts to change its facing "
 "uncontrollably, this can now be turned off."
 msgstr "即将坠毁的 Jumpjet 会开始不可控地改变其朝向，现在可以将其关闭。"
 
-#: ../../Fixed-or-Improved-Logics.md:1183
+#: ../../Fixed-or-Improved-Logics.md:1215
 msgid ""
 "[SOMETECHNO]               ; TechnoType\n"
 "JumpjetRotateOnCrash=true  ; boolean\n"
@@ -4410,25 +4498,25 @@ msgstr ""
 "[SOMETECHNO]               ; TechnoType\n"
 "JumpjetRotateOnCrash=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1189
+#: ../../Fixed-or-Improved-Logics.md:1221
 msgid "This may subject to further changes."
 msgstr "这可能会在未来进一步更改。"
 
-#: ../../Fixed-or-Improved-Logics.md:1192
+#: ../../Fixed-or-Improved-Logics.md:1224
 msgid "Kill spawns on low power"
 msgstr "断电时击杀子机"
 
-#: ../../Fixed-or-Improved-Logics.md:1194
+#: ../../Fixed-or-Improved-Logics.md:1226
 msgid ""
 "`Powered=yes` structures that spawns aircraft like Aircrafts Carriers "
 "will stop targeting the enemy if low power."
 msgstr "拥有 `Powered=yes` 的建筑航母在断电时将会停止攻击敌人。"
 
-#: ../../Fixed-or-Improved-Logics.md:1195
+#: ../../Fixed-or-Improved-Logics.md:1227
 msgid "Spawned aircrafts self-destruct if they are flying."
 msgstr "被生成的战机如果正在飞行那么会自毁。"
 
-#: ../../Fixed-or-Improved-Logics.md:1198
+#: ../../Fixed-or-Improved-Logics.md:1230
 msgid ""
 "[SOMESTRUCTURE]          ; BuildingType\n"
 "Powered.KillSpawns=false ; boolean\n"
@@ -4436,17 +4524,17 @@ msgstr ""
 "[SOMESTRUCTURE]          ; BuildingType\n"
 "Powered.KillSpawns=false ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1203
+#: ../../Fixed-or-Improved-Logics.md:1235
 msgid "PipScale pip customizations"
 msgstr "自定义 PipScale"
 
-#: ../../Fixed-or-Improved-Logics.md:1205
+#: ../../Fixed-or-Improved-Logics.md:1237
 msgid ""
 "It is now possible to change the size of pips (or more accurately the "
 "pixel increment to the next pip drawn) displayed on `PipScale`."
 msgstr "现在可以更改在 `PipScale` 中显示的 pip 的大小（或者更确切的说是绘制下一个 pip 的像素增量）。"
 
-#: ../../Fixed-or-Improved-Logics.md:1206
+#: ../../Fixed-or-Improved-Logics.md:1238
 msgid ""
 "`Pips.Generic.(Buildings.)Size` is for non-ammo pips on non-building "
 "TechnoTypes / buildings, accordingly, and `Pips.Ammo.(Buildings.)Size` is"
@@ -4456,17 +4544,17 @@ msgstr ""
 "`Pips.Generic.(Buildings.)Size` 用于非建筑科技类型／建筑的非弹药 "
 "pip，相应的，`Pips.Ammo.(Buildings.)Size` 则是针对弹药 pip，同样分别对应非建筑科技类型／建筑。"
 
-#: ../../Fixed-or-Improved-Logics.md:1207
+#: ../../Fixed-or-Improved-Logics.md:1239
 msgid ""
 "Ammo pip size can also be overridden on per TechnoType-basis using "
 "`AmmoPipSize`."
 msgstr "还可以通过 `AmmoPipSize` 为每个科技类型重写弹药 pip 的大小。"
 
-#: ../../Fixed-or-Improved-Logics.md:1208
+#: ../../Fixed-or-Improved-Logics.md:1240
 msgid "Ammo pip frames can now also be customized."
 msgstr "现在也可以自定义弹药  pip 的帧。"
 
-#: ../../Fixed-or-Improved-Logics.md:1209
+#: ../../Fixed-or-Improved-Logics.md:1241
 msgid ""
 "`AmmoPipFrame` and `EmptyAmmoPipFrame` are frames (zero-based) of "
 "`pips2.shp` used for ammo pip and empty ammo pip (this is not set by "
@@ -4475,7 +4563,7 @@ msgstr ""
 "`AmmoPipFrame` 和 `EmptyAmmoPipFrame` 是在 `PipWrap=0`（这是默认行为）时使用的 "
 "`pips2.shp` 中（从 0 开始的）帧，用于弹药 pip 和空弹药 pip。"
 
-#: ../../Fixed-or-Improved-Logics.md:1210
+#: ../../Fixed-or-Improved-Logics.md:1242
 msgid ""
 "`AmmoPipWrapStartFrame` is used as start frame (zero-based, from "
 "`pips2.shp`) for when `PipWrap` is above 0. The start frame is the empty "
@@ -4485,21 +4573,21 @@ msgstr ""
 "`AmmoPipWrapStartFrame` 用作 `PipWrap` 大于 0 时将 `pips2.shp` 中（从 0 "
 "开始的）帧设为起始帧。起始帧是空帧，从起始帧之后最多有 `Ammo` 除以 `PipWrap` 个帧用于不同的装填阶段。"
 
-#: ../../Fixed-or-Improved-Logics.md:1211
+#: ../../Fixed-or-Improved-Logics.md:1243
 msgid "`AmmoPipOffset` can be used to shift the starting position of ammo pips."
 msgstr "`AmmoPipOffset` 可用于移动弹药 pip 的起始位置。"
 
-#: ../../Fixed-or-Improved-Logics.md:1212
+#: ../../Fixed-or-Improved-Logics.md:1244
 msgid "Pips for TechnoTypes with `Spawns` can now also be customized."
 msgstr "现在带有 `Spawns` 的科技类型的 pip 也可以进行自定义。"
 
-#: ../../Fixed-or-Improved-Logics.md:1213
+#: ../../Fixed-or-Improved-Logics.md:1245
 msgid ""
 "`ShowSpawnsPips` determines whether or not these pips are shown at all, "
 "as they are independent from `PipScale` setting."
 msgstr "`ShowSpawnsPips` 决定这些 pip 是否显示，因为它们与 `PipScale` 设置无关。"
 
-#: ../../Fixed-or-Improved-Logics.md:1214
+#: ../../Fixed-or-Improved-Logics.md:1246
 msgid ""
 "`SpawnsPipFrame` and `EmptySpawnsPipFrame` are frames (zero-based) of "
 "`pips.shp` (for buildings) or `pips2.shp` (for others) used for a spawnee"
@@ -4508,7 +4596,7 @@ msgstr ""
 "`SpawnsPipFrame` 和 `EmptySpawnsPipFrame` 分别是 `pips.shp`（对于建筑）或 "
 "`pips2.shp`（对于其他）中（从 0 开始的）帧，用于子机 pip 和空子机 pip。"
 
-#: ../../Fixed-or-Improved-Logics.md:1215
+#: ../../Fixed-or-Improved-Logics.md:1247
 msgid ""
 "`SpawnsPipSize` determines the pixel increment to the next pip drawn. "
 "Defaults to `[AudioVisual] -> Pips.Generic.(Buildings.)Size` if not set."
@@ -4516,19 +4604,19 @@ msgstr ""
 "`SpawnsPipSize` 决定了到下一个 pip 绘制的像素增量。若未设置则默认为 `[AudioVisual] -> "
 "Pips.Generic.(Buildings.)Size`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1216
+#: ../../Fixed-or-Improved-Logics.md:1248
 msgid ""
 "`SpawnsPipoffset` can be used to shift the starting position of spawnee "
 "pips."
 msgstr "`SpawnsPipoffset` 可以被用于移动子机 pip 的起始位置。"
 
-#: ../../Fixed-or-Improved-Logics.md:1217
+#: ../../Fixed-or-Improved-Logics.md:1249
 msgid ""
 "Pips for `Storage` can now also be customized via new keys in "
 "`[AudioVisual]`."
 msgstr "现在可以通过 `[AudioVisual]` 中的新标签来自定义 `Storage` 的 pip。"
 
-#: ../../Fixed-or-Improved-Logics.md:1218
+#: ../../Fixed-or-Improved-Logics.md:1250
 msgid ""
 "`Pips.Tiberiums.Frames` can be used to list frames (zero-based) of "
 "`pips.shp` (for buildings) or `pips2.shp` (for others) used for tiberium "
@@ -4538,13 +4626,13 @@ msgstr ""
 "`Pips.Tiberiums.Frames` 可用于列出用于泰伯利亚类型的 `pips.shp`（用于建筑）或 "
 "`pips2.shp`（用于其他）中（从 0 开始的）帧，按与泰伯利亚类型序数对应的列表排列顺序，泰伯利亚类型为 1 时默认为 5，否则为 2。"
 
-#: ../../Fixed-or-Improved-Logics.md:1219
+#: ../../Fixed-or-Improved-Logics.md:1251
 msgid ""
 "`Pips.Tiberiums.EmptyFrame` can be used to set the frame for empty slots,"
 " defaults to 0."
 msgstr "`Pips.Tiberiums.EmptyFrame` 可用于设置空槽的帧，默认为 0。"
 
-#: ../../Fixed-or-Improved-Logics.md:1220
+#: ../../Fixed-or-Improved-Logics.md:1252
 msgid ""
 "`Pips.Tiberiums.DisplayOrder` controls in which order the tiberium type "
 "pips are displayed, takes a list of tiberium type indices. Any tiberium "
@@ -4554,7 +4642,7 @@ msgstr ""
 "`Pips.Tiberiums.DisplayOrder` 控制泰伯利亚类型 pip "
 "显示的顺序，取一个泰伯利亚类型索引列表。任何未列出的将在列出后按顺序显示。"
 
-#: ../../Fixed-or-Improved-Logics.md:1221
+#: ../../Fixed-or-Improved-Logics.md:1253
 msgid ""
 "`Pips.Tiberiums.WeedFrame` controls which frame is displayed on Technos "
 "with `Weeder=yes`, takes a (zero-based) index of a frame in `pips.shp` "
@@ -4563,13 +4651,13 @@ msgstr ""
 "`Pips.Tiberiums.WeedFrame` 控制在 `Weeder=yes` 科技类型上显示的帧，使用 "
 "`pips.shp`（用于建筑）或 `pips2.shp`（用于其他）中（从 0 开始的）索引，默认为 1。"
 
-#: ../../Fixed-or-Improved-Logics.md:1222
+#: ../../Fixed-or-Improved-Logics.md:1254
 msgid ""
 "`Pips.Tiberiums.WeedEmptyFrame` can be used to set the frame for empty "
 "weed slots, defaults to 0."
 msgstr "`Pips.Tiberiums.WeedEmptyFrame` 可用于设置空置废矿槽的帧，默认为 0。"
 
-#: ../../Fixed-or-Improved-Logics.md:1225
+#: ../../Fixed-or-Improved-Logics.md:1257
 msgid ""
 "[AudioVisual]\n"
 "Pips.Generic.Size=4,0                ; X,Y, increment in pixels to next "
@@ -4649,17 +4737,17 @@ msgstr ""
 "pip\n"
 "SpawnsPipOffset=0,0                  ; X,Y, position offset from default\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1250
+#: ../../Fixed-or-Improved-Logics.md:1282
 msgid "Power drain for units"
 msgstr "单位消耗电力"
 
-#: ../../Fixed-or-Improved-Logics.md:1252
+#: ../../Fixed-or-Improved-Logics.md:1284
 msgid ""
 "Infantry, vehicles and aircraft can now drain or provide `Power` if "
 "`UnitPowerDrain=true` is set."
 msgstr "如果设置了 `UnitPowerDrain=true`，步兵、载具和战机现在都将可以消耗或提供 `Power`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1255
+#: ../../Fixed-or-Improved-Logics.md:1287
 msgid ""
 "[General]\n"
 "UnitPowerDrain=false  ; boolean\n"
@@ -4675,17 +4763,17 @@ msgstr ""
 "Power=0               ; integer, positive means output, negative means "
 "drain\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1263
+#: ../../Fixed-or-Improved-Logics.md:1295
 msgid "RadarInvisible for non-enemy house"
 msgstr "不仅限于敌方的 `RadarInvisible`"
 
-#: ../../Fixed-or-Improved-Logics.md:1265
+#: ../../Fixed-or-Improved-Logics.md:1297
 msgid ""
 "In vanilla, `RadarInvisible` is ignored if the techno is allied with the "
 "current player. Now you can change this behavior."
 msgstr "在原版游戏中 `RadarInvisible` 仅对当前非友军的玩家有效，现在你可以更改这一行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1268
+#: ../../Fixed-or-Improved-Logics.md:1300
 msgid ""
 "[SOMETECHNO]                         ; TechnoType\n"
 "RadarInvisibleToHouse=               ; Affected House Enumeration "
@@ -4697,21 +4785,21 @@ msgstr ""
 "(none|owner/self|allies/ally|team|enemies/enemy|all), default to enemy if"
 " RadarInvisible=true, none otherwise\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1273
+#: ../../Fixed-or-Improved-Logics.md:1305
 msgid "Re-enable obsolete [JumpjetControls]"
 msgstr "重启废弃的 [JumpjetControls]"
 
-#: ../../Fixed-or-Improved-Logics.md:1275
+#: ../../Fixed-or-Improved-Logics.md:1307
 msgid ""
 "Re-enable obsolete `[JumpjetControls]`, the keys in it will be as the "
 "default value of jumpjet units."
 msgstr "重启了废弃的 `[JumpjetControls]`，其中的标签将用于 Jumpjet 单位的默认值。"
 
-#: ../../Fixed-or-Improved-Logics.md:1276
+#: ../../Fixed-or-Improved-Logics.md:1308
 msgid "Moreover, added two tags for missing ones."
 msgstr "此外，新增了两个标签用于空缺项。"
 
-#: ../../Fixed-or-Improved-Logics.md:1279
+#: ../../Fixed-or-Improved-Logics.md:1311
 msgid ""
 "[JumpjetControls]\n"
 "Crash=5.0        ; floating point value\n"
@@ -4721,7 +4809,7 @@ msgstr ""
 "Crash=5.0        ; floating point value\n"
 "NoWobbles=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1286
+#: ../../Fixed-or-Improved-Logics.md:1318
 msgid ""
 "`CruiseHeight` is for `JumpjetHeight`, `WobblesPerSecond` is for "
 "`JumpjetWobbles`, `WobbleDeviation` is for `JumpjetDeviation`, and "
@@ -4732,18 +4820,18 @@ msgstr ""
 "`JumpjetWobbles`、`WobbleDeviation` 对应 `JumpjetDeviation` 以及 "
 "`Acceleration` 对应 `JumpjetAccel`。其他所有相应的标签只是去掉了 Jumpjet 前缀。"
 
-#: ../../Fixed-or-Improved-Logics.md:1289
+#: ../../Fixed-or-Improved-Logics.md:1321
 msgid "Skirmish AI behavior dehardcode"
 msgstr "遭遇战 AI 行为去硬编码"
 
-#: ../../Fixed-or-Improved-Logics.md:1291
+#: ../../Fixed-or-Improved-Logics.md:1323
 msgid ""
 "In vanilla, there is a hardcoded behavior that when an skirmish AI player"
 " has no factory and has not taken damage for a while, it will sell its "
 "buildings and set its units to hunt. This can be customized now."
 msgstr "在原版中存在一个遭遇战 AI 玩家没有 Factory 类建筑且一段时间未受到伤害将会发起卖家冲锋（让所有单位进入 Hunt）的硬编码的行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1292
+#: ../../Fixed-or-Improved-Logics.md:1324
 msgid ""
 "`[General] -> AIFireSale` and `[General] -> AIAllToHunt` control whether "
 "the AI will act selling and hunting respectively."
@@ -4751,7 +4839,7 @@ msgstr ""
 "`[General] -> AIFireSale` 和 `[General] -> AIAllToHunt` 分别控制 AI "
 "是否会执行卖家和狩猎（冲锋）行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1293
+#: ../../Fixed-or-Improved-Logics.md:1325
 msgid ""
 "`[General] -> AIFireSaleDelay` defines a timer, it will only work if "
 "`[General] -> AIFireSale` is set to `true`. When the first time the AI "
@@ -4761,23 +4849,23 @@ msgstr ""
 "`[General] -> AIFireSaleDelay` 定义了一个计时器，它只有当 `[General] -> AIFireSale` 设为"
 " true 时才会生效。当 AI 首次达到原有行为的触发条件时计时器开始计时，并在计时器到期之前阻止出售建筑的行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1294
+#: ../../Fixed-or-Improved-Logics.md:1326
 msgid ""
 "You can use these flags to make the AIs \"all in\" before they are "
 "defeated."
 msgstr "你可以用这些标签让 AI 被击败前 “全力以赴”"
 
-#: ../../Fixed-or-Improved-Logics.md:1295
+#: ../../Fixed-or-Improved-Logics.md:1327
 msgid ""
 "Another hardcoded behavior is that, when the AI deploys a MCV, it will "
 "gather all of its forces to that place. This can be toggle off now."
 msgstr "另一个硬编码行为是，当 AI 部署 MCV 时，它会将所有部队集结到该地点。现在可以关闭这一行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1296
+#: ../../Fixed-or-Improved-Logics.md:1328
 msgid "`[General] -> GatherWhenMCVDeploy` controls this behavior."
 msgstr "`[General] -> GatherWhenMCVDeploy` 控制这一行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1299
+#: ../../Fixed-or-Improved-Logics.md:1331
 msgid ""
 "[General]\n"
 "AIFireSale=true           ; boolean\n"
@@ -4791,17 +4879,17 @@ msgstr ""
 "AIAllToHunt=true          ; boolean\n"
 "GatherWhenMCVDeploy=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1307
+#: ../../Fixed-or-Improved-Logics.md:1339
 msgid "Subterranean unit travel height and speed"
 msgstr "钻地单位移动高度和速度"
 
-#: ../../Fixed-or-Improved-Logics.md:1309
+#: ../../Fixed-or-Improved-Logics.md:1341
 msgid ""
 "It is now possible to control the height at which units with subterranean"
 " (Tunnel) `Locomotor` travel, globally or per TechnoType."
 msgstr "现在可以控制拥有钻地（Tunnel）`Locomotor` 的单位移动的高度，可以在全局和每个科技类型上定义。"
 
-#: ../../Fixed-or-Improved-Logics.md:1310
+#: ../../Fixed-or-Improved-Logics.md:1342
 msgid ""
 "Subterranean movement speed is now also customizable, both globally and "
 "per TechnoType. If per-TechnoType value is negative, global value is "
@@ -4812,7 +4900,7 @@ msgstr ""
 "钻地移动速度现在也可以自定义，同样拥有全局和微观标签。如果微观标签的值为负数则使用全局值。这不会影响单位在钻地时的垂直移动速度。该速度由 "
 "`Speed` * `[General] -> TunnelSpeed` 决定。"
 
-#: ../../Fixed-or-Improved-Logics.md:1313
+#: ../../Fixed-or-Improved-Logics.md:1345
 msgid ""
 "[General]\n"
 "SubterraneanHeight=-256  ; integer, height in leptons (1/256th of a cell)"
@@ -4834,17 +4922,17 @@ msgstr ""
 "\n"
 "SubterraneanSpeed=-1     ; floating point value\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1324
+#: ../../Fixed-or-Improved-Logics.md:1356
 msgid ""
 "`SubterraneanHeight` expects negative values to be used and may behave "
 "erratically if set to above -50."
 msgstr "`SubterraneanHeight` 最好使用一个负值并且如果设置为大于 -50 的值可能会出现异常行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1327
+#: ../../Fixed-or-Improved-Logics.md:1359
 msgid "Voxel body multi-section shadows"
 msgstr "Voxel 主体多组件阴影"
 
-#: ../../Fixed-or-Improved-Logics.md:1329
+#: ../../Fixed-or-Improved-Logics.md:1361
 msgid ""
 "It is also now possible for vehicles and aircraft to display shadows for "
 "multiple sections of the voxel body at once, instead of just one section "
@@ -4856,7 +4944,7 @@ msgstr ""
 "`ShadowIndex`）指定多个组件索引来一性次显示出 Voxel 主体中多个组件的影子，而不再仅限于绘制 `ShadowIndex` "
 "所指定的单个组件。"
 
-#: ../../Fixed-or-Improved-Logics.md:1330
+#: ../../Fixed-or-Improved-Logics.md:1362
 msgid ""
 "`ShadowIndex.Frame` and `ShadowIndices.Frame` can be used to customize "
 "which frame of the HVA animation for the section from `ShadowIndex` and "
@@ -4868,7 +4956,7 @@ msgstr ""
 "`ShadowIndices` 所指定组件的 HVA 动画中显示影子时所使用的帧。-1 是一个用于表示使用当前帧的特殊值，并且 "
 "`ShadowIndices.Frame` 默认如此。"
 
-#: ../../Fixed-or-Improved-Logics.md:1333
+#: ../../Fixed-or-Improved-Logics.md:1365
 msgid ""
 "[SOMETECHNO]          ; TechnoType\n"
 "ShadowIndices=        ; List of integers (voxel section indices)\n"
@@ -4880,11 +4968,11 @@ msgstr ""
 "ShadowIndex.Frame=0   ; integer (HVA animation frame index)\n"
 "ShadowIndices.Frame=  ; List of integers (HVA animation frame indices)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1340
+#: ../../Fixed-or-Improved-Logics.md:1372
 msgid "Voxel light source customization"
 msgstr "自定义 Voxel 光源"
 
-#: ../../Fixed-or-Improved-Logics.md:1342
+#: ../../Fixed-or-Improved-Logics.md:1374
 msgid ""
 "Vanilla game applies some weird unnecessary math which resulted in the "
 "voxel light source being \"nudged\" up by a bit and light being applied "
@@ -4893,7 +4981,7 @@ msgstr ""
 "原本的游戏中使用了一些奇怪且不必要的数学计算导致 Voxel 的光源被 “微调” 向上了一些并在倾斜的 Voxel "
 "上光照效果不正确。现在可以修复这个问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:1345
+#: ../../Fixed-or-Improved-Logics.md:1377
 msgid ""
 "Please note that enabling this will remove the vertical offset vanilla "
 "engine applies to the light source position. Assuming vanilla lighting "
@@ -4904,7 +4992,7 @@ msgstr ""
 "请注意启用此功能将移除原版引擎对光源位置应用的垂直偏移。假设使用原版光照这将会使光线从地下照射来更多，因此建议将 "
 "`VoxelLightSource` 的 Z 值调高。"
 
-#: ../../Fixed-or-Improved-Logics.md:1348
+#: ../../Fixed-or-Improved-Logics.md:1380
 msgid ""
 "![image](_static/images/VoxelLightSourceComparison.png) *Applying "
 "`VoxelLightSource=0.02,-0.69,0.36` (assuming "
@@ -4919,19 +5007,19 @@ msgstr ""
 "target=\"_blank\">CCS_qkl</a> 将 `VoxelLightSource=0.02,-0.69,0.36`（假设 "
 "`UseFixedVoxelLighting=false`）与默认光照分别应用于光棱坦克 Voxel*"
 
-#: ../../Fixed-or-Improved-Logics.md:1351
+#: ../../Fixed-or-Improved-Logics.md:1383
 msgid ""
 "It is now possible to change the position of the light relative to the "
 "voxels. This allows for better lighting to be set up."
 msgstr "现在可以改变光源相对于 Voxel 素材的位置。这有助于更好的设置光照。"
 
-#: ../../Fixed-or-Improved-Logics.md:1352
+#: ../../Fixed-or-Improved-Logics.md:1384
 msgid ""
 "Only the direction of the light is accounted, the distance to the voxel "
 "is not accounted."
 msgstr "仅考虑光源的方向，不考虑与 Voxel 的距离（视为平行光）"
 
-#: ../../Fixed-or-Improved-Logics.md:1353
+#: ../../Fixed-or-Improved-Logics.md:1385
 msgid ""
 "Vanilla light (assuming `UseFixedVoxelLighting=false`) is located roughly"
 " at `VoxelLightSource=0.201,-0.907,-0.362`."
@@ -4939,7 +5027,7 @@ msgstr ""
 "原版光照（假设 `UseFixedVoxelLighting=false`）大致位于 "
 "`VoxelLightSource=0.201,-0.907,-0.362`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1356
+#: ../../Fixed-or-Improved-Logics.md:1388
 msgid ""
 "[AudioVisual]\n"
 "UseFixedVoxelLighting=false  ; boolean, whether to fix the lighting\n"
@@ -4951,7 +5039,7 @@ msgstr ""
 "VoxelLightSource=            ; X,Y,Z - position of the light in the world"
 " relative to each voxel, floating point values\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1363
+#: ../../Fixed-or-Improved-Logics.md:1395
 msgid ""
 "In order to easily preview the light source settings use the [VXL Viewer "
 "and VPL Generator tool by thomassneddon](https://github.com/ThomasSneddon"
@@ -4964,18 +5052,18 @@ msgstr ""
 "renderer/releases)。使用该工具时**先将其解压**然后将需要预览的 Voxel 文件**拖拽**到工具上（辅助 VXL 和 "
 "HVA 文件必须在同一文件夹中）。"
 
-#: ../../Fixed-or-Improved-Logics.md:1365
+#: ../../Fixed-or-Improved-Logics.md:1397
 msgid ""
 "Keep in mind that the tool doesn't account for "
 "`UseFixedVoxelLighting=true` as of yet, so the values shown in tool need "
 "to be offset when putting in the game with with fixed voxel lighting."
 msgstr "请注意该工具目前尚未考虑 `UseFixedVoxelLighting=true` 的情况，因此工具中显示的值在启用该修复项的游戏中需要进行调整。"
 
-#: ../../Fixed-or-Improved-Logics.md:1368
+#: ../../Fixed-or-Improved-Logics.md:1400
 msgid "Voxel shadow scaling in air"
 msgstr "Voxel 在空中时的影子缩放"
 
-#: ../../Fixed-or-Improved-Logics.md:1370
+#: ../../Fixed-or-Improved-Logics.md:1402
 msgid ""
 "It is now possible to adjust how voxel air units (`VehicleType` & "
 "`AircraftType`) shadows scale in air. By default the shadows scale by "
@@ -4985,7 +5073,7 @@ msgstr ""
 "现在可以调整 Voxel 空中单位（载具和战机）的影子如何缩放。默认情况下如果单位拥有 `ConsideredAircraft=true` "
 "那么影子会按 `AirShadowBaseScale` （默认为 0.5）进行缩放"
 
-#: ../../Fixed-or-Improved-Logics.md:1371
+#: ../../Fixed-or-Improved-Logics.md:1403
 msgid ""
 "If `HeightShadowScaling=true`, the shadow is scaled by amount that is "
 "determined by following formula: `Max(AirShadowBaseScale ^ (currentHeight"
@@ -5002,7 +5090,7 @@ msgstr ""
 "是一个可覆盖的值，默认为最大巡航高度（`JumpjetHeight`、`FlightLevel` 等），而 "
 "`HeightShadowScaling.MinScale` 设置了缩放的下限。"
 
-#: ../../Fixed-or-Improved-Logics.md:1374
+#: ../../Fixed-or-Improved-Logics.md:1406
 msgid ""
 "[AudioVisual]\n"
 "AirShadowBaseScale=0.5            ; floating point value\n"
@@ -5020,15 +5108,15 @@ msgstr ""
 "[SOMETECHNO]                      ; TechnoType\n"
 "ShadowSizeCharacteristicHeight=   ; integer, height in leptons\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1384
+#: ../../Fixed-or-Improved-Logics.md:1416
 msgid "Terrains"
 msgstr "地形对象"
 
-#: ../../Fixed-or-Improved-Logics.md:1386
+#: ../../Fixed-or-Improved-Logics.md:1418
 msgid "Animated TerrainTypes"
 msgstr "动画化地形对象"
 
-#: ../../Fixed-or-Improved-Logics.md:1388
+#: ../../Fixed-or-Improved-Logics.md:1420
 msgid ""
 "![Waving trees](_static/images/tree-shake.gif) *Animated trees used in "
 "[Ion Shock](https://www.moddb.com/mods/tiberian-war-ionshock)*"
@@ -5036,11 +5124,11 @@ msgstr ""
 "![Waving trees](_static/images/tree-shake.gif) *[Ion "
 "Shock](https://www.moddb.com/mods/tiberian-war-ionshock) 中会动的树*"
 
-#: ../../Fixed-or-Improved-Logics.md:1388
+#: ../../Fixed-or-Improved-Logics.md:1420
 msgid "Waving trees"
 msgstr "会动的树"
 
-#: ../../Fixed-or-Improved-Logics.md:1391
+#: ../../Fixed-or-Improved-Logics.md:1423
 msgid ""
 "By default `IsAnimated`, `AnimationRate` and `AnimationProbability` only "
 "work on TerrainTypes with `SpawnsTiberium` set to true. This restriction "
@@ -5049,7 +5137,7 @@ msgstr ""
 "默认情况下 `IsAnimated`、`AnimationRate` 和 `AnimationProbability` 仅适用于 "
 "`SpawnsTiberium` 设置为 true 的地形对象。这一限制已被解除。"
 
-#: ../../Fixed-or-Improved-Logics.md:1392
+#: ../../Fixed-or-Improved-Logics.md:1424
 msgid ""
 "Length of the animation can now be customized by setting "
 "`AnimationLength` as well, defaulting to half (or quarter if [damaged "
@@ -5059,7 +5147,7 @@ msgstr ""
 "现在动画的长度可以通过设置 `AnimationLength` 来自定义，默认为地形对象图像帧数的一半（如果启用了[破损帧](#damaged-"
 "frames-and-crumbling-animation)则为四分之一）。"
 
-#: ../../Fixed-or-Improved-Logics.md:1395
+#: ../../Fixed-or-Improved-Logics.md:1427
 msgid ""
 "[SOMETERRAINTYPE]  ; TerrainType\n"
 "AnimationLength=   ; integer, number of frames\n"
@@ -5067,35 +5155,35 @@ msgstr ""
 "[SOMETERRAINTYPE]  ; TerrainType\n"
 "AnimationLength=   ; integer, number of frames\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1400
+#: ../../Fixed-or-Improved-Logics.md:1432
 msgid "Custom palette"
 msgstr "自定义色盘"
 
-#: ../../Fixed-or-Improved-Logics.md:1402
+#: ../../Fixed-or-Improved-Logics.md:1434
 msgid ""
 "You can now specify custom palette for TerrainTypes in similar manner as "
 "TechnoTypes can."
 msgstr "现在你可以像为科技类型那样为地形对象指定自定义色盘。"
 
-#: ../../Fixed-or-Improved-Logics.md:1403
+#: ../../Fixed-or-Improved-Logics.md:1435
 msgid ""
 "Note that this palette behaves like an object palette and does not use "
 "tint etc. that have been applied to the tile the TerrainType resides on "
 "like a TerrainType using tile palette would."
 msgstr "注意此色盘的行为就像原有的地形对象色盘那样不受光效影响。也就是地形对象将不会同步使用应用于地形对象所在地块上的色调。"
 
-#: ../../Fixed-or-Improved-Logics.md:1406
+#: ../../Fixed-or-Improved-Logics.md:1438
 msgid ""
 "[SOMETERRAINTYPE]  ; TerrainType\n"
 "Palette=           ; filename - excluding .pal extension and three-"
 "character theater-specific suffix\n"
 msgstr ""
 
-#: ../../Fixed-or-Improved-Logics.md:1411
+#: ../../Fixed-or-Improved-Logics.md:1443
 msgid "Customizable ore spawners"
 msgstr "自定义矿柱"
 
-#: ../../Fixed-or-Improved-Logics.md:1413
+#: ../../Fixed-or-Improved-Logics.md:1445
 msgid ""
 "![image](_static/images/ore-01.png) *Different ore spawners in [Rise of "
 "the East](https://www.moddb.com/mods/riseoftheeast)*"
@@ -5103,18 +5191,18 @@ msgstr ""
 "![image](_static/images/ore-01.png) "
 "*[东方崛起](https://www.moddb.com/mods/riseoftheeast) 中不同的矿柱*"
 
-#: ../../Fixed-or-Improved-Logics.md:1416
+#: ../../Fixed-or-Improved-Logics.md:1448
 msgid "You can now specify which type of ore certain TerrainType would generate."
 msgstr "现在你可以指定地形对象将会生成哪种矿石。"
 
-#: ../../Fixed-or-Improved-Logics.md:1417
+#: ../../Fixed-or-Improved-Logics.md:1449
 msgid ""
 "It's also now possible to specify a range value for an ore generation "
 "area different compared to standard 3x3 rectangle. Ore will be uniformly "
 "distributed across all affected cells in a spread range."
 msgstr "现在还可以指定与标准 3x3 矩形不同的矿石生成区域范围值。矿石将均匀地分布在扩散范围内所有受影响的单元格中。"
 
-#: ../../Fixed-or-Improved-Logics.md:1418
+#: ../../Fixed-or-Improved-Logics.md:1450
 msgid ""
 "You can specify which ore growth stage will be spawned and how many cells"
 " will be filled with ore per ore generation animation. Corresponding tags"
@@ -5122,7 +5210,7 @@ msgid ""
 "allow randomized growth stages from the range (inclusive)."
 msgstr "此外也可以指定将生成哪个矿石生长阶段以及每次播放矿石生成动画将会填充多少个单元格。相对应的标签接受单个整数值或两个逗号分隔的值以允许范围内（含）随机化的生长阶段。"
 
-#: ../../Fixed-or-Improved-Logics.md:1421
+#: ../../Fixed-or-Improved-Logics.md:1453
 msgid ""
 "[SOMETERRAINTYPE]             ; TerrainType\n"
 "SpawnsTiberium.Type=0         ; tiberium/ore type index\n"
@@ -5136,11 +5224,11 @@ msgstr ""
 "SpawnsTiberium.GrowthStage=3  ; integer - single or comma-sep. range\n"
 "SpawnsTiberium.CellsPerAnim=1 ; integer - single or comma-sep. range\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1429
+#: ../../Fixed-or-Improved-Logics.md:1461
 msgid "Damaged frames and crumbling animation"
 msgstr "伤残和倒坍动画"
 
-#: ../../Fixed-or-Improved-Logics.md:1431
+#: ../../Fixed-or-Improved-Logics.md:1463
 msgid ""
 "By default game shows damage frame only for TerrainTypes alive at only 1 "
 "point of health left. Because none of the original game TerrainType "
@@ -5150,7 +5238,7 @@ msgstr ""
 "默认情况下游戏在地形对象仅 1 点血时显示破损帧。由于原本游戏中的地形对象资源文件并未考虑这一点因此目前该逻辑仅限添加了 "
 "`HasDamagedFrames` 的情况下使用。"
 
-#: ../../Fixed-or-Improved-Logics.md:1432
+#: ../../Fixed-or-Improved-Logics.md:1464
 msgid ""
 "Instead of showing at 1 point of HP left, TerrainTypes switch to damaged "
 "frames once their health reaches `[AudioVisual] -> "
@@ -5160,7 +5248,7 @@ msgstr ""
 "地形对象不再在仅剩 1 点血时显示破损帧，而是在其血量达到 `[AudioVisual] -> ConditionYellow.Terrain` "
 "的百分比时才进行切换。如果未设置则默认为 `ConditionYellow`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1433
+#: ../../Fixed-or-Improved-Logics.md:1465
 msgid ""
 "In addition, TerrainTypes can now show 'crumbling' animation after their "
 "health has reached zero and before they are deleted from the map by "
@@ -5169,13 +5257,13 @@ msgstr ""
 "此外，地形对象现在可以在其血量归 0 后到从地图中删除前的这段时间中通过设置 `HasCrumblingFrames` 为 true 来显示一个 "
 "“倒坍” 动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:1434
+#: ../../Fixed-or-Improved-Logics.md:1466
 msgid ""
 "Crumbling frames start from first frame after both regular & damaged "
 "frames and ends at halfway point of the frames in TerrainType's image."
 msgstr "倒坍所用的帧从紧随于常规帧和破损帧之后的第一帧开始直到地形对象图像帧的一半处中止（另一半是影子）。"
 
-#: ../../Fixed-or-Improved-Logics.md:1435
+#: ../../Fixed-or-Improved-Logics.md:1467
 msgid ""
 "Note that the number of regular & damage frames considered for this "
 "depends on value of `HasDamagedFrames` and for `IsAnimated` TerrainTypes,"
@@ -5186,19 +5274,19 @@ msgstr ""
 "注意此处考虑的常规帧和破损帧数量取决于 `HasDamagedFrames` 的值，对于 `IsAnimated` 的地形对象则取决于 "
 "`AnimationLength` 的值（见[动画化地形对象](#animated-terraintypes)）。请谨慎操作以确保显示的帧数正确。"
 
-#: ../../Fixed-or-Improved-Logics.md:1436
+#: ../../Fixed-or-Improved-Logics.md:1468
 msgid ""
 "Sound event from `CrumblingSound` (if set) is played when crumbling "
 "animation starts playing."
 msgstr "当倒坍动画开始播放时将会播放 `CrumblingSound`（如果设置）指定的音效。"
 
-#: ../../Fixed-or-Improved-Logics.md:1437
+#: ../../Fixed-or-Improved-Logics.md:1469
 msgid ""
 "[Destroy animation & sound](New-or-Enhanced-Logics.md#destroy-animation--"
 "sound) only play after crumbling animation has finished."
 msgstr "[摧毁动画和音效](New-or-Enhanced-Logics.md#destroy-animation--sound)仅在倒坍动画结束后播放。"
 
-#: ../../Fixed-or-Improved-Logics.md:1440
+#: ../../Fixed-or-Improved-Logics.md:1472
 msgid ""
 "[AudioVisual]\n"
 "ConditionYellow.Terrain=  ; floating-point value\n"
@@ -5216,18 +5304,18 @@ msgstr ""
 "HasCrumblingFrames=false\n"
 "CrumblingSound=           ; Sound entry\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1450
-#: ../../Fixed-or-Improved-Logics.md:1475
+#: ../../Fixed-or-Improved-Logics.md:1482
+#: ../../Fixed-or-Improved-Logics.md:1507
 msgid "Minimap color customization"
 msgstr "自定义小地图颜色"
 
-#: ../../Fixed-or-Improved-Logics.md:1452
+#: ../../Fixed-or-Improved-Logics.md:1484
 msgid ""
 "TerrainTypes can now be made to display on minimap with different colors "
 "by setting `MinimapColor`."
 msgstr "现在地形对象可以通过设置 `MinimapColor` 使用不同的颜色显示在小地图上。"
 
-#: ../../Fixed-or-Improved-Logics.md:1455
+#: ../../Fixed-or-Improved-Logics.md:1487
 msgid ""
 "[SOMETERRAINTYPE]  ; TerrainType\n"
 "MinimapColor=      ; integer - Red,Green,Blue\n"
@@ -5235,29 +5323,29 @@ msgstr ""
 "[SOMETERRAINTYPE]  ; TerrainType\n"
 "MinimapColor=      ; integer - Red,Green,Blue\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1460
+#: ../../Fixed-or-Improved-Logics.md:1492
 msgid "Passable & buildable-upon TerrainTypes"
 msgstr "可通行和可建造于其上的地形对象"
 
-#: ../../Fixed-or-Improved-Logics.md:1462
+#: ../../Fixed-or-Improved-Logics.md:1494
 msgid ""
 "TerrainTypes can now be made passable or buildable upon by setting "
 "`IsPassable` or `CanBeBuiltOn`, respectively."
 msgstr "现在可以分别通过设置 `IsPassable` 或 `CanBeBuiltOn` 来让地形对象可通行或可以将建筑建造于其上。"
 
-#: ../../Fixed-or-Improved-Logics.md:1463
+#: ../../Fixed-or-Improved-Logics.md:1495
 msgid ""
 "Movement cursor is displayed on `IsPassable` TerrainTypes unless force-"
 "firing."
 msgstr "除非使用强制开火否则 `IsPassable` 的地形对象上会显示移动光标。"
 
-#: ../../Fixed-or-Improved-Logics.md:1464
+#: ../../Fixed-or-Improved-Logics.md:1496
 msgid ""
 "`CanBeBuiltOn=true` terrain objects are removed when building is placed "
 "on them."
 msgstr "`CanBeBuiltOn=true` 的地形对象在建筑建造于其上时会被移除。"
 
-#: ../../Fixed-or-Improved-Logics.md:1467
+#: ../../Fixed-or-Improved-Logics.md:1499
 msgid ""
 "[SOMETERRAINTYPE]   ; TerrainType\n"
 "IsPassable=false    ; boolean\n"
@@ -5267,17 +5355,17 @@ msgstr ""
 "IsPassable=false    ; boolean\n"
 "CanBeBuiltOn=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1473
+#: ../../Fixed-or-Improved-Logics.md:1505
 msgid "Tiberiums (ores)"
 msgstr "泰伯利亚（矿石）"
 
-#: ../../Fixed-or-Improved-Logics.md:1477
+#: ../../Fixed-or-Improved-Logics.md:1509
 msgid ""
 "Ore can now be made to display on minimap with different colors by "
 "setting `MinimapColor` on Tiberiums."
 msgstr "矿石现在可以通过设置 `MinimapColor` 使用不同的颜色显示在小地图上。"
 
-#: ../../Fixed-or-Improved-Logics.md:1480
+#: ../../Fixed-or-Improved-Logics.md:1512
 msgid ""
 "[SOMEORE]      ; Tiberium\n"
 "MinimapColor=  ; integer - Red,Green,Blue\n"
@@ -5285,15 +5373,15 @@ msgstr ""
 "[SOMEORE]      ; Tiberium\n"
 "MinimapColor=  ; integer - Red,Green,Blue\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1485
+#: ../../Fixed-or-Improved-Logics.md:1517
 msgid "Vehicles"
 msgstr "载具类型"
 
-#: ../../Fixed-or-Improved-Logics.md:1487
+#: ../../Fixed-or-Improved-Logics.md:1519
 msgid "Allow miners do area guard"
 msgstr "允许矿车区域警戒"
 
-#: ../../Fixed-or-Improved-Logics.md:1489
+#: ../../Fixed-or-Improved-Logics.md:1521
 msgid ""
 "In vanilla, when miners enter area guard mission, they immediately switch"
 " to harvest mission. Now you can make them perform area guard mission "
@@ -5302,13 +5390,13 @@ msgstr ""
 "在原版中档一个矿车进入 `Area Guard` 任务时会立即切换为 `Havrest` 任务。现在你可以让它们像其他单位那样正常执行 `Area"
 " Guard` 任务了。"
 
-#: ../../Fixed-or-Improved-Logics.md:1490
+#: ../../Fixed-or-Improved-Logics.md:1522
 msgid ""
 "We made it work only for miners controlled by the player, because this "
 "will prevent AI's miners from going work."
 msgstr "这进队玩家控制的矿车有效，因为这会阻断 AI 矿车正常工作。"
 
-#: ../../Fixed-or-Improved-Logics.md:1493
+#: ../../Fixed-or-Improved-Logics.md:1525
 msgid ""
 "[SOMEVEHICLE]                      ; VehicleType\n"
 "Harvester.CanGuardArea=no          ; boolean\n"
@@ -5316,11 +5404,11 @@ msgstr ""
 "[SOMEVEHICLE]                      ; VehicleType\n"
 "Harvester.CanGuardArea=no          ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1498
+#: ../../Fixed-or-Improved-Logics.md:1530
 msgid "Bunker entering check dehardcode"
 msgstr "去除坦克碉堡准入检查的硬编码"
 
-#: ../../Fixed-or-Improved-Logics.md:1500
+#: ../../Fixed-or-Improved-Logics.md:1532
 msgid ""
 "In vanilla, vehicles entering tank bunkers are subject to a series of "
 "hardcoding restrictions, including having to have turrets, having to have"
@@ -5330,17 +5418,17 @@ msgstr ""
 "在原版，载具进入坦克碉堡时受到一系列硬编码限制，包括必须拥有炮塔、必须拥有武器以及速度类型不能为 "
 "`SpeedType=Hover`。现在你可以跳过这些限制。"
 
-#: ../../Fixed-or-Improved-Logics.md:1501
+#: ../../Fixed-or-Improved-Logics.md:1533
 msgid "This needs to be used with `Bunkerable=yes`."
 msgstr "这需要与 `Bunkerable=yes` 共同使用。"
 
-#: ../../Fixed-or-Improved-Logics.md:1502
+#: ../../Fixed-or-Improved-Logics.md:1534
 msgid ""
 "This flag only skips the static check, that is, the check on the unit "
 "type. The dynamic check (cannot be parasitized) remains unchanged."
 msgstr "这个标签仅跳过静态检查，即对单位类型的检查。动态检查（不能处于被寄生状态）保持不变。"
 
-#: ../../Fixed-or-Improved-Logics.md:1505
+#: ../../Fixed-or-Improved-Logics.md:1537
 msgid ""
 "[SOMEVEHICLE]              ; VehicleType\n"
 "BunkerableAnyway=false     ; boolean\n"
@@ -5348,7 +5436,7 @@ msgstr ""
 "[SOMEVEHICLE]              ; VehicleType\n"
 "BunkerableAnyway=false     ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1511
+#: ../../Fixed-or-Improved-Logics.md:1543
 msgid ""
 "Skipping checks with this feature doesn't mean that vehicles and tank "
 "bunkers will interact correctly. Following the simple checks performed by"
@@ -5359,11 +5447,11 @@ msgstr ""
 "使用此功能跳过检查并不就意味着载具和坦克碉堡可以正确的交互。根据次功能提供者的简单检查，坦克碉堡的效果主要受到运动模式影响。不同运动模式进入坦克碉堡的详细信息可以在"
 " [MODENC](https://modenc.renegadeprojects.com/Bunkerable) 上找到。"
 
-#: ../../Fixed-or-Improved-Logics.md:1514
+#: ../../Fixed-or-Improved-Logics.md:1546
 msgid "Customizing crushing tilt and slowdown"
 msgstr "自定义碾压倾斜和减速"
 
-#: ../../Fixed-or-Improved-Logics.md:1516
+#: ../../Fixed-or-Improved-Logics.md:1548
 msgid ""
 "Vehicles with `Crusher=true` and `OmniCrusher=true` / "
 "`MovementZone=CrusherAll` were hardcoded to tilt when crushing vehicles /"
@@ -5377,7 +5465,7 @@ msgstr ""
 "`TiltsWhenCrusher.Vehicles` 和 `TiltsWhenCrusher.Overlays` "
 "对两种情况分别进行定义，它们都默认为 `TiltsWhenCrushes`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1517
+#: ../../Fixed-or-Improved-Logics.md:1549
 msgid ""
 "`CrushForwardTiltPerFrame` determines how much the forward tilt is "
 "adjusted per frame when crushing overlays or vehicles. Defaults to -0.02 "
@@ -5387,13 +5475,13 @@ msgstr ""
 "`CrushForwardTiltPerFrame` 决定在碾压覆盖物或载具时每帧前倾的幅度。对于 `Locomotor=Ship` "
 "的载具碾压覆盖物的时默认为 -0.02，其他情况默认为 -0.050000001。"
 
-#: ../../Fixed-or-Improved-Logics.md:1518
+#: ../../Fixed-or-Improved-Logics.md:1550
 msgid ""
 "`CrushOverlayExtraForwardTilt` is additional forward tilt applied after "
 "an overlay has been crushed by the vehicle."
 msgstr "`CrushOverlayExtraForwardTilt` 是载具碾压覆盖物后额外的向前倾斜量"
 
-#: ../../Fixed-or-Improved-Logics.md:1519
+#: ../../Fixed-or-Improved-Logics.md:1551
 msgid ""
 "It is possible to customize the movement speed slowdown when "
 "`MovementZone=CrusherAll` vehicle crushes walls by setting "
@@ -5402,7 +5490,7 @@ msgstr ""
 "可以通过设置 `CrushSlowdownMultiplier` 来自定义 `MovementZone=CrusherAll` "
 "的载具碾压围墙时移动速度的减速幅度。"
 
-#: ../../Fixed-or-Improved-Logics.md:1522
+#: ../../Fixed-or-Improved-Logics.md:1554
 msgid ""
 "[SOMEVEHICLE]                      ; VehicleType\n"
 "TiltsWhenCrushes.Vehicles=         ; boolean\n"
@@ -5418,11 +5506,11 @@ msgstr ""
 "CrushOverlayExtraForwardTilt=0.02  ; floating point value\n"
 "CrushSlowdownMultiplier=0.2        ; floating point value\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1531
+#: ../../Fixed-or-Improved-Logics.md:1563
 msgid "Destroy animations"
 msgstr "摧毁动画"
 
-#: ../../Fixed-or-Improved-Logics.md:1533
+#: ../../Fixed-or-Improved-Logics.md:1565
 msgid ""
 "`DestroyAnim` has been extended to work with VehicleTypes, with option to"
 " pick random animation if `DestroyAnim.Random` is set to true. These "
@@ -5433,7 +5521,7 @@ msgstr ""
 "那么可以随机选取其中一个动画。这些动画存储了所属方和朝向信息以供[生成单位](New-or-Enhanced-Logics.md#anim-to-"
 "unit)逻辑使用。"
 
-#: ../../Fixed-or-Improved-Logics.md:1536
+#: ../../Fixed-or-Improved-Logics.md:1568
 msgid ""
 "[SOMEVEHICLE]                          ; VehicleType\n"
 "DestroyAnim=                           ; List of AnimationTypes\n"
@@ -5443,17 +5531,17 @@ msgstr ""
 "DestroyAnim=                           ; List of AnimationTypes\n"
 "DestroyAnim.Random=true                ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1542
+#: ../../Fixed-or-Improved-Logics.md:1574
 msgid "`IsSimpleDeployer` vehicle ammo change on deploy"
 msgstr "`IsSimpleDeployer` 载具在部署时更改弹药"
 
-#: ../../Fixed-or-Improved-Logics.md:1544
+#: ../../Fixed-or-Improved-Logics.md:1576
 msgid ""
 "`Ammo.AddOnDeploy` determines the number of ammo added or substracted on "
 "unit deploy."
 msgstr "`Ammo.AddOnDeploy` 决定单位部署时增加或减少的弹药量。"
 
-#: ../../Fixed-or-Improved-Logics.md:1547
+#: ../../Fixed-or-Improved-Logics.md:1579
 msgid ""
 "[SOMEVEHICLE]           ; VehicleType\n"
 "Ammo.AddOnDeploy=0      ; integer\n"
@@ -5461,7 +5549,7 @@ msgstr ""
 "[SOMEVEHICLE]           ; VehicleType\n"
 "Ammo.AddOnDeploy=0      ; integer\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1553
+#: ../../Fixed-or-Improved-Logics.md:1585
 msgid ""
 "Due to technical constraints, units that use `Convert.Deploy` from [Ares'"
 " Type Conversion](https://ares-developers.github.io/Ares-"
@@ -5473,37 +5561,37 @@ msgstr ""
 "docs/new/typeconversion.html)逻辑 `Convert.Deploy` 的单位通过 `Ammo.AddOnDeploy`"
 " 改变类型时无论转换是否成功都会改变弹药量，这同样发生在单位离开坦克碉堡时。"
 
-#: ../../Fixed-or-Improved-Logics.md:1556
+#: ../../Fixed-or-Improved-Logics.md:1588
 msgid "`IsSimpleDeployer` vehicle auto-deploy / deploy block on ammo change"
 msgstr "`IsSimpleDeployer` 的载具根据弹药自动部署／阻止部署"
 
-#: ../../Fixed-or-Improved-Logics.md:1558
+#: ../../Fixed-or-Improved-Logics.md:1590
 msgid "Vehicle deployment can now be affected by ammo count."
 msgstr "载具的部署行为现在可以受弹药数量影响。"
 
-#: ../../Fixed-or-Improved-Logics.md:1559
+#: ../../Fixed-or-Improved-Logics.md:1591
 msgid ""
 "`Ammo.AutoDeployMinimumAmount` determines the minimal number of ammo at "
 "which a vehicle converts/deploys automatically."
 msgstr "`Ammo.AutoDeployMinimumAmount` 决定载具自动转换/部署时所需的最小弹药量。"
 
-#: ../../Fixed-or-Improved-Logics.md:1560
+#: ../../Fixed-or-Improved-Logics.md:1592
 msgid ""
 "`Ammo.DeployUnlockMinimumAmount` determines the minimal number of ammo "
 "that unlocks issuing vehicle converting/deploying command."
 msgstr "`Ammo.DeployUnlockMinimumAmount` 决定载具解除转换/部署命令的最小弹药量。"
 
-#: ../../Fixed-or-Improved-Logics.md:1561
+#: ../../Fixed-or-Improved-Logics.md:1593
 msgid ""
 "`Ammo.AutoDeployMaximumAmount` and `Ammo.DeployUnlockMaximumAmount` "
 "behave analogically."
 msgstr "`Ammo.AutoDeployMaximumAmount` 和 `Ammo.DeployUnlockMaximumAmount` 的功能与之类似。"
 
-#: ../../Fixed-or-Improved-Logics.md:1562
+#: ../../Fixed-or-Improved-Logics.md:1594
 msgid "Setting a negative number will disable ammo count check."
 msgstr "设为负数将禁用弹药数量检查。"
 
-#: ../../Fixed-or-Improved-Logics.md:1565
+#: ../../Fixed-or-Improved-Logics.md:1597
 msgid ""
 "[SOMEVEHICLE]                        ; VehicleType\n"
 "Ammo.AutoDeployMinimumAmount=-1      ; integer\n"
@@ -5517,7 +5605,7 @@ msgstr ""
 "Ammo.DeployUnlockMinimumAmount=-1    ; integer\n"
 "Ammo.DeployUnlockMaximumAmount=-1    ; integer\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1574
+#: ../../Fixed-or-Improved-Logics.md:1606
 msgid ""
 "Auto-deploy feature requires `Convert.Deploy` from [Ares' Type "
 "Conversion](https://ares-developers.github.io/Ares-"
@@ -5527,11 +5615,11 @@ msgstr ""
 "自动部署功能需要 [Ares 的单位转换](https://ares-developers.github.io/Ares-"
 "docs/new/typeconversion.html)功能来改变类型。没有启用该功能的单位将会不断尝试部署直至其弹药量变化。"
 
-#: ../../Fixed-or-Improved-Logics.md:1577
+#: ../../Fixed-or-Improved-Logics.md:1609
 msgid "IsSimpleDeployer vehicle deploy animation / direction customization"
 msgstr "自定义 IsSimpleDeployer 载具部署"
 
-#: ../../Fixed-or-Improved-Logics.md:1579
+#: ../../Fixed-or-Improved-Logics.md:1611
 msgid ""
 "`DeployingAnim.AllowAnyDirection` if set, disables any direction "
 "constraints for deployers with `DeployingAnim` set. Only works for ground"
@@ -5540,26 +5628,26 @@ msgstr ""
 "`DeployingAnim.AllowAnyDirection` 如果设置，那么将会取消所有由于 `DeployingAnim` "
 "设置而对部署者在方向上的约束。只适用于地面单位。"
 
-#: ../../Fixed-or-Improved-Logics.md:1580
+#: ../../Fixed-or-Improved-Logics.md:1612
 msgid ""
 "`DeployingAnim.KeepUnitVisible` determines if the unit is **not** hidden "
 "while the animation is playing."
 msgstr "`DeployingAnim.KeepUnitVisible` 决定单位是否在动画播放期间**不**被隐藏。"
 
-#: ../../Fixed-or-Improved-Logics.md:1581
+#: ../../Fixed-or-Improved-Logics.md:1613
 msgid ""
 "`DeployingAnim.ReverseForUndeploy` controls whether or not the animation "
 "is played in reverse for undeploying."
 msgstr "`DeployingAnim.KeepUnitVisible` 控制反部署时是否使动画反向播放。"
 
-#: ../../Fixed-or-Improved-Logics.md:1582
+#: ../../Fixed-or-Improved-Logics.md:1614
 msgid ""
 "`DeployingAnim.UseUnitDrawer` controls whether or not the animation is "
 "displayed in the unit's palette and team colours or regular animation "
 "palette, including a potential custom palette."
 msgstr "`DeployingAnim.UseUnitDrawer` 控制动画使用 unit 色盘以及所属色还是常规动画色盘，包括潜在的自定义色盘。"
 
-#: ../../Fixed-or-Improved-Logics.md:1585
+#: ../../Fixed-or-Improved-Logics.md:1617
 msgid ""
 "[SOMEVEHICLE]                          ; VehicleType\n"
 "DeployingAnim.AllowAnyDirection=false  ; boolean\n"
@@ -5573,66 +5661,66 @@ msgstr ""
 "DeployingAnim.ReverseForUndeploy=true  ; boolean\n"
 "DeployingAnim.UseUnitDrawer=true       ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1593
+#: ../../Fixed-or-Improved-Logics.md:1625
 msgid "Make harvesters do addtional scan after unload"
 msgstr "使矿车卸载后重新扫描较近的矿区"
 
-#: ../../Fixed-or-Improved-Logics.md:1595
+#: ../../Fixed-or-Improved-Logics.md:1627
 msgid ""
 "In vanilla, miners will remember their current location when they reach "
 "full load and move to that location after unloading. This makes miners to"
 " gradually move deeper into the mine and ignore the closer minerals."
 msgstr "在原版中矿车在满载时会记录当前位置并在卸载后返回该坐标。这一机制会让矿车逐渐向原矿区深处探索但却容易忽略距离更近的矿区。"
 
-#: ../../Fixed-or-Improved-Logics.md:1596
+#: ../../Fixed-or-Improved-Logics.md:1628
 msgid ""
 "Now you can have the miner search for the nearest mineral again after "
 "unloading. If a closer mineral is found, the miner will go to that "
 "location instead of the previously recorded location."
 msgstr "现在你可以让矿车在卸载后重新搜索最近的矿区。如果发现了更近的矿区那么矿车会优先前往它而不是返回先前记录的坐标。"
 
-#: ../../Fixed-or-Improved-Logics.md:1599
+#: ../../Fixed-or-Improved-Logics.md:1631
 msgid ""
 "[General]\n"
 "HarvesterScanAfterUnload=false     ; boolean\n"
 "\n"
-"[SOMEVEHICLE]\n"
+"[SOMEVEHICLE]                      ; VehicleType\n"
 "HarvesterScanAfterUnload=          ; boolean, default to [General] -> "
 "HarvesterScanAfterUnload\n"
 msgstr ""
 "[General]\n"
 "HarvesterScanAfterUnload=false     ; boolean\n"
 "\n"
-"[SOMEVEHICLE]\n"
+"[SOMEVEHICLE]                      ; VehicleType\n"
 "HarvesterScanAfterUnload=          ; boolean, default to [General] -> "
 "HarvesterScanAfterUnload\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1607
+#: ../../Fixed-or-Improved-Logics.md:1639
 msgid "Preserve Iron Curtain / Force Shield status on type conversion"
 msgstr "在单位转换时保留铁幕／力场护盾状态"
 
-#: ../../Fixed-or-Improved-Logics.md:1609
+#: ../../Fixed-or-Improved-Logics.md:1641
 msgid "![image](_static/images/preserve-ic.gif) *Bugfix in action*"
 msgstr "![image](_static/images/preserve-ic.gif) *Bug 修复后的行为*"
 
-#: ../../Fixed-or-Improved-Logics.md:1612
+#: ../../Fixed-or-Improved-Logics.md:1644
 msgid ""
 "Iron Curtain status is now preserved by default when converting between "
 "TechnoTypes via `DeploysInto` / `UndeploysInto`. Force Shield status "
 "preservation is turned off by default."
 msgstr "通过 `DeploysInto`／`UndeploysInto` 在科技类型之间的转换现在默认保留铁幕状态。力场护盾则默认不保留。"
 
-#: ../../Fixed-or-Improved-Logics.md:1613
+#: ../../Fixed-or-Improved-Logics.md:1645
 msgid "This behavior can be turned on/off per-TechnoType and on global basis."
 msgstr "这一行为可以对每个科技类型和全局进行开启／关闭。"
 
-#: ../../Fixed-or-Improved-Logics.md:1614
+#: ../../Fixed-or-Improved-Logics.md:1646
 msgid ""
 "`IronCurtain.Modifier` / `ForceShield.Modifier` (whichever is applicable)"
 " is re-applied upon type conversion."
 msgstr "`IronCurtain.Modifier`／`ForceShield.Modifier`（视情况而定）将在单位转换时刷新。"
 
-#: ../../Fixed-or-Improved-Logics.md:1617
+#: ../../Fixed-or-Improved-Logics.md:1649
 msgid ""
 "[CombatDamage]\n"
 "IronCurtain.KeptOnDeploy=true   ; boolean\n"
@@ -5656,36 +5744,36 @@ msgstr ""
 "ForceShield.KeptOnDeploy=       ; boolean, default to [CombatDamage] -> "
 "ForceShield.KeptOnDeploy\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1627
+#: ../../Fixed-or-Improved-Logics.md:1659
 msgid "Retain target on movement command"
 msgstr "在命令移动后保留目标"
 
-#: ../../Fixed-or-Improved-Logics.md:1629
+#: ../../Fixed-or-Improved-Logics.md:1661
 msgid ""
 "It is now possible for vehicles to retain their target when issued "
 "movement command by setting `KeepTargetOnMove` to true."
 msgstr "现在可以通过设置 `KeepTargetOnMove` 为 true 来使载具在接收到移动命令时保留其目标。"
 
-#: ../../Fixed-or-Improved-Logics.md:1630
+#: ../../Fixed-or-Improved-Logics.md:1662
 msgid ""
 "Note that no check is done whether or not the vehicle or the weapon can "
 "actually fire while moving, this is on modder's discretion."
 msgstr "注意这不会检查载具或武器实际上能否在移动中开火，这由 modder 自行决定。"
 
-#: ../../Fixed-or-Improved-Logics.md:1631
+#: ../../Fixed-or-Improved-Logics.md:1663
 msgid ""
 "The target is automatically reset if the vehicle moves beyond the "
 "weapon's range from the target."
 msgstr "如果由于载具移动导致目标超出武器射程那么目标将自动重置。"
 
-#: ../../Fixed-or-Improved-Logics.md:1632
+#: ../../Fixed-or-Improved-Logics.md:1664
 msgid ""
 "`KeepTargetOnMove.NoMorePursuit` controls whether the unit will restart "
 "chasing the target for attack when it stops again, otherwise it will "
 "clear the target when it moves away."
 msgstr "`KeepTargetOnMove.NoMorePursuit` 控制单位是否会在再次停止后重新开始追击目标以发起攻击，否则会在移动时清除目标。"
 
-#: ../../Fixed-or-Improved-Logics.md:1633
+#: ../../Fixed-or-Improved-Logics.md:1665
 msgid ""
 "`KeepTargetOnMove.ExtraDistance` can be used to modify the distance "
 "considered 'out of range' from target (it is added to weapon range), "
@@ -5694,7 +5782,7 @@ msgstr ""
 "`KeepTargetOnMove.ExtraDistance` 可以用来修改被认为 “超出射程” "
 "的范围（基于武器射程的修正值），负值会缩短判定距离。"
 
-#: ../../Fixed-or-Improved-Logics.md:1636
+#: ../../Fixed-or-Improved-Logics.md:1668
 msgid ""
 "[SOMEVEHICLE]                        ; VehicleType\n"
 "KeepTargetOnMove=false               ; boolean\n"
@@ -5708,25 +5796,25 @@ msgstr ""
 "KeepTargetOnMove.ExtraDistance=0     ; floating point value, distance in "
 "cells\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1643
+#: ../../Fixed-or-Improved-Logics.md:1675
 msgid "Sinking behavior dehardcode"
 msgstr "自定义沉没行为"
 
-#: ../../Fixed-or-Improved-Logics.md:1645
+#: ../../Fixed-or-Improved-Logics.md:1677
 msgid ""
 "In vanilla, whether a ship sinks when it dies on the water is determined "
 "by multiple settings of hardcoding. The speed of the sinking is hardcoded"
 " to 5 Leptons per frame."
 msgstr "原版中一艘舰船在水上死亡是否会沉没由多个硬编码设置决定。沉没速度硬编码为每帧 5 leptons。"
 
-#: ../../Fixed-or-Improved-Logics.md:1646
+#: ../../Fixed-or-Improved-Logics.md:1678
 msgid ""
 "Now you can determine whether a ship sinks with a dedicated flag "
 "`Sinkable`, and use `SinkSpeed` to customize the speed at which the ship "
 "sinks."
 msgstr "现在你可以通过专门的标签 `Sinkable` 来决定一艘舰船是否会沉没，并且可以使用 `SinkSpeed` 来定义舰船的沉没速度。"
 
-#: ../../Fixed-or-Improved-Logics.md:1647
+#: ../../Fixed-or-Improved-Logics.md:1679
 msgid ""
 "`Sinkable.SquidGrab` controls the behavior of a ship when it is killed by"
 " a squid. Set it to `false` to cause the ship to take a lethal damage "
@@ -5736,7 +5824,7 @@ msgstr ""
 "`Sinkable.SquidGrab` 控制一艘船在被巨型乌贼击杀时的行为。将其设为 false "
 "会导致舰船受到致命伤害而非在此时直接沉没（从而遵循 `Sinkable` 的设置）。"
 
-#: ../../Fixed-or-Improved-Logics.md:1650
+#: ../../Fixed-or-Improved-Logics.md:1682
 msgid ""
 "[SOMEVEHICLE]              ; VehicleType\n"
 "Sinkable=                  ; boolean\n"
@@ -5748,11 +5836,11 @@ msgstr ""
 "SinkSpeed=5                ; integer, leptons per frame\n"
 "Sinkable.SquidGrab=true    ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1657
+#: ../../Fixed-or-Improved-Logics.md:1689
 msgid "Stationary vehicles"
 msgstr "静止的载具"
 
-#: ../../Fixed-or-Improved-Logics.md:1659
+#: ../../Fixed-or-Improved-Logics.md:1691
 msgid ""
 "Setting VehicleType `Speed` to 0 now makes game treat them as stationary,"
 " behaving in very similar manner to deployed vehicles with "
@@ -5762,11 +5850,11 @@ msgstr ""
 "现在载具将在 `Speed` 设置为 0 时使游戏将它们视为静止，其行为方式非常类似于 `IsSimpleDeployer` 设置为 true "
 "的部署状态载具。不应用于可生产的载具，否则它们将无法退出工厂。"
 
-#: ../../Fixed-or-Improved-Logics.md:1661
+#: ../../Fixed-or-Improved-Logics.md:1693
 msgid "Unit Without Turret Always Turn To Target"
 msgstr "无炮塔单位始终面向目标"
 
-#: ../../Fixed-or-Improved-Logics.md:1663
+#: ../../Fixed-or-Improved-Logics.md:1695
 msgid ""
 "Now vehicles without turret will attempt to turn to the target while the "
 "weapon is cooling down, rather than after the weapon has cooled down, by "
@@ -5775,7 +5863,7 @@ msgstr ""
 "现在可以通过将 `NoTurret.TrackTarget` 设为 true "
 "来让没有炮塔的载具在武器冷却期间就尝试更改朝向以面向目标而不是等到武器冷却完成后。"
 
-#: ../../Fixed-or-Improved-Logics.md:1666
+#: ../../Fixed-or-Improved-Logics.md:1698
 msgid ""
 "[General]\n"
 "NoTurret.TrackTarget=false   ; boolean\n"
@@ -5791,7 +5879,7 @@ msgstr ""
 "NoTurret.TrackTarget=        ; boolean, defaults to [General] -> "
 "NoTurret.TrackTarget\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1675
+#: ../../Fixed-or-Improved-Logics.md:1707
 msgid ""
 "Jumpjet can also be affected by this if firing an `OmniFire` weapon with "
 "`OmniFire.TurnToTarget` set to true."
@@ -5799,11 +5887,11 @@ msgstr ""
 "如果 Jumpjet 在 `OmniFire.TurnToTarget` 设为 true 的情况下发射一个 `OmniFire` "
 "武器那么也会受到影响。"
 
-#: ../../Fixed-or-Improved-Logics.md:1678
+#: ../../Fixed-or-Improved-Logics.md:1710
 msgid "Voxel turret shadow"
 msgstr "Voxel 炮塔影子"
 
-#: ../../Fixed-or-Improved-Logics.md:1680
+#: ../../Fixed-or-Improved-Logics.md:1712
 msgid ""
 "Vehicle voxel turrets can now draw shadows if `[AudioVisual] -> "
 "DrawTurretShadow` is set to true. This can be overridden per VehicleType "
@@ -5812,7 +5900,7 @@ msgstr ""
 "如果 `[AudioVisual] -> DrawTurretShadow` 被设为 true 那么载具的 Voxel "
 "炮塔现在可以绘制影子。这可以在载具的 `artmd.ini` 小节中设置 `TurretShadow` 来覆盖。"
 
-#: ../../Fixed-or-Improved-Logics.md:1683
+#: ../../Fixed-or-Improved-Logics.md:1715
 msgid ""
 "[AudioVisual]\n"
 "DrawTurretShadow=false  ; boolean\n"
@@ -5820,7 +5908,7 @@ msgstr ""
 "[AudioVisual]\n"
 "DrawTurretShadow=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1689
+#: ../../Fixed-or-Improved-Logics.md:1721
 msgid ""
 "[SOMEVEHICLE]   ; VehicleType\n"
 "TurretShadow=   ; boolean\n"
@@ -5828,74 +5916,74 @@ msgstr ""
 "[SOMEVEHICLE]   ; VehicleType\n"
 "TurretShadow=   ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1694
+#: ../../Fixed-or-Improved-Logics.md:1726
 msgid "Customize harvester dump amount"
 msgstr "自定义矿车单次倒矿量"
 
-#: ../../Fixed-or-Improved-Logics.md:1696
+#: ../../Fixed-or-Improved-Logics.md:1728
 msgid ""
 "Now you can limit how much ore the harvester can dump out per time, like "
 "it in Tiberium Sun."
 msgstr "现在你可以限制矿车每次倒矿时卸载的矿石量，就像《泰伯利亚之日》中的设定"
 
-#: ../../Fixed-or-Improved-Logics.md:1697
+#: ../../Fixed-or-Improved-Logics.md:1729
 msgid ""
 "Less than or equal to 0 means no limit, it will always dump out all at "
 "one time."
 msgstr "若该值小于等于 0 则表示一次倒完，就像《红色警戒2》中原本的行为"
 
-#: ../../Fixed-or-Improved-Logics.md:1700
+#: ../../Fixed-or-Improved-Logics.md:1732
 msgid ""
 "[General]\n"
 "HarvesterDumpAmount=0.0               ; float point value\n"
 "\n"
-"[SOMEVEHICLE]\n"
+"[SOMEVEHICLE]                         ; VehicleType\n"
 "HarvesterDumpAmount=                  ; float point value\n"
 msgstr ""
 "[General]\n"
 "HarvesterDumpAmount=0.0               ; float point value\n"
 "\n"
-"[SOMEVEHICLE]\n"
+"[SOMEVEHICLE]                         ; VehicleType\n"
 "HarvesterDumpAmount=                  ; float point value\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1708
+#: ../../Fixed-or-Improved-Logics.md:1740
 msgid "Veinholes & Weeds"
 msgstr "泰伯利亚藤蔓与泰伯利亚废矿"
 
-#: ../../Fixed-or-Improved-Logics.md:1710
+#: ../../Fixed-or-Improved-Logics.md:1742
 msgid "Veinholes"
 msgstr "泰伯利亚藤蔓"
 
-#: ../../Fixed-or-Improved-Logics.md:1712
+#: ../../Fixed-or-Improved-Logics.md:1744
 msgid "Veinhole monsters now work like they used to in Tiberian Sun."
 msgstr "泰伯利亚藤蔓怪现在可以像《泰伯利亚之日》中那样工作。"
 
-#: ../../Fixed-or-Improved-Logics.md:1713
+#: ../../Fixed-or-Improved-Logics.md:1745
 msgid "Their core parameters are still loaded from `[General]`."
 msgstr "它们的核心参数仍然从 `[General]` 读取。"
 
-#: ../../Fixed-or-Improved-Logics.md:1714
+#: ../../Fixed-or-Improved-Logics.md:1746
 msgid ""
 "The Warhead used by veins is specified under `[CombatDamage]`. The "
 "warhead has to have `Veinhole=yes` set."
 msgstr "藤蔓的弹头在 `[CombatDamage]` 下指定。弹头必须设置 `Veinhole=yes`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1715
+#: ../../Fixed-or-Improved-Logics.md:1747
 msgid "Veinholes are hardcoded to use several overlay types."
 msgstr "泰伯利亚藤蔓被硬编码使用几种覆盖物。"
 
-#: ../../Fixed-or-Improved-Logics.md:1716
+#: ../../Fixed-or-Improved-Logics.md:1748
 msgid ""
 "The vein attack animation specified under `[AudioVisual]` is what deals "
 "the damage. The animation has to be properly listed under `[Animations]` "
 "as well."
 msgstr "泰伯利亚藤蔓造成杀伤的攻击效果动画于 `[AudioVisual]` 下指定。动画必须列于 `[Animations]` 注册表中。"
 
-#: ../../Fixed-or-Improved-Logics.md:1717
+#: ../../Fixed-or-Improved-Logics.md:1749
 msgid "Units can be made immune to veins the same way as in Tiberian Sun."
 msgstr "单位可以像在《泰伯利亚之日》中一样设置对泰伯利亚藤蔓免疫。"
 
-#: ../../Fixed-or-Improved-Logics.md:1718
+#: ../../Fixed-or-Improved-Logics.md:1750
 msgid ""
 "The monster itself is represented by the `VEINTREE` TerrainType, which "
 "has `IsVeinhole=true` set. Its strength is what determines the strength "
@@ -5904,7 +5992,7 @@ msgstr ""
 "怪物主体以 `VEINTREE` 地形对象的形式存在，其拥有 `IsVeinhole=true` 设置。并且它的 `Strength` "
 "决定了泰伯利亚藤蔓的生命值。"
 
-#: ../../Fixed-or-Improved-Logics.md:1721
+#: ../../Fixed-or-Improved-Logics.md:1753
 msgid ""
 "Everything listed below functions identically to Tiberian Sun. Many of "
 "the tags from Tiberian Sun have been re-enabled. The values provided "
@@ -5927,7 +6015,7 @@ msgstr ""
 "中的值相同。你可以在 MODENC "
 "上了解更多关于它们的信息：[VeinholeGrowthRate](https://modenc.renegadeprojects.com/VeinholeGrowthRate)、[VeinholeShrinkRate](https://modenc.renegadeprojects.com/VeinholeShrinkRate)、[MaxVeinholeGrowth](https://modenc.renegadeprojects.com/MaxVeinholeGrowth)、[VeinDamage](https://modenc.renegadeprojects.com/VeinDamage)、[VeinholeTypeClass](https://modenc.renegadeprojects.com/VeinholeTypeClass)、[VeinholeWarhead](https://modenc.renegadeprojects.com/VeinholeWarhead)、[Veinhole](https://modenc.renegadeprojects.com/Veinhole)、[VeinAttack](https://modenc.renegadeprojects.com/VeinAttack)、[ImmuneToVeins](https://modenc.renegadeprojects.com/ImmuneToVeins)、[IsVeinhole](https://modenc.renegadeprojects.com/IsVeinhole)"
 
-#: ../../Fixed-or-Improved-Logics.md:1728
+#: ../../Fixed-or-Improved-Logics.md:1760
 msgid ""
 "[General]\n"
 "VeinholeGrowthRate=300        ; integer\n"
@@ -5977,7 +6065,7 @@ msgstr ""
 "IsVeinhole=true\n"
 "Strength=1000                 ; integer - the strength of the Veinhole\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1755
+#: ../../Fixed-or-Improved-Logics.md:1787
 msgid ""
 "The game expects certain overlays related to Veinholes to have certain "
 "indices, they are listed below. Please keep in mind that the indices in "
@@ -5988,7 +6076,7 @@ msgstr ""
 "游戏需要泰伯利亚藤蔓相关的覆盖物使用特定的索引，如下所示。请注意 `OverlayTypes` 注册表中的索引是从 0 "
 "开始的，由于游戏内部规则，等号左侧的标识符无关紧要。原版 `rulesmd.ini` 已经在正确的索引处列出了所需的覆盖物。"
 
-#: ../../Fixed-or-Improved-Logics.md:1759
+#: ../../Fixed-or-Improved-Logics.md:1791
 msgid ""
 "[OverlayTypes]\n"
 "126=VEINS                     ; The veins (weeds)\n"
@@ -6000,55 +6088,55 @@ msgstr ""
 "167=VEINHOLE                  ; The Veinhole itself\n"
 "178=VEINHOLEDUMMY             ; A technical overlay\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1766
+#: ../../Fixed-or-Improved-Logics.md:1798
 msgid "Weeds & Weed Eaters"
 msgstr "泰伯利亚废矿与废矿采集者"
 
-#: ../../Fixed-or-Improved-Logics.md:1768
+#: ../../Fixed-or-Improved-Logics.md:1800
 msgid ""
 "Vehicles with `Weeder=yes` can now collect weeds. The weeds can then be "
 "deposited into a building with `Weeder=yes`."
 msgstr "拥有 `Weeder=yes` 的载具现在可以收集泰伯利亚废矿。然后这些废矿可以存入 `Weeder=yes` 的建筑中。"
 
-#: ../../Fixed-or-Improved-Logics.md:1769
+#: ../../Fixed-or-Improved-Logics.md:1801
 msgid ""
 "Weeds are not stored in a building's storage, but rather in a House's "
 "storage. The weed capacity is listed under `[General] -> WeedCapacity`."
 msgstr "泰伯利亚废矿并不是储藏在储存仓建筑中而是这个阵营的内部数据。废矿的储藏量读取自 `[General] -> WeedCapacity`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1770
+#: ../../Fixed-or-Improved-Logics.md:1802
 msgid ""
 "Weeders now show the ore gathering animation. It can be customized the "
 "same way as for harvesters."
 msgstr "废矿矿车现在可以像普通矿车那样自定义矿石采集动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:1771
+#: ../../Fixed-or-Improved-Logics.md:1803
 msgid "Weeders can use the Teleport locomotor like chrono miners."
 msgstr "废矿矿车可以像超时空矿车一样使用 Teleport 运动模式。"
 
-#: ../../Fixed-or-Improved-Logics.md:1772
+#: ../../Fixed-or-Improved-Logics.md:1804
 msgid ""
 "Total amount of weeds in storage can be displayed on sidebar, see [Weeds "
 "counter](User-Interface.md#weeds-counter)."
 msgstr "储存的废矿总量可以在侧边栏上显示，参见[废矿计数器](User-Interface.md#weeds-counter)。"
 
-#: ../../Fixed-or-Improved-Logics.md:1774
+#: ../../Fixed-or-Improved-Logics.md:1806
 msgid "Weed-consuming superweapons"
 msgstr "消耗废矿的超级武器"
 
-#: ../../Fixed-or-Improved-Logics.md:1776
+#: ../../Fixed-or-Improved-Logics.md:1808
 msgid ""
 "Superweapons can consume weeds to recharge, like the Chemical Missile "
 "special in Tiberian Sun."
 msgstr "超级武器可以消耗泰伯利亚废矿来加载，就像《泰伯利亚之日》中的化学飞弹一样。"
 
-#: ../../Fixed-or-Improved-Logics.md:1779
+#: ../../Fixed-or-Improved-Logics.md:1811
 msgid ""
 "As the code for the Chemical Missile had been removed, setting "
 "`Type=ChemMissile` will not work."
 msgstr "由于化学飞弹的代码已被移除，设置 `Type=ChemMissile` 并不会生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:1783
+#: ../../Fixed-or-Improved-Logics.md:1815
 #, python-format
 msgid ""
 "[SOMESW]                                        ; SuperWeaponType\n"
@@ -6073,11 +6161,11 @@ msgstr ""
 " weeds % are stored, the SW will show it's ready on the building (open "
 "nuke/open chrono, etc.)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1791
+#: ../../Fixed-or-Improved-Logics.md:1823
 msgid "VoxelAnims"
 msgstr "Voxel 碎片"
 
-#: ../../Fixed-or-Improved-Logics.md:1795
+#: ../../Fixed-or-Improved-Logics.md:1827
 msgid ""
 "The INI keys and behaviour is mostly identical to the [equivalent "
 "behaviour available to regular animations](#customizable-debris--meteor-"
@@ -6089,18 +6177,17 @@ msgstr ""
 "detonation-behaviour)基本相同。主要区别是这些标签必须列在 `rulesmd.ini` 中的 Voxel 碎片条目中，而不是 "
 "`artmd.ini` 中。"
 
-#: ../../Fixed-or-Improved-Logics.md:1797
+#: ../../Fixed-or-Improved-Logics.md:1829
 msgid "Customizable debris trailer anim spawn delay"
 msgstr "自定义 Voxel 碎片尾烟动画生成间隔"
 
-#: ../../Fixed-or-Improved-Logics.md:1799
+#: ../../Fixed-or-Improved-Logics.md:1831
 msgid ""
 "You can now customize the generation interval of VoxelAnim's trailer "
 "animation."
-msgstr ""
-"现在你可以自定义 Voxel 碎片的尾烟动画生成间隔。"
+msgstr "现在你可以自定义 Voxel 碎片的尾烟动画生成间隔。"
 
-#: ../../Fixed-or-Improved-Logics.md:1802
+#: ../../Fixed-or-Improved-Logics.md:1834
 msgid ""
 "[SOMEVOXELANIM]       ; VoxelAnimType\n"
 "Trailer.SpawnDelay=2  ; integer, game frames\n"
@@ -6108,15 +6195,15 @@ msgstr ""
 "[SOMEVOXELANIM]       ; VoxelAnimType\n"
 "Trailer.SpawnDelay=2  ; integer, game frames\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1807
+#: ../../Fixed-or-Improved-Logics.md:1839
 msgid "Warheads"
 msgstr "弹头"
 
-#: ../../Fixed-or-Improved-Logics.md:1809
+#: ../../Fixed-or-Improved-Logics.md:1841
 msgid "Allowing damage dealt to firer"
 msgstr "允许杀伤开火者"
 
-#: ../../Fixed-or-Improved-Logics.md:1811
+#: ../../Fixed-or-Improved-Logics.md:1843
 msgid ""
 "You can now allow warhead to deal damage (and apply damage-adjacent "
 "effects such as `KillDriver` and `DisableWeapons/Sonar/Flash.Duration` "
@@ -6126,14 +6213,14 @@ msgstr ""
 "现在即使对象没有 `DamageSelf=true` 你也可以允许弹头对被视为开火者的对象造成杀伤（并使用诸如 `KillDriver` 和 "
 "`DisableWeapons/Sonar/Flash.Duration`（*Ares 功能*）这些与杀伤相关的效果。）"
 
-#: ../../Fixed-or-Improved-Logics.md:1812
+#: ../../Fixed-or-Improved-Logics.md:1844
 msgid ""
 "Note that effect of `Psychedelic=true`, despite being tied to damage will"
 " still fail to apply on the firer as it does not affect any objects "
 "belonging to same house as the firer, including itself."
 msgstr "注意尽管 `Psychedelic=true` 的效果与杀伤相关但由于其不会影响任何包括开火者在内所有与开火者同一所属的对象因此仍然无法生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:1815
+#: ../../Fixed-or-Improved-Logics.md:1847
 msgid ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "AllowDamageOnSelf=false  ; boolean\n"
@@ -6141,11 +6228,11 @@ msgstr ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "AllowDamageOnSelf=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1820
+#: ../../Fixed-or-Improved-Logics.md:1852
 msgid "Combat light customizations"
 msgstr "自定义战斗闪光"
 
-#: ../../Fixed-or-Improved-Logics.md:1822
+#: ../../Fixed-or-Improved-Logics.md:1854
 msgid ""
 "You can now set minimum detail level at which combat light effects are "
 "shown by setting `[AudioVisual] -> CombatLightDetailLevel` or "
@@ -6154,20 +6241,20 @@ msgstr ""
 "现在你可以通过设置 `[AudioVisual] -> CombatLightDetailLevel` 或在弹头上设置 "
 "`CombatLightDetailLevel` 来限定显示闪光效果的最小画质级别，后者默认为前者。"
 
-#: ../../Fixed-or-Improved-Logics.md:1823
+#: ../../Fixed-or-Improved-Logics.md:1855
 msgid ""
 "You can now set a percentage chance a combat light effect is shown on "
 "Warhead impact by setting `CombatLightChance`."
 msgstr "现在你可以通过设置 `CombatLightChance` 来限定弹头命中时显示战斗闪光效果的概率百分比。"
 
-#: ../../Fixed-or-Improved-Logics.md:1824
+#: ../../Fixed-or-Improved-Logics.md:1856
 msgid ""
 "Setting `CLIsBlack` to true on Warhead will now turn the flash black like"
 " on hitting an Iron Curtained object, irregardless of other color "
 "settings."
 msgstr "现在可以通过在弹头上设置 `CLIsBlack` 为 true 来让闪光就像击中在铁幕保护下的物体一样使用黑色，无视其他颜色设置。"
 
-#: ../../Fixed-or-Improved-Logics.md:1827
+#: ../../Fixed-or-Improved-Logics.md:1859
 msgid ""
 "[AudioVisual]\n"
 "CombatLightDetailLevel=0  ; integer\n"
@@ -6187,11 +6274,11 @@ msgstr ""
 "(0.0-1.0)\n"
 "CLIsBlack=false           ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1837
+#: ../../Fixed-or-Improved-Logics.md:1869
 msgid "Custom debris animations and additional debris spawn settings"
 msgstr "自定义碎片动画和额外的碎片生成设置"
 
-#: ../../Fixed-or-Improved-Logics.md:1839
+#: ../../Fixed-or-Improved-Logics.md:1871
 msgid ""
 "You can now use `DebrisAnims` to specify a list of debris animations to "
 "spawn instead of animations from `[General] -> MetallicDebris` when "
@@ -6201,7 +6288,7 @@ msgstr ""
 "现在可以使用 `DebrisAnims` 指定要生成的碎片动画列表，而不是仅能在引爆拥有 `MaxDebris` > 0 且没有 "
 "`DebrisTypes`（指定 Voxel 碎片）的弹头时使用 `[General] -> MetallicDebris` 列表中的动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:1840
+#: ../../Fixed-or-Improved-Logics.md:1872
 msgid ""
 "`Debris.Conventional`, if set to true, makes `DebrisTypes` or "
 "`DebrisAnims` only spawn if Warhead is fired on non-water cell."
@@ -6209,7 +6296,7 @@ msgstr ""
 "`Debris.Conventional` 如果设为 true，那么仅在弹头在非水面单元格上引爆时才会使用 `DebrisTypes` 或 "
 "`DebrisAnims`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1843
+#: ../../Fixed-or-Improved-Logics.md:1875
 msgid ""
 "[SOMEWARHEAD]              ; WarheadType\n"
 "DebrisAnims=               ; List of AnimationTypes\n"
@@ -6219,22 +6306,38 @@ msgstr ""
 "DebrisAnims=               ; List of AnimationTypes\n"
 "Debris.Conventional=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1849
+#: ../../Fixed-or-Improved-Logics.md:1881
+msgid "Custom debris voxel animations limitation"
+msgstr "自定义 Voxel 碎片数量限制"
+
+#: ../../Fixed-or-Improved-Logics.md:1887
+msgid ""
+"[SOMEWARHEAD]       ; WarheadType\n"
+"DebrisTypes.Limit=  ; boolean\n"
+"DebrisMaximums=     ; List of integers\n"
+"DebrisMinimums=     ; List of integers\n"
+msgstr ""
+"[SOMEWARHEAD]       ; WarheadType\n"
+"DebrisTypes.Limit=  ; boolean\n"
+"DebrisMaximums=     ; List of integers\n"
+"DebrisMinimums=     ; List of integers\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1894
 msgid "Customizable rocker amplitude"
 msgstr "自定义掀起幅度"
 
-#: ../../Fixed-or-Improved-Logics.md:1851
+#: ../../Fixed-or-Improved-Logics.md:1896
 msgid ""
 "The rocker amplitude of warheads with `Rocker=yes` used to be determined "
 "by `Damage` value of the weapon. You can now override it with fixed value"
 " and add a multiplier to it."
 msgstr "拥有 `Rocker=yes` 的弹头其气波掀起载具的幅度过去由武器的 `Damage` 值所决定。现在可以通过固定值覆盖它并添加一个倍率。"
 
-#: ../../Fixed-or-Improved-Logics.md:1852
+#: ../../Fixed-or-Improved-Logics.md:1897
 msgid "When both multiplier and override values are set - both are used."
 msgstr "当同时设置了倍率和覆盖值时两者都会被使用。"
 
-#: ../../Fixed-or-Improved-Logics.md:1855
+#: ../../Fixed-or-Improved-Logics.md:1900
 msgid ""
 "[SOMEWARHEAD]                   ; WarheadType\n"
 "Rocker.AmplitudeMultiplier=1.0  ; floating point value, multiplier\n"
@@ -6244,50 +6347,11 @@ msgstr ""
 "Rocker.AmplitudeMultiplier=1.0  ; floating point value, multiplier\n"
 "Rocker.AmplitudeOverride=       ; integer\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1861
-msgid "Customizable Warhead trigger conditions"
-msgstr "自定义弹头效果触发条件"
-
-#: ../../Fixed-or-Improved-Logics.md:1863
-msgid ""
-"It is now possible to make warheads only trigger when target's HP is "
-"above and/or below certain percentage."
-msgstr ""
-"现在可以设置一个弹头仅在目标单位生命值高／低于特定百分比时才能触发。"
-
-#: ../../Fixed-or-Improved-Logics.md:1864
-msgid ""
-"Both conditions need to evaluate to true in order for the warhead to "
-"trigger."
-msgstr ""
-"两个条件同时满足时才能触发。"
-
-#: ../../Fixed-or-Improved-Logics.md:1865
-#, python-format
-msgid ""
-"If set to `false`, `EffectsRequireVerses` makes the Phobos-introduced "
-"warhead effects trigger even if it can't damage the target because of "
-"it's current ArmorType (e.g. 0% in `Verses`)."
-msgstr ""
-"若设置 `EffectsRequireVerses=false` 那么即便由于目标当前装甲类型导致弹头无法对其造成杀伤（例如 `Verses=0%`）Phobos 所引入的弹头效果也仍会触发。"
-
-#: ../../Fixed-or-Improved-Logics.md:1868
-msgid ""
-"[SOMEWARHEAD]               ; WarheadType\n"
-"AffectsAbovePercent=0.0     ; floating point value, percents or absolute\n"
-"AffectsBelowPercent=1.0     ; floating point value, percents or absolute\n"
-"EffectsRequireVerses=false  ; boolean\n"
-msgstr ""
-"[SOMEWARHEAD]               ; WarheadType\n"
-"AffectsAbovePercent=0.0     ; floating point value, percents or absolute\n"
-"AffectsBelowPercent=1.0     ; floating point value, percents or absolute\n"
-"EffectsRequireVerses=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1875
+#: ../../Fixed-or-Improved-Logics.md:1906
 msgid "Customizable Warhead animation behaviour"
 msgstr "自定义弹头动画行为"
 
-#: ../../Fixed-or-Improved-Logics.md:1877
+#: ../../Fixed-or-Improved-Logics.md:1908
 msgid ""
 "It is possible to make game play random animation from `AnimList` by "
 "setting `AnimList.PickRandom` to true. The result is similar to what "
@@ -6299,7 +6363,7 @@ msgstr ""
 "`EMEffect=true` 时的效果，但它不会带来副作用（`EMEffect=true` 会影响 `Inviso=true` "
 "的抛射体锁定目标，导致它们无法击中移动目标）。"
 
-#: ../../Fixed-or-Improved-Logics.md:1878
+#: ../../Fixed-or-Improved-Logics.md:1909
 msgid ""
 "If `AnimList.CreateAll` is set to true, all animations from `AnimList` "
 "are created, instead of a single anim based on damage or random if "
@@ -6309,7 +6373,7 @@ msgstr ""
 "列表中的动画都将会被创建，而不再是只创建单个基于杀伤值计算或随机选取的动画，前提是 `AnimList.PickRandom` 没有被设为 "
 "true。"
 
-#: ../../Fixed-or-Improved-Logics.md:1879
+#: ../../Fixed-or-Improved-Logics.md:1910
 msgid ""
 "If `AnimList.CreationInterval` is set to a value higher than 0, there "
 "will be that number of detonations of the Warhead before animations from "
@@ -6324,14 +6388,14 @@ msgstr ""
 "中的动画前需要爆炸一定数量的该弹头。如果该弹头是由一个单位发射的，那么该单位只会检查它自己所发射该弹头的次数，否则会对全图所有同一弹头的引爆次数进行计数。如果你希望像"
 " `Airburst` 这种具有大范围扩散的效果其弹头动画可以均匀出现而不是每次引爆都出现的话那么这会非常有用。"
 
-#: ../../Fixed-or-Improved-Logics.md:1880
+#: ../../Fixed-or-Improved-Logics.md:1911
 msgid ""
 "`AnimList.ScatterMin` & `AnimList.ScatterMax` can be used to set a range "
 "in cells around which any created animations will randomly scatter around"
 " from the impact point."
 msgstr "`AnimList.ScatterMin` 和 `AnimList.ScatterMax` 可用于设置从爆炸中心点开始一定范围内的动画随机散布范围。"
 
-#: ../../Fixed-or-Improved-Logics.md:1881
+#: ../../Fixed-or-Improved-Logics.md:1912
 msgid ""
 "`SplashList` can be used to override animations displayed if the Warhead "
 "has `Conventional=true` and it hits water, by default animations from "
@@ -6340,7 +6404,7 @@ msgstr ""
 "`SplashList` 可以在拥有 `Conventional=true` 的弹头击中水面时覆盖显示的动画，默认使用 "
 "`[CombatDamage] -> SplashList` 中的动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:1882
+#: ../../Fixed-or-Improved-Logics.md:1913
 msgid ""
 "`SplashList.PickRandom`, `SplashList.CreateAll`, "
 "`SplashList.CreationInterval` and `SplashList.Scatter(Min/Max)` apply to "
@@ -6349,7 +6413,7 @@ msgstr ""
 "`SplashList.PickRandom`、`SplashList.CreateAll`、`SplashList.CreationInterval`"
 " 和 `SplashList.Scatter(Min/Max)` 与 `AnimList` 同类语句相同。"
 
-#: ../../Fixed-or-Improved-Logics.md:1883
+#: ../../Fixed-or-Improved-Logics.md:1914
 msgid ""
 "`CreateAnimsOnZeroDamage`, if set to true, makes it so that `AnimList` or"
 " `SplashList` animations are created even if the weapon that fired the "
@@ -6358,7 +6422,7 @@ msgstr ""
 "`CreateAnimsOnZeroDamage` 如果设为 true，即便发射该弹头的武器只会造成 0 点伤害也会正常创建 `AnimList`"
 " 或 `SplashList` 动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:1884
+#: ../../Fixed-or-Improved-Logics.md:1915
 msgid ""
 "Setting `Conventional.IgnoreUnits` to true on Warhead with "
 "`Conventional=true` will make the Warhead detonate on non-underwater "
@@ -6370,7 +6434,7 @@ msgstr ""
 "会使弹头命中位于水中的非水下载具类型时视为在水中引爆而不是视为在陆地上引爆。这决定了命中水面舰船时使用 `AnimList` 还是 "
 "`SplashList`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1887
+#: ../../Fixed-or-Improved-Logics.md:1918
 msgid ""
 "[SOMEWARHEAD]                   ; WarheadType\n"
 "AnimList.PickRandom=false       ; boolean\n"
@@ -6410,17 +6474,55 @@ msgstr ""
 "CreateAnimsOnZeroDamage=false   ; boolean\n"
 "Conventional.IgnoreUnits=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1904
+#: ../../Fixed-or-Improved-Logics.md:1935
+msgid "Customizable Warhead trigger conditions"
+msgstr "自定义弹头效果触发条件"
+
+#: ../../Fixed-or-Improved-Logics.md:1937
+msgid ""
+"It is now possible to make warheads only trigger when target's HP is "
+"above and/or below certain percentage."
+msgstr "现在可以设置一个弹头仅在目标单位生命值高／低于特定百分比时才能触发。"
+
+#: ../../Fixed-or-Improved-Logics.md:1938
+msgid ""
+"Both conditions need to evaluate to true in order for the warhead to "
+"trigger."
+msgstr "两个条件同时满足时才能触发。"
+
+#: ../../Fixed-or-Improved-Logics.md:1939
+#, python-format
+msgid ""
+"If set to `false`, `EffectsRequireVerses` makes the Phobos-introduced "
+"warhead effects trigger even if it can't damage the target because of "
+"it's current ArmorType (e.g. 0% in `Verses`)."
+msgstr ""
+"若设置 `EffectsRequireVerses=false` 那么即便由于目标当前装甲类型导致弹头无法对其造成杀伤（例如 "
+"`Verses=0%`）Phobos 所引入的弹头效果也仍会触发。"
+
+#: ../../Fixed-or-Improved-Logics.md:1942
+msgid ""
+"[SOMEWARHEAD]               ; WarheadType\n"
+"AffectsAbovePercent=0.0     ; floating point value, percents or absolute\n"
+"AffectsBelowPercent=1.0     ; floating point value, percents or absolute\n"
+"EffectsRequireVerses=false  ; boolean\n"
+msgstr ""
+"[SOMEWARHEAD]               ; WarheadType\n"
+"AffectsAbovePercent=0.0     ; floating point value, percents or absolute\n"
+"AffectsBelowPercent=1.0     ; floating point value, percents or absolute\n"
+"EffectsRequireVerses=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1949
 msgid "Customizing decloak on damaging targets"
 msgstr "自定义被伤害目标解除隐形"
 
-#: ../../Fixed-or-Improved-Logics.md:1906
+#: ../../Fixed-or-Improved-Logics.md:1951
 msgid ""
 "You can now specify whether or not the warhead decloaks objects that are "
 "damaged by the warhead."
 msgstr "现在你可以指定被这个弹头杀伤的对象是否解除隐形。"
 
-#: ../../Fixed-or-Improved-Logics.md:1909
+#: ../../Fixed-or-Improved-Logics.md:1954
 msgid ""
 "[SOMEWARHEAD]               ; WarheadType\n"
 "DecloakDamagedTargets=true  ; boolean\n"
@@ -6428,15 +6530,15 @@ msgstr ""
 "[SOMEWARHEAD]               ; WarheadType\n"
 "DecloakDamagedTargets=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1914
+#: ../../Fixed-or-Improved-Logics.md:1959
 msgid "Customizing parasite culling targets"
 msgstr "自定义寄生秒杀目标"
 
-#: ../../Fixed-or-Improved-Logics.md:1916
+#: ../../Fixed-or-Improved-Logics.md:1961
 msgid "Now you can specify which targets the parasite will culling them."
 msgstr "现在你可以指定哪些目标会被寄生所秒杀"
 
-#: ../../Fixed-or-Improved-Logics.md:1919
+#: ../../Fixed-or-Improved-Logics.md:1964
 msgid ""
 "[SOMEWARHEAD]                     ; WarheadType\n"
 "Parasite.CullingTarget=infantry   ; List of Affected Target Enumeration "
@@ -6446,11 +6548,11 @@ msgstr ""
 "Parasite.CullingTarget=infantry   ; List of Affected Target Enumeration "
 "(none|aircraft|infantry|units|all)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1924
+#: ../../Fixed-or-Improved-Logics.md:1969
 msgid "Delay automatic attack on the controlled unit"
 msgstr "攻击被心控单位的延迟"
 
-#: ../../Fixed-or-Improved-Logics.md:1926
+#: ../../Fixed-or-Improved-Logics.md:1971
 msgid ""
 "Now you can make the techno that has just been mind controlled not be "
 "automatically attacked by its original friendly forces for a period of "
@@ -6461,13 +6563,13 @@ msgstr ""
 "`MindControl.ThreatDelay` 参数控制，默认取自 `[General] -> "
 "MindControl.ThreatDelay`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1927
+#: ../../Fixed-or-Improved-Logics.md:1972
 msgid ""
 "This will not affect the manual selection of attacks and is useless with "
 "permanent mind control."
 msgstr "这不会影响手动攻击，并且不（也没必要）作用于永久心控的情况。"
 
-#: ../../Fixed-or-Improved-Logics.md:1930
+#: ../../Fixed-or-Improved-Logics.md:1975
 msgid ""
 "[General]\n"
 "MindControl.ThreatDelay=0     ; integer, game frames\n"
@@ -6481,41 +6583,41 @@ msgstr ""
 "[SOMEWARHEAD]                 ; WarheadType\n"
 "MindControl.ThreatDelay=      ; integer, game frames\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1938
+#: ../../Fixed-or-Improved-Logics.md:1983
 msgid "Nonprovocative Warheads"
 msgstr "非挑衅弹头"
 
-#: ../../Fixed-or-Improved-Logics.md:1940
+#: ../../Fixed-or-Improved-Logics.md:1985
 msgid ""
 "You can now make Warheads behave in nonprovocative fashion. Warheads with"
 " `Nonprovocative=true` exhibit following behaviours:"
 msgstr "现在你可以让弹头以非挑衅的方式表现。设置为 `Nonprovocative=true` 的弹头会表现出以下行为："
 
-#: ../../Fixed-or-Improved-Logics.md:1941
+#: ../../Fixed-or-Improved-Logics.md:1986
 msgid ""
 "They will not generate any EVA announcements upon hitting targets, be it "
 "for attacking ore miners, base buildings or ally base buildings."
 msgstr "当命中目标时无论是是矿车、基地建筑还是盟友的基地建筑都不会播放任何 EVA 通报。"
 
-#: ../../Fixed-or-Improved-Logics.md:1942
+#: ../../Fixed-or-Improved-Logics.md:1987
 msgid ""
 "They will not spring 'attacked' / 'attacked by' events. Note that if the "
 "Warhead deals actual damage, events that check for that can still be "
 "sprung."
 msgstr "它们不会触发 “受到攻击”／“被...攻击” 事件。注意如果弹头造成了实际杀伤那么检查杀伤的事件仍可能被触发。"
 
-#: ../../Fixed-or-Improved-Logics.md:1943
+#: ../../Fixed-or-Improved-Logics.md:1988
 msgid ""
 "They will not evoke defense response from AI players when used to attack "
 "base buildings, `ToProtect=true` TechnoTypes or members of TeamTypes with"
 " `Whiner=true`."
 msgstr "它们不会在攻击基地建筑、`ToProtect=true` 的科技类型或具有 `Whiner=true` 的小队的成员时引发 AI 玩家的防御反应。"
 
-#: ../../Fixed-or-Improved-Logics.md:1944
+#: ../../Fixed-or-Improved-Logics.md:1989
 msgid "They will not evoke retaliation from TechnoTypes hit by the Warhead."
 msgstr "它们不会引发弹头所命中科技类型的反击。"
 
-#: ../../Fixed-or-Improved-Logics.md:1947
+#: ../../Fixed-or-Improved-Logics.md:1992
 msgid ""
 "[SOMEWARHEAD]         ; WarheadType\n"
 "Nonprovocative=false  ; boolean\n"
@@ -6523,24 +6625,24 @@ msgstr ""
 "[SOMEWARHEAD]         ; WarheadType\n"
 "Nonprovocative=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1953
+#: ../../Fixed-or-Improved-Logics.md:1998
 msgid ""
 "Due to technical constraints, this does not suppress warnings from Ares' "
 "EMP effect."
 msgstr "由于技术限制，这不会去除 Ares 的 EMP 效果所产生的警告。"
 
-#: ../../Fixed-or-Improved-Logics.md:1956
+#: ../../Fixed-or-Improved-Logics.md:2001
 msgid "Restricting screen shaking to current view"
 msgstr "限制屏幕抖动于当前视角"
 
-#: ../../Fixed-or-Improved-Logics.md:1958
+#: ../../Fixed-or-Improved-Logics.md:2003
 msgid ""
 "You can now specify whether or not the warhead can only shake screen "
 "(`ShakeX/Ylo/hi`) if it is detonated while visible on current screen "
 "view."
 msgstr "现在你可以指定这个弹头是否只能在可视的当前屏幕可见区域内爆炸时才能抖动（`ShakeX/Ylo/hi`）屏幕"
 
-#: ../../Fixed-or-Improved-Logics.md:1961
+#: ../../Fixed-or-Improved-Logics.md:2006
 msgid ""
 "[SOMEWARHEAD]       ; WarheadType\n"
 "ShakeIsLocal=false  ; boolean\n"
@@ -6548,15 +6650,15 @@ msgstr ""
 "[SOMEWARHEAD]       ; WarheadType\n"
 "ShakeIsLocal=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1966
+#: ../../Fixed-or-Improved-Logics.md:2011
 msgid "Weapons"
 msgstr "武器"
 
-#: ../../Fixed-or-Improved-Logics.md:1968
+#: ../../Fixed-or-Improved-Logics.md:2013
 msgid "AmbientDamage customizations"
 msgstr "自定义穿透伤害"
 
-#: ../../Fixed-or-Improved-Logics.md:1970
+#: ../../Fixed-or-Improved-Logics.md:2015
 msgid ""
 "You can now specify separate Warhead used for `AmbientDamage` via "
 "`AmbientDamage.Warhead` or make it never apply to weapon's main target by"
@@ -6565,7 +6667,7 @@ msgstr ""
 "现在你可以通过 `AmbientDamage.Warhead` 指定用于 `AmbientDamage` 的弹头或通过将 "
 "`AmbientDamage.IgnoreTarget` 设为 true 使其永远不会对武器的直接目标生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:1973
+#: ../../Fixed-or-Improved-Logics.md:2018
 msgid ""
 "[SOMEWEAPON]                      ; WeaponType\n"
 "AmbientDamage.Warhead=            ; WarheadType\n"
@@ -6575,11 +6677,11 @@ msgstr ""
 "AmbientDamage.Warhead=            ; WarheadType\n"
 "AmbientDamage.IgnoreTarget=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1979
+#: ../../Fixed-or-Improved-Logics.md:2024
 msgid "Charge turret delays"
 msgstr "炮塔充能间隔"
 
-#: ../../Fixed-or-Improved-Logics.md:1981
+#: ../../Fixed-or-Improved-Logics.md:2026
 msgid ""
 "It is now possible to customize the delay of `IsChargeTurret=true` unit "
 "turret animation per weapon, per `Burst` shot instead of defaulting to "
@@ -6593,13 +6695,13 @@ msgstr ""
 "等）。使用列表中与 `Burst` 一一对应值的间隔，若当前连发的次数高于列表中值的数量那么使用列表中最后一个值。间隔为 0 "
 "或更小将不会被使用，并且不会重置先前的充能序列（目前仍会重置序列但不会重置充能动画播放时间）。"
 
-#: ../../Fixed-or-Improved-Logics.md:1982
+#: ../../Fixed-or-Improved-Logics.md:2027
 msgid ""
 "Note that unlike the default rearm timer that uses `ROF`, any modifiers "
 "are not applied to explicitly set charge turret delays."
 msgstr "注意与使用 `ROF` 的默认重新装填计时器不同，任何倍率都不会对明确指定的充能炮塔间隔生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:1985
+#: ../../Fixed-or-Improved-Logics.md:2030
 msgid ""
 "[SOMEWEAPON]          ; WeaponType\n"
 "ChargeTurret.Delays=  ; List of integers - game frames\n"
@@ -6607,19 +6709,19 @@ msgstr ""
 "[SOMEWEAPON]          ; WeaponType\n"
 "ChargeTurret.Delays=  ; List of integers - game frames\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1990
+#: ../../Fixed-or-Improved-Logics.md:2035
 msgid "Customizable disk laser radius"
 msgstr "自定义飞碟激光半径"
 
-#: ../../Fixed-or-Improved-Logics.md:1992
+#: ../../Fixed-or-Improved-Logics.md:2037
 msgid "![image](_static/images/disklaser-radius-values-01.gif)"
 msgstr "![image](_static/images/disklaser-radius-values-01.gif)"
 
-#: ../../Fixed-or-Improved-Logics.md:1993
+#: ../../Fixed-or-Improved-Logics.md:2038
 msgid "You can now set disk laser animation radius using a new tag."
 msgstr "现在你可以通过一个新的标签来设置飞碟激光动画效果的半径。"
 
-#: ../../Fixed-or-Improved-Logics.md:1996
+#: ../../Fixed-or-Improved-Logics.md:2041
 msgid ""
 "[SOMEWEAPON]          ; WeaponType\n"
 "DiskLaser.Radius=240  ; integer\n"
@@ -6629,18 +6731,18 @@ msgstr ""
 "DiskLaser.Radius=240  ; integer\n"
 "; 240 is the default saucer disk radius\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2002
+#: ../../Fixed-or-Improved-Logics.md:2047
 msgid "Customizable ROF random delay"
 msgstr "自定义 ROF 随机延迟"
 
-#: ../../Fixed-or-Improved-Logics.md:2004
+#: ../../Fixed-or-Improved-Logics.md:2049
 msgid ""
 "By default weapon `ROF` has a random delay of 0 to 2 frames added to it. "
 "This random delay is now customizable, globally and on per-WeaponType "
 "basis."
 msgstr "默认情况下武器的 `ROF` 会添加 0 到 2 的随机延迟。现在可以在全局和武器微观层面定义此随机延迟。"
 
-#: ../../Fixed-or-Improved-Logics.md:2007
+#: ../../Fixed-or-Improved-Logics.md:2052
 msgid ""
 "[CombatDamage]\n"
 "ROF.RandomDelay=0,2  ; integer - single or comma-sep. range (game frames)"
@@ -6658,17 +6760,17 @@ msgstr ""
 "ROF.RandomDelay=     ; integer - single or comma-sep. range (game frames)"
 "\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2015
+#: ../../Fixed-or-Improved-Logics.md:2060
 msgid "Customizing whether passengers are kicked out when an aircraft fires"
 msgstr "自定义战机开火时是否踢出乘客"
 
-#: ../../Fixed-or-Improved-Logics.md:2017
+#: ../../Fixed-or-Improved-Logics.md:2062
 msgid ""
 "You can now customize whether aircraft will forcefully eject passengers "
 "(vanilla behavior) or fire its weapon when attempting to fire."
 msgstr "现在你可以自定义战机在尝试开火时是强行踢出乘客（默认行为）还是发射这个武器。"
 
-#: ../../Fixed-or-Improved-Logics.md:2020
+#: ../../Fixed-or-Improved-Logics.md:2065
 msgid ""
 "[SOMEWEAPON]            ; WeaponType\n"
 "KickOutPassengers=true  ; boolean\n"
@@ -6676,11 +6778,11 @@ msgstr ""
 "[SOMEWEAPON]            ; WeaponType\n"
 "KickOutPassengers=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2025
+#: ../../Fixed-or-Improved-Logics.md:2070
 msgid "Disable FireOnce resetting infantry sequence"
 msgstr "禁止 FireOnce 重置步兵序列"
 
-#: ../../Fixed-or-Improved-Logics.md:2027
+#: ../../Fixed-or-Improved-Logics.md:2072
 msgid ""
 "It is now possible to disable `FireOnce=true` weapon resetting infantry "
 "sequences after firing via `FireOnce.ResetSequence`. Target will be "
@@ -6690,7 +6792,7 @@ msgstr ""
 "现在可以通过 `FireOnce.ResetSequence` 来禁用 `FireOnce=true` "
 "武器在开火后重置步兵序列的效果。目标将像以前一样被遗忘，如果开火后还有剩余帧，那么开火序列将简单地照常继续播放。"
 
-#: ../../Fixed-or-Improved-Logics.md:2030
+#: ../../Fixed-or-Improved-Logics.md:2075
 msgid ""
 "[SOMEWEAPON]                 ; WeaponType\n"
 "FireOnce.ResetSequence=true  ; boolean\n"
@@ -6698,11 +6800,11 @@ msgstr ""
 "[SOMEWEAPON]                 ; WeaponType\n"
 "FireOnce.ResetSequence=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2035
+#: ../../Fixed-or-Improved-Logics.md:2080
 msgid "Electric bolt customizations"
 msgstr "自定义 EBolt"
 
-#: ../../Fixed-or-Improved-Logics.md:2037
+#: ../../Fixed-or-Improved-Logics.md:2082
 msgid ""
 "![image](_static/images/ebolt.gif) *EBolt customization utilized for "
 "different Tesla bolt weapon usage ([RA2: "
@@ -6711,13 +6813,13 @@ msgstr ""
 "![image](_static/images/ebolt.gif) *[RA2: "
 "Reboot](https://www.moddb.com/mods/reboot) 中自定义用于不同磁爆电流武器的 EBolt 效果*"
 
-#: ../../Fixed-or-Improved-Logics.md:2040
+#: ../../Fixed-or-Improved-Logics.md:2085
 msgid ""
 "You can now specify individual bolts you want to disable for "
 "`IsElectricBolt=true` weapons. Note that this is only a visual change."
 msgstr "现在你可以为 `IsElectricBolt=true` 的武器指定你想要关闭的特定电流。注意这只是视觉变化。"
 
-#: ../../Fixed-or-Improved-Logics.md:2041
+#: ../../Fixed-or-Improved-Logics.md:2086
 msgid ""
 "By default `IsElectricBolt=true` effect draws a bolt with 8 arcs. This "
 "can now be customized per WeaponType with `Bolt.Arcs`. Value of 0 results"
@@ -6726,14 +6828,14 @@ msgstr ""
 "默认情况下，`IsElectricBolt=true` 效果会绘制带有 8 条电弧的电流。现在可以通过 `Bolt.Arcs` "
 "为每种武器自定义这一效果。值为 0 将会绘制一条直线。"
 
-#: ../../Fixed-or-Improved-Logics.md:2042
+#: ../../Fixed-or-Improved-Logics.md:2087
 msgid ""
 "`Bolt.Duration` can be specified to explicitly set the overall duration "
 "of the visual electric bolt effect. Only values in range of 1 to 31 are "
 "accepted, values outside this range are clamped into it."
 msgstr "`Bolt.Duration` 可用于明确指定 EBolt 视觉效果的总持续时间，仅支持 1 到 31 范围内的值，超出此范围将会写回该范围内。"
 
-#: ../../Fixed-or-Improved-Logics.md:2043
+#: ../../Fixed-or-Improved-Logics.md:2088
 msgid ""
 "`Bolt.FollowFLH` can be used to override the default behaviour where the "
 "electric bolt source coordinates change to match the unit's firing coord "
@@ -6743,7 +6845,7 @@ msgstr ""
 "`Bolt.FollowFLH` 可用于覆盖 EBolt 起始坐标跟随单位开火坐标每帧改变（时期跟随单位的移动、旋转等）的默认行为。载具默认为 "
 "true 其他所有情况默认为 false。"
 
-#: ../../Fixed-or-Improved-Logics.md:2046
+#: ../../Fixed-or-Improved-Logics.md:2091
 msgid ""
 "[SOMEWEAPON]           ; WeaponType\n"
 "Bolt.Disable1=false    ; boolean\n"
@@ -6761,7 +6863,7 @@ msgstr ""
 "Bolt.Duration=17       ; integer, game frames\n"
 "Bolt.FollowFLH=        ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2057
+#: ../../Fixed-or-Improved-Logics.md:2102
 msgid ""
 "Due to technical constraints, these features do not work with electric "
 "bolts created from support weapon of [Ares' Prism Forwarding](https"
@@ -6772,11 +6874,11 @@ msgstr ""
 "docs/new/buildings/prismforwarding.html) 或那些 `AirburstWeapon` 所创建的 EBolt "
 "效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:2060
+#: ../../Fixed-or-Improved-Logics.md:2105
 msgid "Single-color lasers"
 msgstr "单色激光"
 
-#: ../../Fixed-or-Improved-Logics.md:2062
+#: ../../Fixed-or-Improved-Logics.md:2107
 msgid ""
 "![image](_static/images/issinglecolor.gif) *Comparison of "
 "`IsSingleColor=yes` lasers with higher thickness to regular ones ([RA2: "
@@ -6786,7 +6888,7 @@ msgstr ""
 "Reboot](https://www.moddb.com/mods/reboot) 中宽度更大的 `IsSingleColor=yes` "
 "激光与常规激光的比较*"
 
-#: ../../Fixed-or-Improved-Logics.md:2065
+#: ../../Fixed-or-Improved-Logics.md:2110
 msgid ""
 "You can now set laser to draw using only `LaserInnerColor` by setting "
 "`IsSingleColor`, in same manner as `IsHouseColor` lasers do using "
@@ -6796,7 +6898,7 @@ msgstr ""
 "现在你可以通过设置 `IsSingleColor` 使激光仅使用 `LaserInnerColor` 进行绘制，就像 `IsHouseColor`"
 " 的激光使用玩家所属方的颜色一样。这样的激光同样尊重激光宽度。注意这在光棱塔递光武器上并不可用。"
 
-#: ../../Fixed-or-Improved-Logics.md:2068
+#: ../../Fixed-or-Improved-Logics.md:2113
 msgid ""
 "[SOMEWEAPON]         ; WeaponType\n"
 "IsSingleColor=false  ; boolean\n"
@@ -6804,18 +6906,18 @@ msgstr ""
 "[SOMEWEAPON]         ; WeaponType\n"
 "IsSingleColor=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2073
+#: ../../Fixed-or-Improved-Logics.md:2118
 msgid "RadialIndicator visibility"
 msgstr "范围指示环可见性"
 
-#: ../../Fixed-or-Improved-Logics.md:2075
+#: ../../Fixed-or-Improved-Logics.md:2120
 msgid ""
 "In vanilla game, a structure's radial indicator can be drawn only when it"
 " belongs to the player. Now it can also be visible to observer. On top of"
 " that, you can specify its visibility from other houses."
 msgstr "在原本的游戏中，结构的范围指示环只有在玩家拥有时才绘制。现在它也对观察者可见。此外，你还可以指定其他所属方的可见性。"
 
-#: ../../Fixed-or-Improved-Logics.md:2079
+#: ../../Fixed-or-Improved-Logics.md:2124
 msgid ""
 "[AudioVisual]\n"
 "RadialIndicatorVisibility=allies  ; List of Affected House Enumeration "
@@ -6825,28 +6927,28 @@ msgstr ""
 "RadialIndicatorVisibility=allies  ; List of Affected House Enumeration "
 "(owner/self | allies/ally | enemies/enemy | all)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2084
+#: ../../Fixed-or-Improved-Logics.md:2129
 msgid "Crate improvements"
 msgstr "升级工具箱增强"
 
-#: ../../Fixed-or-Improved-Logics.md:2086
+#: ../../Fixed-or-Improved-Logics.md:2131
 msgid "There are some improvements on goodie crate logic:"
 msgstr "对升级工具箱逻辑提供了以下改进："
 
-#: ../../Fixed-or-Improved-Logics.md:2087
+#: ../../Fixed-or-Improved-Logics.md:2132
 msgid ""
 "The statistic distribution of the randomly generated crates is now more "
 "uniform within the visible map region by using an optimized sampling "
 "procedure."
 msgstr "优化了随机算法使得随机生成的升级工具箱在可见地图区域内的统计分布更加均匀。"
 
-#: ../../Fixed-or-Improved-Logics.md:2088
+#: ../../Fixed-or-Improved-Logics.md:2133
 msgid ""
 "You can now limit the crates' spawn region to land only by setting "
 "`[CrateRules] -> CreateOnlyOnLand` to true."
 msgstr "现在你可以通过将 `[CrateRules] -> CreateOnlyOnLand` 设为 true 来让升级工具箱的生成区域仅限陆地。"
 
-#: ../../Fixed-or-Improved-Logics.md:2089
+#: ../../Fixed-or-Improved-Logics.md:2134
 msgid ""
 "The limit of vehicles a player can own before unit crates start giving "
 "money instead can now be customized by setting `UnitCrateVehicleCap`. "
@@ -6855,7 +6957,7 @@ msgstr ""
 "现在可以通过 `UnitCrateVehicleCap` "
 "来设置玩家在单位箱子转为给予金钱之前可以拥有的载具数量上限。负数将禁用上限也就是永久生成载具不会达到一定数目后转为金钱。"
 
-#: ../../Fixed-or-Improved-Logics.md:2090
+#: ../../Fixed-or-Improved-Logics.md:2135
 msgid ""
 "`FreeMCV` setting is now actually respected and can be used to disable "
 "the forced unit selected from `[General] -> BaseUnit` that is given if "
@@ -6865,13 +6967,13 @@ msgstr ""
 "现在尊重 `FreeMCV` 设置并且可以用来禁止玩家拾取升级工具箱且拥有足够的资金单然而没有建筑或 `BaseUnit` 载具时强制将内容选择为"
 " `[General] -> BaseUnit` 中的单位。"
 
-#: ../../Fixed-or-Improved-Logics.md:2091
+#: ../../Fixed-or-Improved-Logics.md:2136
 msgid ""
 "The previously hardcoded credits threshold that must be passed can also "
 "now be customized via `FreeMCV.CreditsThreshold`."
 msgstr "现在可以通过 `FreeMCV.CreditsThreshold` 自定义先前硬编码需要高于的资金阈值。"
 
-#: ../../Fixed-or-Improved-Logics.md:2092
+#: ../../Fixed-or-Improved-Logics.md:2137
 msgid ""
 "It is possible to influence weighting of units given from crates "
 "(`CrateGoodie=true`) via `CrateGoodie.RerollChance`, which determines the"
@@ -6881,7 +6983,7 @@ msgstr ""
 "现在可以通过 `CrateGoodie.RerollChance` 来影响从升级工具箱 (`CrateGoodie=true`) "
 "中获得一个单位的权重，该值决定了如果随机到这种类型的单位，那么它将重新随机另一种单位的概率。"
 
-#: ../../Fixed-or-Improved-Logics.md:2095
+#: ../../Fixed-or-Improved-Logics.md:2140
 msgid ""
 "[CrateRules]\n"
 "CrateOnlyOnLand=false          ; boolean\n"
@@ -6903,52 +7005,52 @@ msgstr ""
 "CrateGoodie.RerollChance=0.0   ; floating point value, percents or "
 "absolute (0.0-1.0)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2106
+#: ../../Fixed-or-Improved-Logics.md:2151
 msgid "DropPod"
 msgstr "空降仓"
 
-#: ../../Fixed-or-Improved-Logics.md:2108
+#: ../../Fixed-or-Improved-Logics.md:2153
 msgid "DropPod properties can now be customized on a per-InfantryType basis."
 msgstr "现在可以在步兵类型上微观定义 DropPod 属性。"
 
-#: ../../Fixed-or-Improved-Logics.md:2109
+#: ../../Fixed-or-Improved-Logics.md:2154
 msgid ""
 "Note that the DropPod is actually the infantry itself with a different "
 "shp image."
 msgstr "注意 DropPod 其实是使用了不同 shp 图像的该步兵自身。"
 
-#: ../../Fixed-or-Improved-Logics.md:2110
+#: ../../Fixed-or-Improved-Logics.md:2155
 msgid ""
 "If you want to attach the trailer animation to the pod, set "
 "`DropPod.Trailer.Attached` to yes."
 msgstr "如果你要将尾烟动画附加到空降仓上，请将 `DropPod.Trailer.Attached` 设为 yes。"
 
-#: ../../Fixed-or-Improved-Logics.md:2111
+#: ../../Fixed-or-Improved-Logics.md:2156
 msgid ""
 "By default LaserTrails that are attached to the infantry will not be "
 "drawn if it's on DropPod."
 msgstr "默认情况下附加到步兵上的激光尾焰如果处于 DropPod 状态将不会绘制。"
 
-#: ../../Fixed-or-Improved-Logics.md:2112
+#: ../../Fixed-or-Improved-Logics.md:2157
 msgid ""
 "If you really want to use it, set `DropPodOnly` on the LaserTrail's type "
 "entry in art."
 msgstr "如果你实在想要使用它，那么请在 art 中的激光尾焰条目下设置 `DropPodOnly`。"
 
-#: ../../Fixed-or-Improved-Logics.md:2113
+#: ../../Fixed-or-Improved-Logics.md:2158
 msgid ""
 "If you want `DropPod.Weapon` to be fired only upon hard landing, set "
 "`DropPod.Weapon.HitLandOnly` to true."
 msgstr "如果要在着陆时才发射 `DropPod.Weapon`，请将 `DropPod.Weapon.HitLandOnly` 设为 true。"
 
-#: ../../Fixed-or-Improved-Logics.md:2114
+#: ../../Fixed-or-Improved-Logics.md:2159
 msgid ""
 "The landing speed is not smaller than it's current height /10 + 2 for "
 "unknown reason. A small `DropPod.Speed` value therefore results in "
 "exponential deceleration."
 msgstr "由于某些未知原因着陆速度不小于其当前高度 / 20 + 2 的值。因此较小的 `DropPod.Speed` 值会导致指数级减速。"
 
-#: ../../Fixed-or-Improved-Logics.md:2117
+#: ../../Fixed-or-Improved-Logics.md:2162
 msgid ""
 "[SOMEINFANTRY]                ; InfantryType\n"
 "DropPod.Angle=                ; double, default to [General] -> "
@@ -6996,7 +7098,7 @@ msgstr ""
 "DropPodWeapon\n"
 "DropPod.Weapon.HitLandOnly=   ; boolean, default to no\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2134
+#: ../../Fixed-or-Improved-Logics.md:2179
 msgid ""
 "`[General] -> DropPodTrailer` is [Ares features](https://ares-"
 "developers.github.io/Ares-docs/new/droppod.html)."

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Phobos \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-15 21:26+0800\n"
+"POT-Creation-Date: 2025-06-19 21:54+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -196,7 +196,7 @@ msgid ""
 " animation's owner & invoker instead of the object the effect is attached"
 " to."
 msgstr ""
-"`Animation.UseInvokerAsOwner` 可以设置赋予 AE 的所属方和科技类型（例如武器的发射者）为 AE "
+"`Animation.UseInvokerAsOwner` 可以设置创建该效果的所属方和科技类型（例如武器的发射者）为 AE 动画"
 "的所有者和调用者而不是 AE 所附加的对象。"
 
 #: ../../New-or-Enhanced-Logics.md:30
@@ -265,18 +265,28 @@ msgstr ""
 
 #: ../../New-or-Enhanced-Logics.md:36
 msgid ""
+"`ExpireWeapon.UseInvokerAsOwner` can be used to set the house and "
+"TechnoType that created the effect (e.g firer of the weapon that applied "
+"it) as the weapon's owner & invoker instead of the object the effect is "
+"attached to."
+msgstr ""
+"`ExpireWeapon.UseInvokerAsOwner` 可以设置创建该效果的所属方和科技类型（例如武器的发射者）为 `ExpireWeapon` "
+"的所有者和调用者而不是 AE 所附加的对象。"
+
+#: ../../New-or-Enhanced-Logics.md:37
+msgid ""
 "`Tint.Color` & `Tint.Intensity` can be used to set a color tint effect "
 "and additive lighting increase/decrease on the object the effect is "
 "attached to, respectively."
 msgstr "`Tint.Color` 和 `Tint.Intensity` 可用于设置一个染色效果和染色的光效强度。"
 
-#: ../../New-or-Enhanced-Logics.md:37
+#: ../../New-or-Enhanced-Logics.md:38
 msgid ""
 "`Tint.VisibleToHouses` can be used to control which houses can see the "
 "tint effect."
 msgstr "`Tint.VisibleToHouses` 可用于控制哪些所属方可见这些染色效果。"
 
-#: ../../New-or-Enhanced-Logics.md:38
+#: ../../New-or-Enhanced-Logics.md:39
 msgid ""
 "`FirepowerMultiplier`, `ArmorMultiplier`, `SpeedMultiplier` and "
 "`ROFMultiplier` can be used to modify the object's firepower, armor "
@@ -285,7 +295,7 @@ msgstr ""
 "`FirepowerMultiplier`、`ArmorMultiplier`、`SpeedMultiplier` 和 "
 "`ROFMultiplier` 分别修改对象的火力、护甲强度、移动速度和武器装填速度。"
 
-#: ../../New-or-Enhanced-Logics.md:39
+#: ../../New-or-Enhanced-Logics.md:40
 msgid ""
 "`ArmorMultiplier.AllowWarheads` and `ArmorMultiplier.DisallowWarheads` "
 "can be used to restrict which Warheads the armor multiplier is applied to"
@@ -294,7 +304,7 @@ msgstr ""
 "`ArmorMultiplier.AllowWarheads` 和 `ArmorMultiplier.DisallowWarheads` "
 "可用于限制护甲倍率在哪些弹头造成杀伤时生效。"
 
-#: ../../New-or-Enhanced-Logics.md:40
+#: ../../New-or-Enhanced-Logics.md:41
 msgid ""
 "If `ROFMultiplier.ApplyOnCurrentTimer` is set to true, `ROFMultiplier` is"
 " applied on currently running reload timer (if any) when the effect is "
@@ -303,19 +313,19 @@ msgstr ""
 "如果 `ROFMultiplier.ApplyOnCurrentTimer` 设为 true，`ROFMultiplier` 会在 AE "
 "首次赋予时就对当前正在使用的武器装填计时器生效而不是等到下一次。"
 
-#: ../../New-or-Enhanced-Logics.md:41
+#: ../../New-or-Enhanced-Logics.md:42
 msgid ""
 "If `Cloakable` is set to true, the object the effect is attached to is "
 "granted ability to cloak itself for duration of the effect."
 msgstr "如果 `Cloakable` 设为 true，被附加 AE 的对象在 AE 生效期间获得隐形能力。"
 
-#: ../../New-or-Enhanced-Logics.md:42
+#: ../../New-or-Enhanced-Logics.md:43
 msgid ""
 "`ForceDecloak`, if set to true, will uncloak and make the object the "
 "effect is attached to unable to cloak itself for duration of the effect."
 msgstr "如果 `ForceDecloak` 设为 true，被附加 AE 的对象在 AE 生效期间强制显形。"
 
-#: ../../New-or-Enhanced-Logics.md:43
+#: ../../New-or-Enhanced-Logics.md:44
 msgid ""
 "`WeaponRange.Multiplier` and `WeaponRange.ExtraRange` can be used to "
 "multiply the weapon firing range of the object the effect is attached to,"
@@ -327,7 +337,7 @@ msgstr ""
 "可分别用于乘算或加算（以单元格为单位）所附加对象的武器射程。`ExtraRange` 会在所有 AE 的 `Multiplier` "
 "值叠加后叠加计算。"
 
-#: ../../New-or-Enhanced-Logics.md:44
+#: ../../New-or-Enhanced-Logics.md:45
 msgid ""
 "`WeaponRange.AllowWeapons` can be used to list only weapons that can "
 "benefit from this range bonus and `WeaponRange.DisallowWeapons` weapons "
@@ -336,7 +346,7 @@ msgstr ""
 "`WeaponRange.AllowWeapons` 和 `WeaponRange.DisallowWeapons` "
 "分别设定哪些武器可以／不可以获得上述射程加成。"
 
-#: ../../New-or-Enhanced-Logics.md:45
+#: ../../New-or-Enhanced-Logics.md:46
 msgid ""
 "On TechnoTypes with `OpenTopped=true`, "
 "`OpenTopped.UseTransportRangeModifiers` can be set to true to make "
@@ -345,7 +355,7 @@ msgstr ""
 "对于拥有 `OpenTopped=true` 的科技类型，`OpenTopped.UseTransportRangeModifiers` 可以设为"
 " true 以使载员同步获得运输工具所获得的射程加成。"
 
-#: ../../New-or-Enhanced-Logics.md:46
+#: ../../New-or-Enhanced-Logics.md:47
 msgid ""
 "`Crit.Multiplier` and `Crit.ExtraChance` can be used to multiply the "
 "[critical hit](#chance-based-extra-damage-or-warhead-detonation"
@@ -355,26 +365,36 @@ msgstr ""
 "`Crit.Multiplier` 和 `Crit.ExtraChance` 可以分别乘算或加算 AE 所附加对象的[暴击](#chance-"
 "based-extra-damage-or-warhead-detonation--critical-hits)概率。"
 
-#: ../../New-or-Enhanced-Logics.md:47
+#: ../../New-or-Enhanced-Logics.md:48
 msgid ""
 "`Crit.AllowWarheads` can be used to list only Warheads that can benefit "
 "from this critical hit chance multiplier and `Crit.DisallowWarheads` "
 "weapons that are not allowed to, respectively."
 msgstr "`Crit.AllowWarheads` 和 `Crit.DisallowWarheads` 可分别列出哪些弹头可以／不可以获得上述暴击概率加成。"
 
-#: ../../New-or-Enhanced-Logics.md:48
+#: ../../New-or-Enhanced-Logics.md:49
 msgid ""
 "`RevengeWeapon` can be used to temporarily grant the specified weapon as "
 "a [revenge weapon](#revenge-weapon) for the attached object."
 msgstr "`RevengeWeapon` 可用于通过 AE 为被附加对象设置一个临时的[复仇武器](#revenge-weapon)。"
 
-#: ../../New-or-Enhanced-Logics.md:49
+#: ../../New-or-Enhanced-Logics.md:50
 msgid ""
 "`RevengeWeapon.AffectsHouses` customizes which houses can trigger the "
 "revenge weapon."
 msgstr "`RevengeWeapon.AffectsHouses` 定义哪些所属方可以触发这个复仇武器。"
 
-#: ../../New-or-Enhanced-Logics.md:50
+#: ../../New-or-Enhanced-Logics.md:51
+msgid ""
+"`RevengeWeapon.UseInvokerAsOwner` can be used to set the house and "
+"TechnoType that created the effect (e.g firer of the weapon that applied "
+"it) as the weapon's owner & invoker instead of the object the effect is "
+"attached to."
+msgstr ""
+"`RevengeWeapon.UseInvokerAsOwner` 可以设置创建该效果的所属方和科技类型（例如武器的发射者）为 `RevengeWeapon` "
+"的所有者和调用者而不是 AE 所附加的对象。"
+
+#: ../../New-or-Enhanced-Logics.md:52
 msgid ""
 "`ReflectDamage` can be set to true to have any positive damage dealt to "
 "the object the effect is attached to be reflected back to the attacker. "
@@ -394,7 +414,7 @@ msgstr ""
 "决定触发反弹的几率，`ReflectDamage.Multiplier` 是反弹回的伤害值相对于所接收的伤害值的倍率，而 "
 "`ReflectDamage.Override` 则定义反弹回了一个固定大小的伤害量。反弹效果不会被另一个反弹来的伤害所触发。"
 
-#: ../../New-or-Enhanced-Logics.md:51
+#: ../../New-or-Enhanced-Logics.md:53
 msgid ""
 "Warheads can prevent reflect damage from occuring by setting "
 "`SuppressReflectDamage` to true. `SuppressReflectDamage.Types` can "
@@ -408,13 +428,23 @@ msgstr ""
 "类型的反弹伤害效果会被抑制。如果留空则代表所有 AE 类型。`SuppressReflectDamage.Groups` "
 "的作用与此相同，但用于所列分组名下的所有 AE 类型。"
 
-#: ../../New-or-Enhanced-Logics.md:52
+#: ../../New-or-Enhanced-Logics.md:54
+msgid ""
+"`ReflectDamage.UseInvokerAsOwner` can be used to set the house and "
+"TechnoType that created the effect (e.g firer of the weapon that applied "
+"it) as the reflected damage's owner & invoker instead of the object the "
+"effect is attached to."
+msgstr ""
+"`ReflectDamage.UseInvokerAsOwner` 可以设置创建该效果的所属方和科技类型（例如武器的发射者）为 `ReflectDamage` "
+"的所有者和调用者而不是 AE 所附加的对象。"
+
+#: ../../New-or-Enhanced-Logics.md:55
 msgid ""
 "`DisableWeapons` can be used to disable ability to fire any and all "
 "weapons."
 msgstr "`DisableWeapons` 可用于禁用 AE 附加对象的所有武器。"
 
-#: ../../New-or-Enhanced-Logics.md:53
+#: ../../New-or-Enhanced-Logics.md:56
 msgid ""
 "On TechnoTypes with `OpenTopped=true`, "
 "`OpenTopped.CheckTransportDisableWeapons` can be set to true to make "
@@ -424,31 +454,31 @@ msgstr ""
 "在拥有 `OpenTopped=true` 的科技类型上，`OpenTopped.CheckTransportDisableWeapons` "
 "可设为 true 以使载员在运输工具受 `DisableWeapons` 影响期间同步禁言效果。"
 
-#: ../../New-or-Enhanced-Logics.md:54
+#: ../../New-or-Enhanced-Logics.md:57
 msgid ""
 "`Unkillable` can be used to prevent the techno from being killed by taken"
 " damage (minimum health will be 1)."
 msgstr "`Unkillable` 可用于防止科技类型因受到伤害而死亡（最低为 1）。"
 
-#: ../../New-or-Enhanced-Logics.md:55
+#: ../../New-or-Enhanced-Logics.md:58
 msgid ""
 "It is possible to set groups for attach effect types by defining strings "
 "in `Groups`."
 msgstr "可以通过在 `Groups` 中定义字符串来为 AE 类型设置分组。"
 
-#: ../../New-or-Enhanced-Logics.md:56
+#: ../../New-or-Enhanced-Logics.md:59
 msgid ""
 "Groups can be used instead of types for removing effects and weapon "
 "filters."
 msgstr "组别可用于在移除 AE 和武器过滤时替代类型参与计算。"
 
-#: ../../New-or-Enhanced-Logics.md:58
+#: ../../New-or-Enhanced-Logics.md:61
 msgid ""
 "AttachEffectTypes can be attached to TechnoTypes using "
 "`AttachEffect.AttachTypes`."
 msgstr "AE 可以通过 `AttachEffect.AttachTypes` 在科技类型上赋予。"
 
-#: ../../New-or-Enhanced-Logics.md:59 ../../New-or-Enhanced-Logics.md:66
+#: ../../New-or-Enhanced-Logics.md:62 ../../New-or-Enhanced-Logics.md:69
 msgid ""
 "`AttachEffect.DurationOverrides` can be used to override the default "
 "durations. Duration matching the position in `AttachTypes` is used for "
@@ -457,7 +487,7 @@ msgstr ""
 "`AttachEffect.DurationOverrides` 可用于覆盖 AE 自身所写的默认 `Duration`。该列表中的值与 "
 "`AttachTypes` 中的 AE 类型一一对应，如果一个 AE 类型没有对应的项目则使用该列表中的最后一个。"
 
-#: ../../New-or-Enhanced-Logics.md:60
+#: ../../New-or-Enhanced-Logics.md:63
 msgid ""
 "`AttachEffect.Delays` can be used to set the delays for recreating the "
 "effects on the TechnoType after they expire. Defaults to 0 (immediately),"
@@ -468,7 +498,7 @@ msgstr ""
 "`AttachEffect.Delays` 可用于设置 AE 在科技类型上自然结束后重新创建所需的时间间隔。默认为 0（立即），负值表示 AE "
 "不会被重新创建。该列表中的值与 `AttachTypes` 中的 AE 类型一一对应，如果一个 AE 类型没有对应的项目则使用该列表中的最后一个。"
 
-#: ../../New-or-Enhanced-Logics.md:61
+#: ../../New-or-Enhanced-Logics.md:64
 msgid ""
 "`AttachEffect.InitialDelays` can be used to set the delays before first "
 "creating the effects on TechnoType. Defaults to 0 (immediately). Delay "
@@ -478,7 +508,7 @@ msgstr ""
 "`AttachEffect.InitialDelays` 可用于设置 AE 在科技类型上首次创建所需的初始间隔。默认为 0（立即）。该列表中的值与"
 " `AttachTypes` 中的 AE 类型一一对应，如果一个 AE 类型没有对应的项目则使用该列表中的最后一个。"
 
-#: ../../New-or-Enhanced-Logics.md:62
+#: ../../New-or-Enhanced-Logics.md:65
 msgid ""
 "`AttachEffect.RecreationDelays` is used to determine if the effect can be"
 " recreated if it is removed completely (e.g `AttachEffect.RemoveTypes`), "
@@ -491,7 +521,7 @@ msgstr ""
 "表示不允许重新创建。该列表中的值与 `AttachTypes` 中的 AE 类型一一对应，如果一个 AE "
 "类型没有对应的项目则使用该列表中的最后一个。"
 
-#: ../../New-or-Enhanced-Logics.md:63
+#: ../../New-or-Enhanced-Logics.md:66
 msgid ""
 "Note that neither `InitialDelays` or `RecreationDelays` count down if the"
 " effect cannot currently be active due to `DiscardOn` condition."
@@ -499,13 +529,13 @@ msgstr ""
 "需要注意的是 `InitialDelays` 或 `RecreationDelays` 在由于 `DiscardOn` 导致 AE "
 "当前不生效的情况下都不会进行计时。"
 
-#: ../../New-or-Enhanced-Logics.md:65
+#: ../../New-or-Enhanced-Logics.md:68
 msgid ""
 "AttachEffectTypes can be attached to objects via Warheads using "
 "`AttachEffect.AttachTypes`."
 msgstr "AE 可以通过 `AttachEffect.AttachTypes` 被弹头上赋予给其他对象。"
 
-#: ../../New-or-Enhanced-Logics.md:67
+#: ../../New-or-Enhanced-Logics.md:70
 msgid ""
 "`AttachEffect.CumulativeRefreshAll` if set to true makes it so that "
 "trying to attach `Cumulative=true` effect to a target that already has "
@@ -520,7 +550,7 @@ msgstr ""
 "的持续时间而不只是刷新所剩持续时间最短的那个。如果 `AttachEffect.CumulativeRefreshAll.OnAttach` "
 "也设为 true，那么即使未达到 `Cumulative.MaxCount` 也使用此刷新效果。"
 
-#: ../../New-or-Enhanced-Logics.md:68
+#: ../../New-or-Enhanced-Logics.md:71
 msgid ""
 "`AttachEffect.CumulativeRefreshSameSourceOnly` controls whether or not "
 "trying to apply `Cumulative=true` effect on target requires any existing "
@@ -530,13 +560,13 @@ msgstr ""
 "`AttachEffect.CumulativeRefreshSameSourceOnly` 控制是否需要现有 AE "
 "来自同一个发射者的同一个弹头才能达到使用上述刷新效果的条件。"
 
-#: ../../New-or-Enhanced-Logics.md:69
+#: ../../New-or-Enhanced-Logics.md:72
 msgid ""
 "Attached Effects can be removed from objects by Warheads using "
 "`AttachEffect.RemoveTypes` or `AttachEffect.RemoveGroups`."
 msgstr "AE 可以通过弹头上的 `AttachEffect.RemoveTypes` 或 `AttachEffect.RemoveGroups` 移除。"
 
-#: ../../New-or-Enhanced-Logics.md:70
+#: ../../New-or-Enhanced-Logics.md:73
 msgid ""
 "`AttachEffect.CumulativeRemoveMinCounts` sets minimum number of active "
 "instaces per `RemoveTypes`/`RemoveGroups` required for `Cumulative=true` "
@@ -545,7 +575,7 @@ msgstr ""
 "`AttachEffect.CumulativeRemoveMinCounts` 设置了 `Cumulative=true` 类 AE 被 "
 "`RemoveTypes`/`RemoveGroups` 每次移除的最小数量。"
 
-#: ../../New-or-Enhanced-Logics.md:71
+#: ../../New-or-Enhanced-Logics.md:74
 msgid ""
 "`AttachEffect.CumulativeRemoveMaxCounts` sets maximum number of active "
 "instaces per `RemoveTypes`/`RemoveGroups` for `Cumulative=true` that are "
@@ -554,13 +584,13 @@ msgstr ""
 "`AttachEffect.CumulativeRemoveMaxCounts` 设置了 `Cumulative=true` 类 AE 被 "
 "`RemoveTypes`/`RemoveGroups` 一次移除的最大数量。"
 
-#: ../../New-or-Enhanced-Logics.md:73
+#: ../../New-or-Enhanced-Logics.md:76
 msgid ""
 "Weapons can require attached effects on target to fire, or be prevented "
 "by firing if specific attached effects are applied."
 msgstr "武器可以根据目标上是否附加了特定的 AE 来决定是否（不）可以开火。"
 
-#: ../../New-or-Enhanced-Logics.md:74
+#: ../../New-or-Enhanced-Logics.md:77
 msgid ""
 "`AttachEffect.RequiredTypes` can be used to list attached effects "
 "required to be on target to fire, all listed effect types must be present"
@@ -569,7 +599,7 @@ msgstr ""
 "`AttachEffect.RequiredTypes` 可用设置一个对象可以作为武器目标所需要拥有的 AE 列表，当所有列出的 AE "
 "类型全部拥有时才允许开火。"
 
-#: ../../New-or-Enhanced-Logics.md:75
+#: ../../New-or-Enhanced-Logics.md:78
 msgid ""
 "`AttachEffect.DisallowedTypes` can be used to list attached effects that "
 "when present prevent the weapon from firing, any of the listed effect "
@@ -578,7 +608,7 @@ msgstr ""
 "`AttachEffect.DisallowedTypes` 可用于设置一个对象作为武器目标所不得拥有的 AE 列表，当表中列出的 AE "
 "任一类型存在时将阻止开火。"
 
-#: ../../New-or-Enhanced-Logics.md:76
+#: ../../New-or-Enhanced-Logics.md:79
 msgid ""
 "`AttachEffect.Required/DisallowedGroups` have the same effect except "
 "applied with/to all types that have one of the listed groups in their "
@@ -587,7 +617,7 @@ msgstr ""
 "`AttachEffect.Required/DisallowedGroups` 与上面两句拥有相同的效果但使用 `Groups` 列表而不是 "
 "AE 类型列表。"
 
-#: ../../New-or-Enhanced-Logics.md:77
+#: ../../New-or-Enhanced-Logics.md:80
 msgid ""
 "`AttachEffect.(Required|Disallowed)MinCounts & "
 "(Required|Disallowed)MaxCounts` can be used to set the minimum and "
@@ -598,69 +628,70 @@ msgstr ""
 "(Required|Disallowed)MaxCounts` 可用于设置科技类型上必须存在／禁止存在的 `Cumulative=true` "
 "类（对其他类型无效） AE 的最小／最大数量。"
 
-#: ../../New-or-Enhanced-Logics.md:78
+#: ../../New-or-Enhanced-Logics.md:81
 msgid ""
 "`AttachEffect.IgnoreFromSameSource` can be set to true to ignore effects "
 "that have been attached by the firer of the weapon and its Warhead."
 msgstr "`AttachEffect.IgnoreFromSameSource` 可设为 true 以忽略由武器开火者及其弹头赋予的 AE 效果。"
 
-#: ../../New-or-Enhanced-Logics.md:79
+#: ../../New-or-Enhanced-Logics.md:82
 msgid ""
 "`AttachEffect.CheckOnFirer` is set to true makes it so that the required "
 "/ disallowed attached effects are checked from the firer of the weapon "
 "instead of the target."
 msgstr "`AttachEffect.CheckOnFirer` 可设为 true 以将必须存在／禁止存在 AE 的检查对象更改为武器发射者而不是目标。"
 
-#: ../../New-or-Enhanced-Logics.md:81 ../../New-or-Enhanced-Logics.md:190
-#: ../../New-or-Enhanced-Logics.md:258 ../../New-or-Enhanced-Logics.md:276
-#: ../../New-or-Enhanced-Logics.md:542 ../../New-or-Enhanced-Logics.md:555
-#: ../../New-or-Enhanced-Logics.md:574 ../../New-or-Enhanced-Logics.md:586
-#: ../../New-or-Enhanced-Logics.md:600 ../../New-or-Enhanced-Logics.md:644
-#: ../../New-or-Enhanced-Logics.md:657 ../../New-or-Enhanced-Logics.md:668
-#: ../../New-or-Enhanced-Logics.md:682 ../../New-or-Enhanced-Logics.md:719
-#: ../../New-or-Enhanced-Logics.md:759 ../../New-or-Enhanced-Logics.md:799
-#: ../../New-or-Enhanced-Logics.md:863 ../../New-or-Enhanced-Logics.md:918
-#: ../../New-or-Enhanced-Logics.md:953 ../../New-or-Enhanced-Logics.md:968
-#: ../../New-or-Enhanced-Logics.md:981 ../../New-or-Enhanced-Logics.md:1004
-#: ../../New-or-Enhanced-Logics.md:1030 ../../New-or-Enhanced-Logics.md:1043
-#: ../../New-or-Enhanced-Logics.md:1080 ../../New-or-Enhanced-Logics.md:1105
-#: ../../New-or-Enhanced-Logics.md:1125 ../../New-or-Enhanced-Logics.md:1142
-#: ../../New-or-Enhanced-Logics.md:1168 ../../New-or-Enhanced-Logics.md:1203
-#: ../../New-or-Enhanced-Logics.md:1231 ../../New-or-Enhanced-Logics.md:1242
-#: ../../New-or-Enhanced-Logics.md:1264 ../../New-or-Enhanced-Logics.md:1282
-#: ../../New-or-Enhanced-Logics.md:1296 ../../New-or-Enhanced-Logics.md:1327
-#: ../../New-or-Enhanced-Logics.md:1343 ../../New-or-Enhanced-Logics.md:1362
-#: ../../New-or-Enhanced-Logics.md:1375 ../../New-or-Enhanced-Logics.md:1391
-#: ../../New-or-Enhanced-Logics.md:1429 ../../New-or-Enhanced-Logics.md:1452
-#: ../../New-or-Enhanced-Logics.md:1466 ../../New-or-Enhanced-Logics.md:1502
-#: ../../New-or-Enhanced-Logics.md:1530 ../../New-or-Enhanced-Logics.md:1543
-#: ../../New-or-Enhanced-Logics.md:1557 ../../New-or-Enhanced-Logics.md:1576
-#: ../../New-or-Enhanced-Logics.md:1595 ../../New-or-Enhanced-Logics.md:1608
-#: ../../New-or-Enhanced-Logics.md:1638 ../../New-or-Enhanced-Logics.md:1668
-#: ../../New-or-Enhanced-Logics.md:1684 ../../New-or-Enhanced-Logics.md:1702
-#: ../../New-or-Enhanced-Logics.md:1718 ../../New-or-Enhanced-Logics.md:1731
-#: ../../New-or-Enhanced-Logics.md:1750 ../../New-or-Enhanced-Logics.md:1773
-#: ../../New-or-Enhanced-Logics.md:1789 ../../New-or-Enhanced-Logics.md:1801
-#: ../../New-or-Enhanced-Logics.md:1814 ../../New-or-Enhanced-Logics.md:1831
-#: ../../New-or-Enhanced-Logics.md:1848 ../../New-or-Enhanced-Logics.md:1869
-#: ../../New-or-Enhanced-Logics.md:1907 ../../New-or-Enhanced-Logics.md:1917
-#: ../../New-or-Enhanced-Logics.md:1940 ../../New-or-Enhanced-Logics.md:1983
-#: ../../New-or-Enhanced-Logics.md:2007 ../../New-or-Enhanced-Logics.md:2018
-#: ../../New-or-Enhanced-Logics.md:2029 ../../New-or-Enhanced-Logics.md:2052
-#: ../../New-or-Enhanced-Logics.md:2076 ../../New-or-Enhanced-Logics.md:2102
-#: ../../New-or-Enhanced-Logics.md:2117 ../../New-or-Enhanced-Logics.md:2143
-#: ../../New-or-Enhanced-Logics.md:2159 ../../New-or-Enhanced-Logics.md:2169
-#: ../../New-or-Enhanced-Logics.md:2180 ../../New-or-Enhanced-Logics.md:2193
-#: ../../New-or-Enhanced-Logics.md:2207 ../../New-or-Enhanced-Logics.md:2220
-#: ../../New-or-Enhanced-Logics.md:2231 ../../New-or-Enhanced-Logics.md:2245
-#: ../../New-or-Enhanced-Logics.md:2261 ../../New-or-Enhanced-Logics.md:2276
-#: ../../New-or-Enhanced-Logics.md:2293 ../../New-or-Enhanced-Logics.md:2306
-#: ../../New-or-Enhanced-Logics.md:2319 ../../New-or-Enhanced-Logics.md:2343
-#: ../../New-or-Enhanced-Logics.md:2357 ../../New-or-Enhanced-Logics.md:2379
+#: ../../New-or-Enhanced-Logics.md:84 ../../New-or-Enhanced-Logics.md:197
+#: ../../New-or-Enhanced-Logics.md:279 ../../New-or-Enhanced-Logics.md:297
+#: ../../New-or-Enhanced-Logics.md:563 ../../New-or-Enhanced-Logics.md:576
+#: ../../New-or-Enhanced-Logics.md:589 ../../New-or-Enhanced-Logics.md:612
+#: ../../New-or-Enhanced-Logics.md:624 ../../New-or-Enhanced-Logics.md:638
+#: ../../New-or-Enhanced-Logics.md:665 ../../New-or-Enhanced-Logics.md:678
+#: ../../New-or-Enhanced-Logics.md:689 ../../New-or-Enhanced-Logics.md:703
+#: ../../New-or-Enhanced-Logics.md:740 ../../New-or-Enhanced-Logics.md:780
+#: ../../New-or-Enhanced-Logics.md:820 ../../New-or-Enhanced-Logics.md:884
+#: ../../New-or-Enhanced-Logics.md:939 ../../New-or-Enhanced-Logics.md:974
+#: ../../New-or-Enhanced-Logics.md:989 ../../New-or-Enhanced-Logics.md:1002
+#: ../../New-or-Enhanced-Logics.md:1025 ../../New-or-Enhanced-Logics.md:1051
+#: ../../New-or-Enhanced-Logics.md:1064 ../../New-or-Enhanced-Logics.md:1101
+#: ../../New-or-Enhanced-Logics.md:1126 ../../New-or-Enhanced-Logics.md:1146
+#: ../../New-or-Enhanced-Logics.md:1163 ../../New-or-Enhanced-Logics.md:1189
+#: ../../New-or-Enhanced-Logics.md:1224 ../../New-or-Enhanced-Logics.md:1252
+#: ../../New-or-Enhanced-Logics.md:1263 ../../New-or-Enhanced-Logics.md:1285
+#: ../../New-or-Enhanced-Logics.md:1303 ../../New-or-Enhanced-Logics.md:1317
+#: ../../New-or-Enhanced-Logics.md:1348 ../../New-or-Enhanced-Logics.md:1364
+#: ../../New-or-Enhanced-Logics.md:1383 ../../New-or-Enhanced-Logics.md:1396
+#: ../../New-or-Enhanced-Logics.md:1412 ../../New-or-Enhanced-Logics.md:1450
+#: ../../New-or-Enhanced-Logics.md:1473 ../../New-or-Enhanced-Logics.md:1487
+#: ../../New-or-Enhanced-Logics.md:1523 ../../New-or-Enhanced-Logics.md:1551
+#: ../../New-or-Enhanced-Logics.md:1564 ../../New-or-Enhanced-Logics.md:1578
+#: ../../New-or-Enhanced-Logics.md:1597 ../../New-or-Enhanced-Logics.md:1616
+#: ../../New-or-Enhanced-Logics.md:1629 ../../New-or-Enhanced-Logics.md:1659
+#: ../../New-or-Enhanced-Logics.md:1689 ../../New-or-Enhanced-Logics.md:1705
+#: ../../New-or-Enhanced-Logics.md:1723 ../../New-or-Enhanced-Logics.md:1739
+#: ../../New-or-Enhanced-Logics.md:1752 ../../New-or-Enhanced-Logics.md:1771
+#: ../../New-or-Enhanced-Logics.md:1794 ../../New-or-Enhanced-Logics.md:1810
+#: ../../New-or-Enhanced-Logics.md:1822 ../../New-or-Enhanced-Logics.md:1835
+#: ../../New-or-Enhanced-Logics.md:1852 ../../New-or-Enhanced-Logics.md:1869
+#: ../../New-or-Enhanced-Logics.md:1890 ../../New-or-Enhanced-Logics.md:1929
+#: ../../New-or-Enhanced-Logics.md:1939 ../../New-or-Enhanced-Logics.md:1962
+#: ../../New-or-Enhanced-Logics.md:2005 ../../New-or-Enhanced-Logics.md:2029
+#: ../../New-or-Enhanced-Logics.md:2040 ../../New-or-Enhanced-Logics.md:2051
+#: ../../New-or-Enhanced-Logics.md:2074 ../../New-or-Enhanced-Logics.md:2098
+#: ../../New-or-Enhanced-Logics.md:2124 ../../New-or-Enhanced-Logics.md:2139
+#: ../../New-or-Enhanced-Logics.md:2165 ../../New-or-Enhanced-Logics.md:2181
+#: ../../New-or-Enhanced-Logics.md:2191 ../../New-or-Enhanced-Logics.md:2202
+#: ../../New-or-Enhanced-Logics.md:2215 ../../New-or-Enhanced-Logics.md:2229
+#: ../../New-or-Enhanced-Logics.md:2242 ../../New-or-Enhanced-Logics.md:2253
+#: ../../New-or-Enhanced-Logics.md:2267 ../../New-or-Enhanced-Logics.md:2283
+#: ../../New-or-Enhanced-Logics.md:2298 ../../New-or-Enhanced-Logics.md:2315
+#: ../../New-or-Enhanced-Logics.md:2328 ../../New-or-Enhanced-Logics.md:2341
+#: ../../New-or-Enhanced-Logics.md:2365 ../../New-or-Enhanced-Logics.md:2379
+#: ../../New-or-Enhanced-Logics.md:2401
 msgid "In `rulesmd.ini`:"
 msgstr "在 `rulesmd.ini`："
 
-#: ../../New-or-Enhanced-Logics.md:82
+#: ../../New-or-Enhanced-Logics.md:85
 msgid ""
 "[AttachEffectTypes]\n"
 "0=SOMEATTACHEFFECT\n"
@@ -697,6 +728,7 @@ msgid ""
 "weapon trigger condition enumeration "
 "(none|expire|remove|death|discard|all)\n"
 "ExpireWeapon.CumulativeOnlyOnce=false              ; boolean\n"
+"ExpireWeapon.UseInvokerAsOwner=false               ; boolean\n"
 "Tint.Color=                                        ; integer - R,G,B\n"
 "Tint.Intensity=                                    ; floating point value"
 "\n"
@@ -734,6 +766,7 @@ msgid ""
 "RevengeWeapon=                                     ; WeaponType\n"
 "RevengeWeapon.AffectsHouses=all                    ; List of Affected "
 "House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)\n"
+"RevengeWeapon.UseInvokerAsOwner=false              ; boolean\n"
 "ReflectDamage=false                                ; boolean\n"
 "ReflectDamage.Warhead=                             ; WarheadType\n"
 "ReflectDamage.Warhead.Detonate=false               ; WarheadType\n"
@@ -744,8 +777,10 @@ msgid ""
 "ReflectDamage.Chance=1.0                           ; floating point value"
 "\n"
 "ReflectDamage.Override=                            ; integer\n"
+"ReflectDamage.UseInvokerAsOwner=false              ; boolean\n"
 "DisableWeapons=false                               ; boolean\n"
 "Unkillable=false                                   ; boolean\n"
+"LaserTrail.Type=                                   ; lasertrail type\n"
 "Groups=                                            ; comma-separated list"
 " of strings (group IDs)\n"
 "\n"
@@ -848,6 +883,7 @@ msgstr ""
 "weapon trigger condition enumeration "
 "(none|expire|remove|death|discard|all)\n"
 "ExpireWeapon.CumulativeOnlyOnce=false              ; boolean\n"
+"ExpireWeapon.UseInvokerAsOwner=false               ; boolean\n"
 "Tint.Color=                                        ; integer - R,G,B\n"
 "Tint.Intensity=                                    ; floating point value"
 "\n"
@@ -885,6 +921,7 @@ msgstr ""
 "RevengeWeapon=                                     ; WeaponType\n"
 "RevengeWeapon.AffectsHouses=all                    ; List of Affected "
 "House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)\n"
+"RevengeWeapon.UseInvokerAsOwner=false              ; boolean\n"
 "ReflectDamage=false                                ; boolean\n"
 "ReflectDamage.Warhead=                             ; WarheadType\n"
 "ReflectDamage.Warhead.Detonate=false               ; WarheadType\n"
@@ -895,8 +932,10 @@ msgstr ""
 "ReflectDamage.Chance=1.0                           ; floating point value"
 "\n"
 "ReflectDamage.Override=                            ; integer\n"
+"ReflectDamage.UseInvokerAsOwner=false              ; boolean\n"
 "DisableWeapons=false                               ; boolean\n"
 "Unkillable=false                                   ; boolean\n"
+"LaserTrail.Type=                                   ; lasertrail type\n"
 "Groups=                                            ; comma-separated list"
 " of strings (group IDs)\n"
 "\n"
@@ -964,38 +1003,38 @@ msgstr ""
 "SuppressReflectDamage.Groups=                      ; comma-separated list"
 " of strings (group IDs)\n"
 
-#: ../../New-or-Enhanced-Logics.md:177
+#: ../../New-or-Enhanced-Logics.md:184
 msgid "Custom Radiation Types"
 msgstr "自定义辐射类型"
 
-#: ../../New-or-Enhanced-Logics.md:179
+#: ../../New-or-Enhanced-Logics.md:186
 msgid "![image](_static/images/radtype-01.png) *Mixing different radiation types*"
 msgstr "![image](_static/images/radtype-01.png) *混合起来的多种辐射类型*"
 
-#: ../../New-or-Enhanced-Logics.md:179 ../../New-or-Enhanced-Logics.md:273
-#: ../../New-or-Enhanced-Logics.md:455 ../../New-or-Enhanced-Logics.md:563
-#: ../../New-or-Enhanced-Logics.md:703 ../../New-or-Enhanced-Logics.md:1097
-#: ../../New-or-Enhanced-Logics.md:1155 ../../New-or-Enhanced-Logics.md:1413
-#: ../../New-or-Enhanced-Logics.md:1416 ../../New-or-Enhanced-Logics.md:1460
-#: ../../New-or-Enhanced-Logics.md:1521 ../../New-or-Enhanced-Logics.md:1590
-#: ../../New-or-Enhanced-Logics.md:1861 ../../New-or-Enhanced-Logics.md:1902
-#: ../../New-or-Enhanced-Logics.md:2015 ../../New-or-Enhanced-Logics.md:2093
-#: ../../New-or-Enhanced-Logics.md:2287 ../../New-or-Enhanced-Logics.md:2332
-#: ../../New-or-Enhanced-Logics.md:2373
+#: ../../New-or-Enhanced-Logics.md:186 ../../New-or-Enhanced-Logics.md:294
+#: ../../New-or-Enhanced-Logics.md:476 ../../New-or-Enhanced-Logics.md:601
+#: ../../New-or-Enhanced-Logics.md:724 ../../New-or-Enhanced-Logics.md:1118
+#: ../../New-or-Enhanced-Logics.md:1176 ../../New-or-Enhanced-Logics.md:1434
+#: ../../New-or-Enhanced-Logics.md:1437 ../../New-or-Enhanced-Logics.md:1481
+#: ../../New-or-Enhanced-Logics.md:1542 ../../New-or-Enhanced-Logics.md:1611
+#: ../../New-or-Enhanced-Logics.md:1882 ../../New-or-Enhanced-Logics.md:1924
+#: ../../New-or-Enhanced-Logics.md:2037 ../../New-or-Enhanced-Logics.md:2115
+#: ../../New-or-Enhanced-Logics.md:2309 ../../New-or-Enhanced-Logics.md:2354
+#: ../../New-or-Enhanced-Logics.md:2395
 msgid "image"
 msgstr "图像"
 
-#: ../../New-or-Enhanced-Logics.md:182
+#: ../../New-or-Enhanced-Logics.md:189
 msgid ""
 "Any weapon can now have a custom radiation type. More details on "
 "radiation [here](https://www.modenc.renegadeprojects.com/Radiation)."
 msgstr "现在任何武器都可以拥有自定义的辐射类。有关辐射的更多详细信息请参见[此处](https://www.modenc.renegadeprojects.com/Radiation)。"
 
-#: ../../New-or-Enhanced-Logics.md:183
+#: ../../New-or-Enhanced-Logics.md:190
 msgid "There are several new properties available to all radiation types."
 msgstr "所有辐射类型现在都有几个新的属性可用。"
 
-#: ../../New-or-Enhanced-Logics.md:184
+#: ../../New-or-Enhanced-Logics.md:191
 msgid ""
 "`RadApplicationDelay.Building` can be set to value higher than 0 to allow"
 " radiation to damage buildings. How many times a single radiation site "
@@ -1007,7 +1046,7 @@ msgstr ""
 "的值以允许辐射对建筑造成伤害。单个辐射源可以对同一建筑（建筑所占的每个单元格都会受到该单元格上所有辐射源的伤害）造成这种伤害的次数可以通过 "
 "`RadBuildingDamageMaxCount` 来定义，负值表示无限制。"
 
-#: ../../New-or-Enhanced-Logics.md:185
+#: ../../New-or-Enhanced-Logics.md:192
 msgid ""
 "`RadSiteWarhead.Detonate` can be set to make `RadSiteWarhead` detonate on"
 " affected objects rather than only be used to dealt direct damage. This "
@@ -1021,7 +1060,7 @@ msgstr ""
 "`RadSiteWarhead.Detonate.Full` 设为 false 那么它只能对所在区域造成杀伤和 Phobos "
 "所提供的弹头效果而不是完全引爆。"
 
-#: ../../New-or-Enhanced-Logics.md:186
+#: ../../New-or-Enhanced-Logics.md:193
 msgid ""
 "`RadHasOwner`, if set to true, makes damage dealt by the radiation count "
 "as having been dealt by the house that fired the projectile that created "
@@ -1032,7 +1071,7 @@ msgstr ""
 "`RadHasOwner` 如果设为 true 则辐射造成的伤害会被视为由发射用于创建辐射区域的抛射体其开火者的所属方造成的。这意味着诸如 "
 "`AffectsAllies` 之类的弹头设置将可以使用，并且任何被击杀的单位都将计入该玩家的摧毁数。"
 
-#: ../../New-or-Enhanced-Logics.md:187
+#: ../../New-or-Enhanced-Logics.md:194
 msgid ""
 "`RadHasInvoker`, if set to true, makes the damage dealt by the radiation "
 "count as having been dealt by the TechnoType (the 'invoker') that fired "
@@ -1046,7 +1085,7 @@ msgstr ""
 "`RadHasOwner` "
 "的效果外这还将使调用者从被辐射击杀的单位中获得经验。注意如果调用者在辐射生命周期中的任何时刻死亡那么它将继续变得如同没有调用者一样。"
 
-#: ../../New-or-Enhanced-Logics.md:188
+#: ../../New-or-Enhanced-Logics.md:195
 msgid ""
 "By default `UseGlobalRadApplicationDelay` is set to true. This makes game"
 " always use `RadApplicationDelay` and `RadApplicationDelay.Building` from"
@@ -1058,7 +1097,7 @@ msgstr ""
 "`RadApplicationDelay` 和 `RadApplicationDelay.Building` "
 "而不是特定辐射类型的。这是个性能优化措施，如果你需要给辐射类型使用不同的间隔那么应当禁用该设置。"
 
-#: ../../New-or-Enhanced-Logics.md:191
+#: ../../New-or-Enhanced-Logics.md:198
 msgid ""
 "[RadiationTypes]\n"
 "0=SOMERADTYPE\n"
@@ -1116,7 +1155,7 @@ msgstr ""
 "RadHasOwner=false                  ; boolean\n"
 "RadHasInvoker=false                ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:221
+#: ../../New-or-Enhanced-Logics.md:228
 msgid ""
 "Due to performance concerns, unless any radiation type has "
 "`RadApplicationDelay.Building` set to above 0, all functionality related "
@@ -1129,11 +1168,11 @@ msgstr ""
 "的辐射类型否则与之相关的所有功能在游戏内都将被完全禁用。这在其最早的可用时机（地图初始场景启动结束或存档加载后）就会进行判定，并且 **不会** "
 "随着后续场景的改变或存档的加载而更新。"
 
-#: ../../New-or-Enhanced-Logics.md:224 ../../New-or-Enhanced-Logics.md:226
+#: ../../New-or-Enhanced-Logics.md:231 ../../New-or-Enhanced-Logics.md:233
 msgid "Laser Trails"
 msgstr "激光尾焰"
 
-#: ../../New-or-Enhanced-Logics.md:226
+#: ../../New-or-Enhanced-Logics.md:233
 msgid ""
 "![Laser Trails](_static/images/lasertrails.gif) *Laser trails used in "
 "[Rise of the East](https://www.moddb.com/mods/riseoftheeast)*"
@@ -1141,48 +1180,67 @@ msgstr ""
 "![Laser Trails](_static/images/lasertrails.gif) "
 "*[东方崛起](https://www.moddb.com/mods/riseoftheeast) 中的激光尾焰应用实例*"
 
-#: ../../New-or-Enhanced-Logics.md:229
+#: ../../New-or-Enhanced-Logics.md:236
 msgid ""
 "Technos, Projectiles, and VoxelAnims can now have colorful trails of "
 "different transparency, thickness and color, which are drawn via laser "
 "drawing code."
 msgstr "科技类型、抛射体和 Voxel 碎片现在都可以拥有不同透明度、宽度和颜色的彩色尾焰，这些尾焰是通过激光绘制代码完成的。"
 
-#: ../../New-or-Enhanced-Logics.md:230
+#: ../../New-or-Enhanced-Logics.md:237
 msgid ""
 "Technos, Projectiles, and VoxelAnims can have multiple laser trails. For "
 "technos each trail can have custom laser trail type and FLH offset "
 "relative to turret and body."
 msgstr "科技类型、抛射体和 Voxel 碎片可以拥有多个尾焰。对于科技类型的每个激光尾焰都可以自定义其相对于炮塔或车体的 FLH 偏移值。"
 
-#: ../../New-or-Enhanced-Logics.md:232 ../../New-or-Enhanced-Logics.md:471
-#: ../../New-or-Enhanced-Logics.md:500 ../../New-or-Enhanced-Logics.md:514
-#: ../../New-or-Enhanced-Logics.md:527 ../../New-or-Enhanced-Logics.md:631
-#: ../../New-or-Enhanced-Logics.md:693 ../../New-or-Enhanced-Logics.md:1405
-#: ../../New-or-Enhanced-Logics.md:1884
+#: ../../New-or-Enhanced-Logics.md:238
+msgid "LaserTrail can also be drawn as EBolt or RadBeam."
+msgstr "激光尾焰现在同样可以使用 EBolt 或 辐射波 特效。"
+
+#: ../../New-or-Enhanced-Logics.md:240 ../../New-or-Enhanced-Logics.md:492
+#: ../../New-or-Enhanced-Logics.md:521 ../../New-or-Enhanced-Logics.md:535
+#: ../../New-or-Enhanced-Logics.md:548 ../../New-or-Enhanced-Logics.md:652
+#: ../../New-or-Enhanced-Logics.md:714 ../../New-or-Enhanced-Logics.md:1426
+#: ../../New-or-Enhanced-Logics.md:1905
 msgid "In `artmd.ini`:"
 msgstr "在 `artmd.ini`："
 
-#: ../../New-or-Enhanced-Logics.md:233
+#: ../../New-or-Enhanced-Logics.md:241
 msgid ""
 "[LaserTrailTypes]\n"
 "0=SOMETRAIL\n"
 "\n"
 "[SOMETRAIL]                      ; LaserTrailType name\n"
-"IsHouseColor=false               ; boolean\n"
-"Color=255,0,0                    ; integer - R,G,B\n"
-"FadeDuration=64                  ; integer\n"
-"Thickness=4                      ; integer\n"
+"DrawType=laser                   ; laser trail type (laser | ebolt | "
+"radbeam)\n"
+"FadeDuration=                    ; integer, default to 64 for laser, 17 "
+"for ebolt, 15 for radbeam\n"
 "SegmentLength=128                ; integer, minimal length of each trail "
 "segment\n"
 "IgnoreVertical=false             ; boolean, whether the trail won't be "
 "drawn on vertical movement\n"
-"IsIntense=false                  ; boolean, whether the laser is "
-"\"supported\" (AKA prism forwarding)\n"
 "CloakVisible=false               ; boolean, whether the laser is visible "
 "when the attached unit is cloaked\n"
 "CloakVisible.DetectedOnly=false  ; boolean, whether CloakVisible=true "
 "laser is visible only to those who can detect the attached unit\n"
+"; laser\n"
+"Color=255,0,0                    ; integer - R,G,B\n"
+"IsHouseColor=false               ; boolean\n"
+"Thickness=4                      ; integer\n"
+"IsIntense=false                  ; boolean, whether the laser is "
+"\"supported\" (AKA prism forwarding)\n"
+"; ebolt\n"
+"IsAlternateColor=false           ; boolean\n"
+"Bolt.Color1=                     ; integer - R,G,B\n"
+"Bolt.Disable1=false              ; boolean\n"
+"Bolt.Color2=                     ; integer - R,G,B\n"
+"Bolt.Disable2=false              ; boolean\n"
+"Bolt.Color3=                     ; integer - R,G,B\n"
+"Bolt.Disable3=false              ; boolean\n"
+"; radbeam\n"
+"Beam.Color=                      ; integer - R,G,B\n"
+"Beam.Amplitude=40.0              ; floating point value\n"
 "\n"
 "[SOMEPROJECTILE]                 ; Projectile Image\n"
 "LaserTrail.Types=SOMETRAIL       ; List of LaserTrailTypes\n"
@@ -1198,20 +1256,35 @@ msgstr ""
 "0=SOMETRAIL\n"
 "\n"
 "[SOMETRAIL]                      ; LaserTrailType name\n"
-"IsHouseColor=false               ; boolean\n"
-"Color=255,0,0                    ; integer - R,G,B\n"
-"FadeDuration=64                  ; integer\n"
-"Thickness=4                      ; integer\n"
+"DrawType=laser                   ; laser trail type (laser | ebolt | "
+"radbeam)\n"
+"FadeDuration=                    ; integer, default to 64 for laser, 17 "
+"for ebolt, 15 for radbeam\n"
 "SegmentLength=128                ; integer, minimal length of each trail "
 "segment\n"
 "IgnoreVertical=false             ; boolean, whether the trail won't be "
 "drawn on vertical movement\n"
-"IsIntense=false                  ; boolean, whether the laser is "
-"\"supported\" (AKA prism forwarding)\n"
 "CloakVisible=false               ; boolean, whether the laser is visible "
 "when the attached unit is cloaked\n"
 "CloakVisible.DetectedOnly=false  ; boolean, whether CloakVisible=true "
 "laser is visible only to those who can detect the attached unit\n"
+"; laser\n"
+"Color=255,0,0                    ; integer - R,G,B\n"
+"IsHouseColor=false               ; boolean\n"
+"Thickness=4                      ; integer\n"
+"IsIntense=false                  ; boolean, whether the laser is "
+"\"supported\" (AKA prism forwarding)\n"
+"; ebolt\n"
+"IsAlternateColor=false           ; boolean\n"
+"Bolt.Color1=                     ; integer - R,G,B\n"
+"Bolt.Disable1=false              ; boolean\n"
+"Bolt.Color2=                     ; integer - R,G,B\n"
+"Bolt.Disable2=false              ; boolean\n"
+"Bolt.Color3=                     ; integer - R,G,B\n"
+"Bolt.Disable3=false              ; boolean\n"
+"; radbeam\n"
+"Beam.Color=                      ; integer - R,G,B\n"
+"Beam.Amplitude=40.0              ; floating point value\n"
 "\n"
 "[SOMEPROJECTILE]                 ; Projectile Image\n"
 "LaserTrail.Types=SOMETRAIL       ; List of LaserTrailTypes\n"
@@ -1223,42 +1296,42 @@ msgstr ""
 "turret\n"
 "; where N = 0, 1, 2, ...\n"
 
-#: ../../New-or-Enhanced-Logics.md:259
+#: ../../New-or-Enhanced-Logics.md:280
 msgid ""
-"[SOMEVOXELANIM]             ; VoxelAnim\n"
-"LaserTrail.Types=SOMETRAIL  ; List of LaserTrailTypes\n"
+"[SOMEVOXELANIM]                  ; VoxelAnim\n"
+"LaserTrail.Types=SOMETRAIL       ; List of LaserTrailTypes\n"
 msgstr ""
-"[SOMEVOXELANIM]             ; VoxelAnim\n"
-"LaserTrail.Types=SOMETRAIL  ; List of LaserTrailTypes\n"
+"[SOMEVOXELANIM]                  ; VoxelAnim\n"
+"LaserTrail.Types=SOMETRAIL       ; List of LaserTrailTypes\n"
 
-#: ../../New-or-Enhanced-Logics.md:265
+#: ../../New-or-Enhanced-Logics.md:286
 msgid ""
 "Laser trails are very resource intensive! Due to the game not utilizing "
 "GPU having a lot of trails can quickly drop the FPS on even good "
 "machines. To reduce that effect:"
 msgstr "激光尾焰非常占用资源！由于游戏不使用 GPU，大量尾焰即便在高性能设备上也会迅速降低 FPS。想要减少这种影响："
 
-#: ../../New-or-Enhanced-Logics.md:266
+#: ../../New-or-Enhanced-Logics.md:287
 msgid "don't put too many laser trails on units and projectiles;"
 msgstr "不要在单位和抛射体上使用过多的激光尾焰；"
 
-#: ../../New-or-Enhanced-Logics.md:267
+#: ../../New-or-Enhanced-Logics.md:288
 msgid ""
 "make sure you set as high `SegmentLength` value as possible without "
 "trails being too jagged;"
 msgstr "在确保在尾焰不会过于锯齿状的前提下使用尽量高的 `SegmentLength` 值；"
 
-#: ../../New-or-Enhanced-Logics.md:268
+#: ../../New-or-Enhanced-Logics.md:289
 msgid ""
 "try to keep the length of the trail minimal (can be achieved with smaller"
 " `FadeDuration` durations)."
 msgstr "使用长度尽量短的激光尾焰，即设置一个较小的 `FadeDuration` 值。"
 
-#: ../../New-or-Enhanced-Logics.md:271
+#: ../../New-or-Enhanced-Logics.md:292
 msgid "Shields"
 msgstr "护盾"
 
-#: ../../New-or-Enhanced-Logics.md:273
+#: ../../New-or-Enhanced-Logics.md:294
 msgid ""
 "![image](_static/images/technoshield-01.gif) *Buildings, Infantries and "
 "Vehicles with Shield in [Fantasy ADVENTURE](https://www.moddb.com/mods"
@@ -1267,7 +1340,7 @@ msgstr ""
 "![image](_static/images/technoshield-01.gif) "
 "*[幻想奇遇](https://www.moddb.com/mods/fantasy-adventure) 中拥有护盾的建筑、步兵和载具*"
 
-#: ../../New-or-Enhanced-Logics.md:277
+#: ../../New-or-Enhanced-Logics.md:298
 msgid ""
 "[AudioVisual]\n"
 "Shield.ConditionYellow=                     ; floating point value, "
@@ -1523,13 +1596,13 @@ msgstr ""
 "Shield.MinimumReplaceDelay=0                ; integer, game frames\n"
 "Shield.InheritStateOnReplace=false          ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:382
+#: ../../New-or-Enhanced-Logics.md:403
 msgid ""
 "Now you can have a shield for any TechnoType. It serves as a second "
 "health pool with independent `Armor` and `Strength` values."
 msgstr "现在你可以给予任何科技类型护盾。它作为一个独立的第二血条拥有独立的 `Armor` 和 `Strength` 设定。"
 
-#: ../../New-or-Enhanced-Logics.md:383
+#: ../../New-or-Enhanced-Logics.md:404
 msgid ""
 "Shield will not take damage if the TechnoType is under effects of "
 "`Temporal` warhead, is Iron Curtained / Force Shielded, has `Immune=true`"
@@ -1539,13 +1612,13 @@ msgstr ""
 "如果科技类型处于 `Temporal` 弹头的效果中、处于铁幕／力场护盾保护中、拥有 `Immune=true` 或者拥有 "
 "`TypeImmune=true` 并且伤害来自相同所属的同种科技类型，那么护盾将不会受到伤害。"
 
-#: ../../New-or-Enhanced-Logics.md:384
+#: ../../New-or-Enhanced-Logics.md:405
 msgid ""
 "Negative damage will recover shield, unless shield has been broken. If "
 "shield isn't full, all negative damage will be absorbed by shield."
 msgstr "负值伤害将会恢复护盾，除非护盾已被击碎。在护盾回满前所有负值伤害都将被护盾吸收。"
 
-#: ../../New-or-Enhanced-Logics.md:385
+#: ../../New-or-Enhanced-Logics.md:406
 msgid ""
 "Negative damage weapons will consider targets with active, but not at "
 "full health shields in need of healing / repairing unless the Warhead has"
@@ -1554,7 +1627,7 @@ msgstr ""
 "负值伤害武器会将一个拥有激活状态且不满血的护盾的目标视为需要治疗／维修，除非弹头具有 "
 "`Shield.Penetrate=true`，这种情况下只会考虑对象的血量。"
 
-#: ../../New-or-Enhanced-Logics.md:386
+#: ../../New-or-Enhanced-Logics.md:407
 msgid ""
 "When a TechnoType has an unbroken shield, `[ShieldType] -> Armor` will "
 "replace `[TechnoType] -> Armor` for targeting and damage calculation "
@@ -1563,7 +1636,7 @@ msgstr ""
 "当一个科技类型拥有未被击碎的护盾时，`[ShieldType] -> Armor` 将替代 `[TechnoType] -> Armor` "
 "用于参与索敌和杀伤计算。"
 
-#: ../../New-or-Enhanced-Logics.md:387
+#: ../../New-or-Enhanced-Logics.md:408
 msgid ""
 "`InheritArmorFromTechno` can be set to true to override this so that "
 "`[TechnoType] -> Armor` is used even if shield is active and "
@@ -1572,7 +1645,7 @@ msgstr ""
 "`InheritArmorFromTechno` 可设为 true 以覆盖这一行为即即便护盾处于激活状态也使用 `[TechnoType] -> "
 "Armor` 而忽略 `[ShieldType] -> Armor`。"
 
-#: ../../New-or-Enhanced-Logics.md:388
+#: ../../New-or-Enhanced-Logics.md:409
 msgid ""
 "`InheritArmor.Allowed` lists TechnoTypes whose armor can be overridden. "
 "If empty, any TechnoType not listed in `InheritArmor.Disallowed` is okay."
@@ -1580,7 +1653,7 @@ msgstr ""
 "`InheritArmor.Allowed` 列出了其护甲可以被覆盖的科技类型。如果为空，则相当于任何不在 "
 "`InheritArmor.Disallowed` 列表的对象。"
 
-#: ../../New-or-Enhanced-Logics.md:389
+#: ../../New-or-Enhanced-Logics.md:410
 msgid ""
 "`InheritArmor.Disallowed` lists TechnoTypes whose armor can't be "
 "overridden. If empty, any TechnoTypes are okay as long as "
@@ -1589,13 +1662,13 @@ msgstr ""
 "`InheritArmor.Disallowed` 列出了其护甲不可被覆盖的科技类型。如果为空，则相当于任何科技类型都可以被覆盖，只要 "
 "`InheritArmor.Allowed` 为空或者这些科技类型列在该列表中。"
 
-#: ../../New-or-Enhanced-Logics.md:390
+#: ../../New-or-Enhanced-Logics.md:411
 msgid ""
 "`InitialStrength` can be used to set a different initial strength value "
 "from maximum."
 msgstr "`InitialStrength` 可用于设置一个不同于最大值的初始护盾值。"
 
-#: ../../New-or-Enhanced-Logics.md:391
+#: ../../New-or-Enhanced-Logics.md:412
 msgid ""
 "`ConditionYellow` and `ConditionRed` can be used to set the thresholds "
 "for shield damage states, defaulting to `[AudioVisual] -> "
@@ -1606,7 +1679,7 @@ msgstr ""
 "-> Shield.ConditionYellow & Shield.ConditionRed` 而它们又默认为 `ConditionYellow"
 " & ConditionRed`。"
 
-#: ../../New-or-Enhanced-Logics.md:392
+#: ../../New-or-Enhanced-Logics.md:413
 msgid ""
 "When executing `DeploysInto` or `UndeploysInto`, if both of the "
 "TechnoTypes have shields, the transformed unit/building would keep "
@@ -1618,29 +1691,29 @@ msgstr ""
 "时，如果两个科技类型都拥有护盾，转换后的单位／建筑将保持相对（百分比）的护盾值，类似 "
 "`Strength`。如果其中一个科技类型没有护盾，其护盾状态会被保留直到转换回来。"
 
-#: ../../New-or-Enhanced-Logics.md:393
+#: ../../New-or-Enhanced-Logics.md:414
 msgid "This also works with Ares' `Convert.*`."
 msgstr "这同样适用于 Ares 的 `Convert.*`。"
 
-#: ../../New-or-Enhanced-Logics.md:394
+#: ../../New-or-Enhanced-Logics.md:415
 msgid ""
 "`Powered` controls whether or not the shield is active when a unit is "
 "running low on power or it is affected by EMP."
 msgstr "`Powered` 控制当前单位电力不足或受 EMP 影响时护盾是否依然工作。"
 
-#: ../../New-or-Enhanced-Logics.md:395
+#: ../../New-or-Enhanced-Logics.md:416
 msgid ""
 "Attention, if TechnoType itself is not `Powered`, then the shield won't "
 "be offline when low power."
 msgstr "注意，如果科技类型自身不受制于  `Powered`，那么护盾在电力不足时也不会罢工。"
 
-#: ../../New-or-Enhanced-Logics.md:396
+#: ../../New-or-Enhanced-Logics.md:417
 msgid ""
 "`AbsorbOverDamage` controls whether or not the shield absorbs damage "
 "dealt beyond shield's current strength when the shield breaks."
 msgstr "`AbsorbOverDamage` 控制护盾是否在被击碎时吸收本次所受的所有伤害。"
 
-#: ../../New-or-Enhanced-Logics.md:397
+#: ../../New-or-Enhanced-Logics.md:418
 #, python-format
 msgid ""
 "`SelfHealing` and `Respawn` respect the following settings: 0.0 disables "
@@ -1651,13 +1724,13 @@ msgstr ""
 "`SelfHealing` 和 `Respawn` 遵循以下设置：0.0 禁用该功能，1%-100% "
 "按百分比恢复／重生护盾值，其他数字直接恢复／重生指定护盾值。特别的一点是 `SelfHealing` 为负数代表扣除护盾值。"
 
-#: ../../New-or-Enhanced-Logics.md:398
+#: ../../New-or-Enhanced-Logics.md:419
 msgid ""
 "If you want shield recovers/respawns 1 HP per time, currently you need to"
 " set tag value to any number between 1 and 2, like `1.1`."
 msgstr "如果你想让护盾每次恢复／重生 1 点 HP，目前你需要将标签值设为 1 到 2 之间的任意数字，比如 `1.1`。"
 
-#: ../../New-or-Enhanced-Logics.md:399
+#: ../../New-or-Enhanced-Logics.md:420
 msgid ""
 "If `SelfHealing.RestartInCombat` is set, self-healing timer pauses and "
 "then resumes after `SelfHealing.RestartInCombatDelay` frames have passed "
@@ -1666,7 +1739,7 @@ msgstr ""
 "如果设置了 `SelfHealing.RestartInCombat` 当护盾受到伤害时其恢复计时器将被暂停直至 "
 "`SelfHealing.RestartInCombatDelay` 指定的帧数后。"
 
-#: ../../New-or-Enhanced-Logics.md:400
+#: ../../New-or-Enhanced-Logics.md:421
 msgid ""
 "`SelfHealing.Rate` and `Respawn.Rate` respect the following settings: 0.0"
 " instantly recovers the shield, other values determine the frequency of "
@@ -1675,20 +1748,20 @@ msgstr ""
 "`SelfHealing.Rate` 和 `Respawn.Rate` 遵循以下设置：0.0 "
 "立即恢复护盾，其他值表示护盾恢复／重生间隔（单位：分）。"
 
-#: ../../New-or-Enhanced-Logics.md:401
+#: ../../New-or-Enhanced-Logics.md:422
 msgid ""
 "`SelfHealing.EnabledBy` can be used to control the self-heal of the "
 "shield. If the owner has no structures from this list then the shield "
 "won't self-heal."
 msgstr "`SelfHealing.EnabledBy` 可用于控制护盾自愈行为。只有拥有此列表中的建筑时才可以自愈。"
 
-#: ../../New-or-Enhanced-Logics.md:402
+#: ../../New-or-Enhanced-Logics.md:423
 msgid ""
 "`IdleAnim`, if set, will be played while the shield is intact. This "
 "animation is automatically set to loop indefinitely."
 msgstr "`IdleAnim` 如果设置则会在护盾完好时播放。该动画会自动设置为无限循环播放。"
 
-#: ../../New-or-Enhanced-Logics.md:403
+#: ../../New-or-Enhanced-Logics.md:424
 msgid ""
 "`IdleAnim.ConditionYellow` and `IdleAnim.ConditionRed` can be used to set"
 " different animations for when shield health is at or below the "
@@ -1701,7 +1774,7 @@ msgstr ""
 "`IdleAnim.ConditionRed` 则会回退到 `IdleAnim.ConditionYellow`，而后者则会回退到 "
 "`IdleAnim`。"
 
-#: ../../New-or-Enhanced-Logics.md:404
+#: ../../New-or-Enhanced-Logics.md:425
 msgid ""
 "`IdleAnimDamaged`, `IdleAnimDamaged.ConditionYellow` and "
 "`IdleAnimDamaged.ConditionRed` are used in an identical manner, but only "
@@ -1715,35 +1788,35 @@ msgstr ""
 "-> ConditionYellow` 的百分比时使用。遵守与常规 `IdleAnim` "
 "相同的回退序列，如果未设置则回退到伤残状态的上一个闲置动画变体或者直至回退到常规的 `IdleAnim`。"
 
-#: ../../New-or-Enhanced-Logics.md:405
+#: ../../New-or-Enhanced-Logics.md:426
 msgid ""
 "`Bouncer=true` and `IsMeteor=true` animations can exhibit irregular "
 "behaviour when used as `IdleAnim` and should be avoided."
 msgstr "`Bouncer=true` 和 `IsMeteor=true` 的动画在用作 `IdleAnim` 时会出现不合理的行为，应避免使用。"
 
-#: ../../New-or-Enhanced-Logics.md:406
+#: ../../New-or-Enhanced-Logics.md:427
 msgid ""
 "`IdleAnim.OfflineAction` indicates what happens to the animation when the"
 " shield is in a low power state."
 msgstr "`IdleAnim.OfflineAction` 指定处于低电量状态时护盾动画的行为。"
 
-#: ../../New-or-Enhanced-Logics.md:407
+#: ../../New-or-Enhanced-Logics.md:428
 msgid ""
 "`IdleAnim.TemporalAction` indicates what happens to the animation when "
 "the shield is attacked by temporal weapons."
 msgstr "`IdleAnim.TemporalAction` 指定被时空武器冻结时护盾动画的行为。"
 
-#: ../../New-or-Enhanced-Logics.md:408
+#: ../../New-or-Enhanced-Logics.md:429
 msgid "`BreakAnim`, if set, will be played when the shield has been broken."
 msgstr "`BreakAnim` 如果设置则会在护盾被击碎时播放。"
 
-#: ../../New-or-Enhanced-Logics.md:409
+#: ../../New-or-Enhanced-Logics.md:430
 msgid ""
 "`HitAnim`, if set, will be played when the shield is attacked, similar to"
 " `WeaponNullifyAnim` for Iron Curtain."
 msgstr "`HitAnim` 如果设置则会在护盾受到攻击时播放，类似于 `WeaponNullifyAnim` 用于铁幕。"
 
-#: ../../New-or-Enhanced-Logics.md:410
+#: ../../New-or-Enhanced-Logics.md:431
 msgid ""
 "`HitFlash`, if set to true, makes it so that a light flash is generated "
 "when the shield is attacked by a Warhead unless it has "
@@ -1761,19 +1834,19 @@ msgstr ""
 "`HitFlash.Red/Green/Blue` 进行自定义。如果设置了 `HitFlash.Black` 为 "
 "true，那么无论其他颜色设置如何，产生的闪光都是黑色的。"
 
-#: ../../New-or-Enhanced-Logics.md:411
+#: ../../New-or-Enhanced-Logics.md:432
 msgid ""
 "`BreakWeapon`, if set, will be fired at the TechnoType once the shield "
 "breaks."
 msgstr "`BreakWeapon` 如果设置则将在护盾被击碎时向科技类型发射。"
 
-#: ../../New-or-Enhanced-Logics.md:412
+#: ../../New-or-Enhanced-Logics.md:433
 msgid ""
 "`AbsorbPercent` controls the percentage of damage that will be absorbed "
 "by the shield. Defaults to 1.0, meaning full damage absorption."
 msgstr "`AbsorbPercent` 控制该护盾吸收伤害的百分比。默认为 1.0，表示完全吸收伤害。"
 
-#: ../../New-or-Enhanced-Logics.md:413
+#: ../../New-or-Enhanced-Logics.md:434
 msgid ""
 "`PassPercent` controls the percentage of damage that will *not* be "
 "absorbed by the shield, and will be dealt to the unit directly even if "
@@ -1782,7 +1855,7 @@ msgstr ""
 "`PassPercent` 控制该护盾所 **没** 能吸收（穿透了）伤害的百分比，即使护盾处于激活状态也会直接被施加到单位上。默认为 0.0 -"
 " 无穿透。"
 
-#: ../../New-or-Enhanced-Logics.md:414
+#: ../../New-or-Enhanced-Logics.md:435
 msgid ""
 "`ReceivedDamage.Minimum` & `ReceivedDamage.Maximum` control the minimum "
 "and maximum amount of damage that can be dealt to shield in a single hit."
@@ -1794,7 +1867,7 @@ msgstr ""
 "控制单次攻击中对护盾造成的最小和最大伤害量。这在应用护甲类型和 `AbsorbPercent` 百分比之后生效。如果 "
 "`AbsorbOverDamage=false`，则对科技类型造成的剩余伤害仍基于原始伤害受此范围调整前的值。"
 
-#: ../../New-or-Enhanced-Logics.md:415
+#: ../../New-or-Enhanced-Logics.md:436
 msgid ""
 "`AllowTransfer` controls whether or not the shield can be transferred if "
 "the TechnoType changes (such as `(Un)DeploysInto` or Ares type "
@@ -1804,7 +1877,7 @@ msgstr ""
 "`AllowTransfer` 控制如果科技类型发生变化（例如 `(Un)DeploysInto` 或 Ares "
 "的单位转换）时护盾能否转移。如果未设置，通过 `Shield.AttachTypes` 被赋予来的护盾默认为 true 其他默认为 false。"
 
-#: ../../New-or-Enhanced-Logics.md:416
+#: ../../New-or-Enhanced-Logics.md:437
 msgid ""
 "`ImmuneToBerserk` gives the immunity against `Psychedelic=yes` warhead. "
 "Otherwise the berserk effect penetrates shields by default. Note that "
@@ -1815,7 +1888,7 @@ msgstr ""
 "弹头的免疫能力。否则混乱默认可以穿过护盾。注意这不应阻止单位对护盾所保护对象进行索敌。在这种情况下 `Versus.shieldArmor=0%`"
 " 仍然是必需的。"
 
-#: ../../New-or-Enhanced-Logics.md:417
+#: ../../New-or-Enhanced-Logics.md:438
 msgid ""
 "A tint effect similar to that used by Iron Curtain / Force Shield or "
 "`Psychedelic=true` Warheads can be applied to TechnoTypes with shields by"
@@ -1824,32 +1897,32 @@ msgstr ""
 "通过设置 `Tint.Color` 和／或 `Tint Intensity` 可以为拥有护盾的科技类型使用类似于铁幕／力场护盾或 "
 "`Psychedelic=true` 弹头的染色效果。"
 
-#: ../../New-or-Enhanced-Logics.md:418 ../../New-or-Enhanced-Logics.md:1292
+#: ../../New-or-Enhanced-Logics.md:439 ../../New-or-Enhanced-Logics.md:1313
 msgid ""
 "`Tint.Intensity` is additive lighting increase/decrease - 1.0 is the "
 "default object lighting."
 msgstr "`Tint.Intensity` 是增加／减少的光照，1.0 是默认的对象光照。"
 
-#: ../../New-or-Enhanced-Logics.md:419 ../../New-or-Enhanced-Logics.md:1293
+#: ../../New-or-Enhanced-Logics.md:440 ../../New-or-Enhanced-Logics.md:1314
 msgid ""
 "`Tint.VisibleToHouses` can be used to customize which houses can see the "
 "tint effect."
 msgstr "`Tint.VisibleToHouses` 可用于自定义哪些所属方可见这些染色效果。"
 
-#: ../../New-or-Enhanced-Logics.md:420
+#: ../../New-or-Enhanced-Logics.md:441
 msgid ""
 "A TechnoType with a shield will show its shield Strength. An empty shield"
 " strength bar will be left after destroyed if it is respawnable. Several "
 "customizations are available for the shield strength pips."
 msgstr "拥有护盾的科技类型将显示其护盾值。若护盾可以重生则会在被击碎后留下一个空的胡盾条。对于护盾条的 pip 有多种自定义选项可选。"
 
-#: ../../New-or-Enhanced-Logics.md:421
+#: ../../New-or-Enhanced-Logics.md:442
 msgid ""
 "By default, buildings use the 6th frame of `pips.shp` to display the "
 "shield strength while others use the 17th frame."
 msgstr "默认情况下建筑使用 `pips.shp` 的第 6 帧来显示护盾值，其他则使用第 17 帧。   "
 
-#: ../../New-or-Enhanced-Logics.md:422
+#: ../../New-or-Enhanced-Logics.md:443
 msgid ""
 "`Pips.Shield` can be used to specify which pip frame should be used as "
 "shield strength. If only 1 digit is set, then it will always display that"
@@ -1864,7 +1937,7 @@ msgstr ""
 "与否分别使用。`Pips.Shield.Building` 用于 BuildingTypes。-1 "
 "作为值将使用默认帧，无论是否回退到第一个值或上述硬编码的默认值。"
 
-#: ../../New-or-Enhanced-Logics.md:423
+#: ../../New-or-Enhanced-Logics.md:444
 msgid ""
 "`Pips.Shield.Background` can be used to set the background or 'frame' for"
 " non-building pips, which defaults to `pipbrd.shp`. 4th frame is used to "
@@ -1874,20 +1947,20 @@ msgstr ""
 "`Pips.Shield.Background` 可用于指定非建筑 pip 的背景或 “边框”。默认为 `pipbrd.shp`。第 4 "
 "帧用于显示步兵的护盾值，其他单位使用第 3 帧，如果可用帧不足则分别使用第 2 帧和第 1 帧。"
 
-#: ../../New-or-Enhanced-Logics.md:424
+#: ../../New-or-Enhanced-Logics.md:445
 msgid ""
 "`Pips.Shield.Building.Empty` can be used to set the frame of `pips.shp` "
 "displayed for empty building strength pips, defaults to 1st frame of "
 "`pips.shp`."
 msgstr "`Pips.Shield.Building.Empty` 可用于设置建筑空护盾值显示的 pip 帧，默认为 `pips.shp` 的第 1 帧。"
 
-#: ../../New-or-Enhanced-Logics.md:425
+#: ../../New-or-Enhanced-Logics.md:446
 msgid ""
 "`Pips.HideIfNoStrength` can be used to hide the shield's pip frame if the"
 " `Strength` is 0."
 msgstr "`Pips.HideIfNoStrength` 可用于在 `Strength` 归 0 时隐藏护盾条而不是留下一个空框。"
 
-#: ../../New-or-Enhanced-Logics.md:426
+#: ../../New-or-Enhanced-Logics.md:447
 msgid ""
 "The above customizations are also available on per ShieldType basis, e.g "
 "`[ShieldType] -> Pips` instead of `[AudioVisual] -> Pips.Shield` and so "
@@ -1897,7 +1970,7 @@ msgstr ""
 "以上配置支持基于每个护盾类型单独设置，例如使用 `[ShieldType] -> Pips` 替代全局的 `[AudioVisual] -> "
 "Pips.Shield`。护盾类型上的设置优先于全局设置，未单独设置时回退至全局默认值。"
 
-#: ../../New-or-Enhanced-Logics.md:427
+#: ../../New-or-Enhanced-Logics.md:448
 msgid ""
 "`BracketDelta` can be used as additional vertical offset (negative shifts"
 " it up) for shield strength bar. Much like `PixelSelectionBracketDelta`, "
@@ -1906,7 +1979,7 @@ msgstr ""
 "`BracketDelta` 可用于添加护盾条在竖直方向的偏移量（负数为向上）。类似于 "
 "`PixelSelectionBracketDelta`，对建筑无效。"
 
-#: ../../New-or-Enhanced-Logics.md:428
+#: ../../New-or-Enhanced-Logics.md:449
 msgid ""
 "Warheads have new options that interact with shields. Note that all of "
 "these that do not by their very nature require ability to target the "
@@ -1918,39 +1991,39 @@ msgstr ""
 "或移除／附加护盾这样的修改）的选项仍然需要弹头的 `Verses` 才能影响目标，除非在弹头上将 `EffectsRequireVerses` "
 "设置为 false。"
 
-#: ../../New-or-Enhanced-Logics.md:429
+#: ../../New-or-Enhanced-Logics.md:450
 msgid ""
 "`Shield.Penetrate` allows the warhead ignore the shield and always deal "
 "full damage to the TechnoType itself. It also allows targeting the "
 "TechnoType as if shield doesn't exist."
 msgstr "`Shield.Penetrate` 允许弹头无视这些护盾始终对科技类型本体造成全额伤害。并允许忽略护盾直接锁定科技类型。"
 
-#: ../../New-or-Enhanced-Logics.md:430
+#: ../../New-or-Enhanced-Logics.md:451
 msgid ""
 "`Shield.Break` allows the warhead to always break shields of TechnoTypes."
 " This is done before damage is dealt."
 msgstr "`Shield.Break` 允许弹头总是会击碎科技类型上的这些护盾。此效果在结算伤害前生效。"
 
-#: ../../New-or-Enhanced-Logics.md:431
+#: ../../New-or-Enhanced-Logics.md:452
 msgid ""
 "`Shield.BreakAnim` will be displayed instead of ShieldType `BreakAnim` if"
 " the shield is broken by the Warhead, either through damage or "
 "`Shield.Break`."
 msgstr "`Shield.BreakAnim` 用于设置弹头击中护盾时替代护盾 `BreakAnim` 播放的动画。"
 
-#: ../../New-or-Enhanced-Logics.md:432
+#: ../../New-or-Enhanced-Logics.md:453
 msgid ""
 "`Shield.HitAnim` will be displayed instead of ShieldType `HitAnim` if set"
 " when Warhead hits the shield."
 msgstr "`Shield.HitAnim` 用于设置弹头击中护盾时替代护盾 `HitAnim` 播放的动画。"
 
-#: ../../New-or-Enhanced-Logics.md:433
+#: ../../New-or-Enhanced-Logics.md:454
 msgid ""
 "If `Shield.SkipHitAnim` is set to true, no hit anim is shown when the "
 "Warhead damages the shield whatsoever."
 msgstr "如果 `Shield.SkipHitAnim` 设为 true，当弹头对护盾造成伤害时将不会播放任何击中动画。"
 
-#: ../../New-or-Enhanced-Logics.md:434
+#: ../../New-or-Enhanced-Logics.md:455
 msgid ""
 "`Shield.BreakWeapon` will be fired instead of ShieldType `BreakWeapon` if"
 " the shield is broken by the Warhead, either through damage or "
@@ -1959,19 +2032,19 @@ msgstr ""
 "`Shield.BreakWeapon` 用于设置弹头击碎护盾时替代护盾 `BreakWeapon` 发射的武器，无论是伤害饱和还是 "
 "`Shield.Break` 所造成的击碎。"
 
-#: ../../New-or-Enhanced-Logics.md:435
+#: ../../New-or-Enhanced-Logics.md:456
 msgid ""
 "`Shield.AbsorbPercent` overrides the `AbsorbPercent` value set in the "
 "ShieldType that is being damaged."
 msgstr "`Shield.AbsorbPercent` 覆盖被杀伤护盾类型的 `AbsorbPercent` 值。"
 
-#: ../../New-or-Enhanced-Logics.md:436
+#: ../../New-or-Enhanced-Logics.md:457
 msgid ""
 "`Shield.PassPercent` overrides the `PassPercent` value set in the "
 "ShieldType that is being damaged."
 msgstr "`Shield.PassPercent` 覆盖被杀伤护盾类型的 `PassPercent` 值。"
 
-#: ../../New-or-Enhanced-Logics.md:437
+#: ../../New-or-Enhanced-Logics.md:458
 msgid ""
 "`Shield.ReceivedDamage.Minimum` & `Shield.ReceivedDamage.Maximum` "
 "override the values set in in the ShieldType that is being damaged."
@@ -1979,7 +2052,7 @@ msgstr ""
 "`Shield.ReceivedDamage.Minimum` 和 `Shield.ReceivedDamage.Maximum` "
 "覆盖被杀伤护盾类型上的同类设置。"
 
-#: ../../New-or-Enhanced-Logics.md:438
+#: ../../New-or-Enhanced-Logics.md:459
 msgid ""
 "`Shield.ReceivedDamage.MinMultiplier` and "
 "`Shield.ReceivedDamage.MinMultiplier` are multipliers to the effective "
@@ -1991,7 +2064,7 @@ msgstr ""
 "分别为上面`Shield.ReceivedDamage.Minimum` 和 `Shield.ReceivedDamage.Maximum` "
 "用于被杀伤护盾计算弹头所造成伤害的倍率。"
 
-#: ../../New-or-Enhanced-Logics.md:439
+#: ../../New-or-Enhanced-Logics.md:460
 msgid ""
 "`Shield.Respawn.Rate` & `Shield.Respawn.Amount` override ShieldType "
 "`Respawn.Rate` and `Respawn.Amount` for duration of "
@@ -2012,7 +2085,7 @@ msgstr ""
 "按比例进行调整（例如计时器在前后保持相同百分比的进度）而不会重置。如果效果在重生计时器运作状态中失效，剩余时间也同样会按比例调整为护盾自身的`Respawn.Rate`。重新应用效果会将持续时间重置为"
 " `Shield.Respawn.Duration`"
 
-#: ../../New-or-Enhanced-Logics.md:440
+#: ../../New-or-Enhanced-Logics.md:461
 msgid ""
 "`Shield.SelfHealing.Rate` & `Shield.SelfHealing.Amount` override "
 "ShieldType `SelfHealing.Rate` and `SelfHealing.Amount` for duration of "
@@ -2034,7 +2107,7 @@ msgstr ""
 "按比例进行调整（例如计时器在前后保持相同百分比的进度）而不会重置。如果效果在恢复计时器运作状态中失效，剩余时间也同样会按比例调整为护盾自身的 "
 "`SelfHealing.Rate`。重新应用效果会将持续时间重置为 `Shield.SelfHealing.Duration`。"
 
-#: ../../New-or-Enhanced-Logics.md:441
+#: ../../New-or-Enhanced-Logics.md:462
 msgid ""
 "Additionally `Shield.SelfHealing.RestartInCombat` & "
 "`Shield.SelfHealing.RestartInCombatDelay` can be used to override "
@@ -2043,14 +2116,14 @@ msgstr ""
 "此外 `Shield.SelfHealing.RestartInCombat` 和 "
 "`Shield.SelfHealing.RestartInCombatDelay` 可用于覆盖护盾类型上的同类设置。"
 
-#: ../../New-or-Enhanced-Logics.md:442
+#: ../../New-or-Enhanced-Logics.md:463
 msgid ""
 "`Shield.AffectTypes` allows listing which ShieldTypes can be affected by "
 "any of the effects listed above. If none are listed, all ShieldTypes are "
 "affected."
 msgstr "`Shield.AffectTypes` 允许列出哪些护盾类型受上述效果的影响。如果未列出则代表所有护盾类型。"
 
-#: ../../New-or-Enhanced-Logics.md:443
+#: ../../New-or-Enhanced-Logics.md:464
 msgid ""
 "`Shield.AffectTypes` can be overriden for specific shield interactions by"
 " using keys `Shield.Penetrate.Types`, `Shield.Break.Types`, "
@@ -2060,7 +2133,7 @@ msgstr ""
 "`Shield.Penetrate.Types`、`Shield.Break.Types`、`Shield.Respawn.Types` 和 "
 "`Shield.SelfHealing.Types` 分别为特定的护盾分离覆盖的参数类型。"
 
-#: ../../New-or-Enhanced-Logics.md:444
+#: ../../New-or-Enhanced-Logics.md:465
 msgid ""
 "`Shield.AttachTypes` & `Shield.RemoveTypes` allows listing ShieldTypes "
 "that are attached or removed, respectively from any targets affected by "
@@ -2070,7 +2143,7 @@ msgstr ""
 "`Shield.AttachTypes` 和 `Shield.RemoveTypes` 允许分别列出从被弹头影响（正 `Verses` "
 "值）的任何目标上附加或移除的护盾类型。通常只使用 `Shield.AttachTypes` 中列出的第一个。"
 
-#: ../../New-or-Enhanced-Logics.md:445
+#: ../../New-or-Enhanced-Logics.md:466
 msgid ""
 "If `Shield.ReplaceOnly` is set, shields from `Shield.AttachTypes` are "
 "only applied to affected targets from which shields were simultaneously "
@@ -2082,7 +2155,7 @@ msgstr ""
 " `Shield.RemoveTypes` 列表中的顺序对应。如果 `Shield.AttachTypes` 中的项少于 "
 "`Shield.RemoveTypes` 则使用前者的最后一项来替换任何剩余的被移除护盾类型。"
 
-#: ../../New-or-Enhanced-Logics.md:446
+#: ../../New-or-Enhanced-Logics.md:467
 msgid ""
 "If `Shield.ReplaceNonRespawning` is set, shield from `Shield.AttachTypes`"
 " replaces existing shields that have been broken and cannot respawn on "
@@ -2091,7 +2164,7 @@ msgstr ""
 "如果设置 `Shield.ReplaceNonRespawning` 则 `Shield.AttachTypes` "
 "中的护盾将替换那些已被击碎且无法自行重生的已有护盾。"
 
-#: ../../New-or-Enhanced-Logics.md:447
+#: ../../New-or-Enhanced-Logics.md:468
 msgid ""
 "If `Shield.RemoveAll` is set, all shield types are removed from the "
 "affected targets, even those that are not listed in `Shield.RemoveTypes`."
@@ -2103,14 +2176,14 @@ msgstr ""
 "中。如果设置了 `Shield.ReplaceOnly` 则 `Shield.AttachTypes` 中的第一项将用于替换那些被移除但未列在 "
 "`Shield.RemoveTypes` 中的护盾类型。"
 
-#: ../../New-or-Enhanced-Logics.md:448
+#: ../../New-or-Enhanced-Logics.md:469
 msgid ""
 "`Shield.MinimumReplaceDelay` can be used to control how long after the "
 "shield has been broken (in game frames) can it be replaced. If not enough"
 " frames have passed, it won't be replaced."
 msgstr "`Shield.MinimumReplaceDelay` 可用于控制护盾被击碎后（以游戏帧为单位）多久才能被替换。如果未经过足够的时间则不会被替换。"
 
-#: ../../New-or-Enhanced-Logics.md:449
+#: ../../New-or-Enhanced-Logics.md:470
 msgid ""
 "If `Shield.InheritStateOnReplace` is set, shields replaced via "
 "`Shield.ReplaceOnly` inherit the current strength (relative to ShieldType"
@@ -2120,19 +2193,19 @@ msgstr ""
 "如果设置 `Shield.InheritStateOnReplace` 则通过 `Shield.ReplaceOnly` "
 "替换的护盾将继承前一个护盾的当前强度（护盾类型的 `Strength`）以及是否已被击碎的状态。恢复和重生计时器将始终被重置。"
 
-#: ../../New-or-Enhanced-Logics.md:451
+#: ../../New-or-Enhanced-Logics.md:472
 msgid "Animations"
 msgstr "动画"
 
-#: ../../New-or-Enhanced-Logics.md:453
+#: ../../New-or-Enhanced-Logics.md:474
 msgid "Anim-to-Unit"
 msgstr "动画生成单位"
 
-#: ../../New-or-Enhanced-Logics.md:455
+#: ../../New-or-Enhanced-Logics.md:476
 msgid "![image](_static/images/animToUnit.gif)"
 msgstr "![image](_static/images/animToUnit.gif)"
 
-#: ../../New-or-Enhanced-Logics.md:457
+#: ../../New-or-Enhanced-Logics.md:478
 msgid ""
 "Animations can now create (or \"convert\" to) any unit (vehicles, "
 "aircraft and infantry) when they end via `CreateUnit`. This offers more "
@@ -2141,7 +2214,7 @@ msgstr ""
 "动画现在可以在结束时通过 `CreateUnit` 创建任何单位（载具、战机和步兵）。这比专用于生成步兵的 `MakeInfantry` "
 "提供了更多的可选参数。"
 
-#: ../../New-or-Enhanced-Logics.md:458
+#: ../../New-or-Enhanced-Logics.md:479
 msgid ""
 "`CreateUnit.Owner` determines which house will own the created unit. This"
 " only works as expected if the animation has owner set. If there is no "
@@ -2152,7 +2225,7 @@ msgstr ""
 "`CreateUnit.Owner` 决定创建的单位属于哪个所属方。这仅在动画拥有所有者的情况生效。如果没有所属方或所属方已败北，除非 "
 "`CreateUnit.RequireOwner` 为 true 以禁止生成，否则被创建的单位将归属于第一个平民所属方"
 
-#: ../../New-or-Enhanced-Logics.md:459
+#: ../../New-or-Enhanced-Logics.md:480
 msgid ""
 "Vehicle [destroy animations](Fixed-or-Improved-Logics.md#destroy-"
 "animations), animations from Warhead `AnimList/SplashList` and map "
@@ -2161,13 +2234,13 @@ msgstr ""
 "载具[摧毁动画](Fixed-or-Improved-Logics.md#destroy-animations)、弹头 "
 "`AnimList/SplashList` 的动画以及地图触发结果 `41 播放动画在...` 将拥有正确的所有者。"
 
-#: ../../New-or-Enhanced-Logics.md:460
+#: ../../New-or-Enhanced-Logics.md:481
 msgid ""
 "`CreateUnit.RemapAnim`, if set to true, will cause the animation to be "
 "drawn in unit palette and remappable to owner's team color."
 msgstr "`CreateUnit.RemapAnim` 如果设为 true 则动画将使用单位色盘绘制并可重映射所有者的颜色。"
 
-#: ../../New-or-Enhanced-Logics.md:461
+#: ../../New-or-Enhanced-Logics.md:482
 msgid ""
 "`CreateUnit.Mission` determines the initial mission of the created unit. "
 "This can be overridden for AI players by setting `CreateUnit.AIMission`."
@@ -2175,17 +2248,17 @@ msgstr ""
 "`CreateUnit.Mission` 决定所创建单位的初始任务。对于 AI 玩家可使用 `CreateUnit.AIMission` "
 "来分离设置。"
 
-#: ../../New-or-Enhanced-Logics.md:462
+#: ../../New-or-Enhanced-Logics.md:483
 msgid "`CreateUnit.Facing` determines the initial facing of created unit."
 msgstr "`CreateUnit.Facing` 决定所创建单位的初始朝向。"
 
-#: ../../New-or-Enhanced-Logics.md:463
+#: ../../New-or-Enhanced-Logics.md:484
 msgid ""
 "`CreateUnit.RandomFacing`, if set to true, makes it so that a random "
 "facing is picked instead."
 msgstr "`CreateUnit.RandomFacing` 如果设为 true 那么初始朝向会随机选取。"
 
-#: ../../New-or-Enhanced-Logics.md:464
+#: ../../New-or-Enhanced-Logics.md:485
 msgid ""
 "For VehicleTypes only, `CreateUnit.InheritFacings` and "
 "`CreateUnit.InheritTurretFacings` inherit facings for vehicle body and "
@@ -2197,7 +2270,7 @@ msgstr ""
 "`CreateUnit.InheritTurretFacings` "
 "将分别从被摧毁载具的载具上继承载具主体和炮塔的朝向。由于技术限制，`InheritTurretFacings` 不适用于 Jumpjet 载具。"
 
-#: ../../New-or-Enhanced-Logics.md:465
+#: ../../New-or-Enhanced-Logics.md:486
 msgid ""
 "`CreateUnit.AlwaysSpawnOnGround`, if set to true, ensures the unit will "
 "be created on the cell at ground level even if animation is in air. If "
@@ -2207,7 +2280,7 @@ msgstr ""
 "`CreateUnit.AlwaysSpawnOnGround` 如果设为 true 那么即使动画在空中单位也会在对应的地面单元格上创建。如果设为"
 " false 则此设置无效。"
 
-#: ../../New-or-Enhanced-Logics.md:466
+#: ../../New-or-Enhanced-Logics.md:487
 msgid ""
 "`CreateUnit.SpawnParachutedInAir`, if set to true, makes it so that the "
 "unit is created with a parachute if it is spawned in air. Has no effect "
@@ -2216,7 +2289,7 @@ msgstr ""
 "`CreateUnit.SpawnParachutedInAir` 如果设为 true 那么动画在空中的情况下所创建的单位会拥有降落伞。如果 "
 "`CreateUnit.AlwaysSpawnOnGround` 设为 true 则此设置无效。"
 
-#: ../../New-or-Enhanced-Logics.md:467
+#: ../../New-or-Enhanced-Logics.md:488
 msgid ""
 "`CreateUnit.ConsiderPathfinding`, if set to true, will consider whether "
 "or not the cell where the animation is located is occupied by other "
@@ -2227,14 +2300,14 @@ msgstr ""
 "`CreateUnit.ConsiderPathfinding` 如果设为 true "
 "则考虑动画所在单元格是否被其他对象占据或对于所要创建的单位而言无法行驶并尝试寻找一个附近未被占用的单元格。否则即便存在障碍物单位也会尽量创建在动画所在的位置。"
 
-#: ../../New-or-Enhanced-Logics.md:468
+#: ../../New-or-Enhanced-Logics.md:489
 msgid ""
 "`CreateUnit.SpawnAnim` can be used to play another animation at created "
 "unit's location after it has appeared. This animation has same owner and "
 "invoker as the parent animation."
 msgstr "`CreateUnit.SpawnAnim` 可用于在创建的单位出现后在其位置播放另一个动画。此动画拥有与父动画相同的所有者和调用者。"
 
-#: ../../New-or-Enhanced-Logics.md:469
+#: ../../New-or-Enhanced-Logics.md:490
 msgid ""
 "`CreateUnit.SpawnHeight` can be set to override the animation's height "
 "when determining where to spawn the created unit if set to positive "
@@ -2243,7 +2316,7 @@ msgstr ""
 "`CreateUnit.SpawnHeight` 如果设为正值则决定动画创建单位的高度。如果 "
 "`CreateUnit.AlwaysSpawnOnGround` 设为 true 则此设置无效。"
 
-#: ../../New-or-Enhanced-Logics.md:472
+#: ../../New-or-Enhanced-Logics.md:493
 msgid ""
 "[SOMEANIM]                             ; AnimationType\n"
 "CreateUnit=                            ; TechnoType\n"
@@ -2283,7 +2356,7 @@ msgstr ""
 "CreateUnit.SpawnAnim=                  ; AnimationType\n"
 "CreateUnit.SpawnHeight=-1              ; integer, height in leptons\n"
 
-#: ../../New-or-Enhanced-Logics.md:492
+#: ../../New-or-Enhanced-Logics.md:513
 msgid ""
 "Due to technical constraints, infantry death animations including Ares' "
 "`InfDeathAnim` cannot have `CreateUnit.Owner` correctly applied to them. "
@@ -2293,25 +2366,25 @@ msgstr ""
 "由于技术限制，包括 Ares 语句 `InfDeathAnim` 在内的步兵死亡动画无法正确应用 `CreateUnit.Owner`。你可以使用"
 " Ares 的 `MakeInfantryOwner` 作为替代方案，此方案无需设置 `MakeInfantry` 也能正常工作。"
 
-#: ../../New-or-Enhanced-Logics.md:495
+#: ../../New-or-Enhanced-Logics.md:516
 msgid "Attached particle system"
 msgstr "附加粒子系统"
 
-#: ../../New-or-Enhanced-Logics.md:497
+#: ../../New-or-Enhanced-Logics.md:518
 msgid ""
 "It is now possible to attach a particle system to an animation. Only "
 "particle systems with `BehavesLike=Smoke` are supported. This works "
 "similarly to the identically named key on `VoxelAnims`."
 msgstr "现在可以为一个动画附加一个粒子系统。仅支持 `BehavesLike=Smoke` 的粒子系统。这与 Voxel 碎片中的同名语句等效。"
 
-#: ../../New-or-Enhanced-Logics.md:498
+#: ../../New-or-Enhanced-Logics.md:519
 msgid ""
 "On animations with `Next`, the particle system will be deleted when the "
 "next animation starts playing and new one created in its stead if the "
 "`Next` animation defines a different particle system."
 msgstr "对于有 `Next` 的动画下一个动画开始播放时粒子系统将被删除且如果 `Next` 的动画定义了另一个粒子系统那么新的粒子系统将被创建。"
 
-#: ../../New-or-Enhanced-Logics.md:501
+#: ../../New-or-Enhanced-Logics.md:522
 msgid ""
 "[SOMEANIM]       ; AnimationType\n"
 "AttachedSystem=  ; ParticleSystemType\n"
@@ -2319,17 +2392,17 @@ msgstr ""
 "[SOMEANIM]       ; AnimationType\n"
 "AttachedSystem=  ; ParticleSystemType\n"
 
-#: ../../New-or-Enhanced-Logics.md:506
+#: ../../New-or-Enhanced-Logics.md:527
 msgid "Customizable animation visibility settings"
 msgstr "自定义动画可见性"
 
-#: ../../New-or-Enhanced-Logics.md:508
+#: ../../New-or-Enhanced-Logics.md:529
 msgid ""
 "It is now possible to customize which players can see an animation using "
 "`VisibleTo`."
 msgstr "现在可以通过 `VisibleTo` 自定义哪些玩家可以看到动画。"
 
-#: ../../New-or-Enhanced-Logics.md:509
+#: ../../New-or-Enhanced-Logics.md:530
 msgid ""
 "`VisibleTo.ConsiderInvokerAsOwner`, if set, makes it so that animation's "
 "invoker house is considered as owner for purposes of `VisibleTo` instead "
@@ -2340,13 +2413,13 @@ msgstr ""
 "`VisibleTo.ConsiderInvokerAsOwner` 如果设置则动画调用者的所属方将被视为 `VisibleTo` "
 "的所有者而不是它所附着科技类型或动画的的所属方。大多动画中它们是相同的但部分动画可能不同。"
 
-#: ../../New-or-Enhanced-Logics.md:510
+#: ../../New-or-Enhanced-Logics.md:531
 msgid ""
 "Note that this is a purely visual feature, any logic attached to these "
 "animations like damage is still processed for all players."
 msgstr "注意这是一个视觉效果，任何附加到动画上的逻辑例如造成伤害仍然会为所有玩家处理。"
 
-#: ../../New-or-Enhanced-Logics.md:511
+#: ../../New-or-Enhanced-Logics.md:532
 msgid ""
 "`RestrictVisibilityIfCloaked`, if set to true, makes so that attached "
 "animations or aircraft `Trailer` animations (due to technical "
@@ -2357,13 +2430,13 @@ msgstr ""
 "`RestrictVisibilityIfCloaked` 如果设为 true 则隐形对象上所附着的动画和战机 `Trailer` "
 "的（由于技术限制导弹子机的尾烟不受此限制）动画仅对观察者和可检测到它们的玩家可见。"
 
-#: ../../New-or-Enhanced-Logics.md:512
+#: ../../New-or-Enhanced-Logics.md:533
 msgid ""
 "`DetachOnCloak` can be set to false to override vanilla game behaviour "
 "where attached animations are removed from cloaked objects."
 msgstr "`DetachOnCloak` 可设为 false 以覆盖原本游戏从隐形对象上移除所附着动画的行为。"
 
-#: ../../New-or-Enhanced-Logics.md:515
+#: ../../New-or-Enhanced-Logics.md:536
 msgid ""
 "[SOMEANIM]                              ; AnimationType\n"
 "VisibleTo=all                           ; List of Affected House "
@@ -2379,11 +2452,11 @@ msgstr ""
 "RestrictVisibilityIfCloaked=false       ; boolean\n"
 "DetachOnCloak=true                      ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:523
+#: ../../New-or-Enhanced-Logics.md:544
 msgid "Play sound as a detached sound event"
 msgstr "以独立声音事件播放声音"
 
-#: ../../New-or-Enhanced-Logics.md:525
+#: ../../New-or-Enhanced-Logics.md:546
 msgid ""
 "It is now possible for animation to play a sound that is not attached to "
 "an audio event handler by using `DetachedReport`. By default animation "
@@ -2397,7 +2470,7 @@ msgstr ""
 "`Report`／`StartSound` 由音频事件处理器播放，这允许它即使在初始创建后发生了变化声音也会循环和在正确的位置播放。这也导致通过 "
 "`Next` 链接不同的动画类型时出现问题，因为动画重新开始时音频事件处理器会重置。"
 
-#: ../../New-or-Enhanced-Logics.md:528
+#: ../../New-or-Enhanced-Logics.md:549
 msgid ""
 "[SOMEANIM]       ; AnimationType\n"
 "DetachedReport=  ; Sound entry\n"
@@ -2405,21 +2478,21 @@ msgstr ""
 "[SOMEANIM]       ; AnimationType\n"
 "DetachedReport=  ; Sound entry\n"
 
-#: ../../New-or-Enhanced-Logics.md:533
+#: ../../New-or-Enhanced-Logics.md:554
 msgid "Buildings"
 msgstr "建筑"
 
-#: ../../New-or-Enhanced-Logics.md:535
+#: ../../New-or-Enhanced-Logics.md:556
 msgid "Build area customizations"
 msgstr "自定义建造区域"
 
-#: ../../New-or-Enhanced-Logics.md:537
+#: ../../New-or-Enhanced-Logics.md:558
 msgid ""
 "There are now additional customizations available for building placement "
 "next to other buildings."
 msgstr "现在允许自定义一个建筑能为哪些建筑扩展建造范围。"
 
-#: ../../New-or-Enhanced-Logics.md:538
+#: ../../New-or-Enhanced-Logics.md:559
 msgid ""
 "`Adjacent.Allowed` lists BuildingTypes this BuildingType can be placed "
 "off (within distance defined by `Adjacent`). If empty, any BuildingType "
@@ -2428,7 +2501,7 @@ msgstr ""
 "`Adjacent.Allowed` 列出了可以放置在其附近（由 `Adjacent` 定义的距离内）的建筑类型。如果留空则任何未列在 "
 "`Adjacent.Disallowed` 的建筑类型都可以。"
 
-#: ../../New-or-Enhanced-Logics.md:539
+#: ../../New-or-Enhanced-Logics.md:560
 msgid ""
 "`Adjacent.Disallowed` lists BuildingTypes this BuildingType cannot be "
 "placed next to. If empty, any BuildingTypes are okay as long as "
@@ -2437,14 +2510,14 @@ msgstr ""
 "`Adjacent.Disallowed` 列出了不得放置在其附近（由 `Adjacent` "
 "定义的距离内）的建筑类型。如果留空则任何建筑类型都可以。"
 
-#: ../../New-or-Enhanced-Logics.md:540
+#: ../../New-or-Enhanced-Logics.md:561
 msgid ""
 "If `NoBuildAreaOnBuildup` is set to true, no building can be built next "
 "to this building regardless of any other settings if it is currently "
 "displaying its buildup animation."
 msgstr "如果 `NoBuildAreaOnBuildup` 设为 true 则任何建筑类型都不能当其在播放建造动画时在其附近建造。"
 
-#: ../../New-or-Enhanced-Logics.md:543
+#: ../../New-or-Enhanced-Logics.md:564
 msgid ""
 "[SOMEBUILDING]              ; BuildingType\n"
 "Adjacent.Allowed=           ; List of BuildingTypes\n"
@@ -2456,11 +2529,11 @@ msgstr ""
 "Adjacent.Disallowed=        ; List of BuildingTypes\n"
 "NoBuildAreaOnBuildup=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:550
+#: ../../New-or-Enhanced-Logics.md:571
 msgid "Destroyable pathfinding obstacles"
 msgstr "可摧毁的寻路障碍"
 
-#: ../../New-or-Enhanced-Logics.md:552
+#: ../../New-or-Enhanced-Logics.md:573
 msgid ""
 "It is possible to make buildings be considered pathfinding obstacles that"
 " can be destroyed by setting `IsDestroyableBlockage` to true. What this "
@@ -2474,7 +2547,7 @@ msgstr ""
 "`MovementZone`（允许处理可摧毁障碍物的类别，例如 "
 "`(Infantry|Amphibious)Destroyer`）的单位能够将建筑视为像墙类覆盖物和地形对象那样不可通行且不可逾越的障碍物。"
 
-#: ../../New-or-Enhanced-Logics.md:553
+#: ../../New-or-Enhanced-Logics.md:574
 msgid ""
 "Keep in mind that if an unit has appropriate `MovementZone` but no means "
 "to actually destroy an obstacle (such as a weapon that can fire and deal "
@@ -2484,7 +2557,7 @@ msgstr ""
 "注意如果一个单位拥有适当的 `MovementZone` "
 "但缺少实际摧毁障碍物的手段（例如一个可以发射并造成伤害的武器）那么它们仍会尝试摧毁并穿越障碍物并导致卡在那里而不是绕过障碍物。"
 
-#: ../../New-or-Enhanced-Logics.md:556
+#: ../../New-or-Enhanced-Logics.md:577
 msgid ""
 "[SOMEBUILDING]               ; BuildingType\n"
 "IsDestroyableObstacle=false  ; boolean\n"
@@ -2492,11 +2565,58 @@ msgstr ""
 "[SOMEBUILDING]               ; BuildingType\n"
 "IsDestroyableObstacle=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:561
+#: ../../New-or-Enhanced-Logics.md:582
+msgid "Engineer repair customization"
+msgstr "自定义工程师维修"
+
+#: ../../New-or-Enhanced-Logics.md:584
+msgid ""
+"You can now set a maximum amount when engineer repair a building for "
+"either of them. 0 means the building will be repaired to full health."
+msgstr "现在你可以在工程师维修一个建筑时为它们设定最大修复值。0 代表满血。"
+
+#: ../../New-or-Enhanced-Logics.md:585
+#, python-format
+msgid ""
+"Negative value means percentage. For example, `EngineerRepairAmount=-50` "
+"means you can only repair 50% of the building's health per Engineer."
+msgstr "负值按百分比计算。例如 `EngineerRepairAmount=-50` 表示每名工程师每次最多修 50%。"
+
+#: ../../New-or-Enhanced-Logics.md:586
+msgid ""
+"If both the building and the engineer has `EngineerRepairAmount` set, the"
+" actual repair amount will be the minimum of them."
+msgstr "如果建筑和工程师都设置了 `EngineerRepairAmount` 则区其中更小的那个使用。"
+
+#: ../../New-or-Enhanced-Logics.md:587
+msgid ""
+"`BuildingRepairedSound` can now be set individually for each building "
+"type."
+msgstr "`BuildingRepairedSound` 现在可以为在每种建筑上单独定义。"
+
+#: ../../New-or-Enhanced-Logics.md:590
+msgid ""
+"[SOMEBUILDING]                     ; BuildingType\n"
+"EngineerRepairAmount=0             ; integer\n"
+"BuildingRepairedSound=             ; Sound entry, default to "
+"[AudioVisual] -> BuildingRepairedSound\n"
+"\n"
+"[SOMEINFANTRY]                     ; InfantryType\n"
+"EngineerRepairAmount=0             ; integer\n"
+msgstr ""
+"[SOMEBUILDING]                     ; BuildingType\n"
+"EngineerRepairAmount=0             ; integer\n"
+"BuildingRepairedSound=             ; Sound entry, default to "
+"[AudioVisual] -> BuildingRepairedSound\n"
+"\n"
+"[SOMEINFANTRY]                     ; InfantryType\n"
+"EngineerRepairAmount=0             ; integer\n"
+
+#: ../../New-or-Enhanced-Logics.md:599
 msgid "Extended building upgrades"
 msgstr "拓展的建筑加载物"
 
-#: ../../New-or-Enhanced-Logics.md:563
+#: ../../New-or-Enhanced-Logics.md:601
 msgid ""
 "![image](_static/images/powersup.owner-01.png) *Upgrading own and allied "
 "Power Plants in [CnC: Final War](https://www.moddb.com/mods/cncfinalwar)*"
@@ -2504,7 +2624,7 @@ msgstr ""
 "![image](_static/images/powersup.owner-01.png) *[CnC: Final "
 "War](https://www.moddb.com/mods/cncfinalwar) 中加载到自己的和盟友的发电厂*"
 
-#: ../../New-or-Enhanced-Logics.md:567
+#: ../../New-or-Enhanced-Logics.md:605
 msgid ""
 "Due to technical limitations, with Ares, upgrades placed through "
 "`PowersUp.Buildings` instead of `PowersUpBuilding` (note that internally "
@@ -2520,7 +2640,7 @@ msgstr ""
 "的第一个条目） **不会** 满足先决条件。建议的解决方法是通过加载物来提供一个超武武器通过 [虚拟投放](#limbodelivery) "
 "的建筑来作为先决条件，当父建筑消失时这些先决条件会被另一个超级武器销毁，以此类推。"
 
-#: ../../New-or-Enhanced-Logics.md:570
+#: ../../New-or-Enhanced-Logics.md:608
 msgid ""
 "Building upgrades now can be placed on own buildings, on allied buildings"
 " and/or on enemy buildings. These three owners can be specified by "
@@ -2530,17 +2650,17 @@ msgstr ""
 "现在建筑加载物可以放置在己方建筑、友方建筑乃至敌方建筑上。这三种所有者可以通过 `PowersUp.Owner` "
 "指定。当加载物放置在建筑上时，它将自动更改为与建筑所有者相同的所有者。"
 
-#: ../../New-or-Enhanced-Logics.md:571
+#: ../../New-or-Enhanced-Logics.md:609
 msgid ""
 "One upgrade can now be applied to multiple different types of buildings "
 "specified by `PowersUp.Buildings`."
 msgstr "现在一个加载物可以应用于由 `PowersUp.Buildings` 指定的多种不同类型的建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:572
+#: ../../New-or-Enhanced-Logics.md:610
 msgid "Ares-introduced build limit for building upgrades works with this feature."
 msgstr "Ares 引入的建筑加载物建造限制与这一功能兼容。"
 
-#: ../../New-or-Enhanced-Logics.md:575
+#: ../../New-or-Enhanced-Logics.md:613
 msgid ""
 "[SOMEBUILDING]      ; BuildingType, as an upgrade\n"
 "PowersUp.Owner=Self ; List of Affected House Enumeration "
@@ -2552,23 +2672,23 @@ msgstr ""
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "PowersUp.Buildings= ; List of BuildingTypes\n"
 
-#: ../../New-or-Enhanced-Logics.md:581
+#: ../../New-or-Enhanced-Logics.md:619
 msgid "Power plant enhancer"
 msgstr "电厂增幅器"
 
-#: ../../New-or-Enhanced-Logics.md:583
+#: ../../New-or-Enhanced-Logics.md:621
 msgid ""
 "When it exists, it can increase the power amount generated by the power "
 "plants."
 msgstr "当它存在时可以增加电厂产生的电量。"
 
-#: ../../New-or-Enhanced-Logics.md:584
+#: ../../New-or-Enhanced-Logics.md:622
 msgid ""
 "When enchancing structures are sold or destroyed, the power amount "
 "returns to normal."
 msgstr "当增幅器被出售或摧毁时电量将复原。"
 
-#: ../../New-or-Enhanced-Logics.md:587
+#: ../../New-or-Enhanced-Logics.md:625
 msgid ""
 "[SOMEBUILDING]                     ; BuildingType\n"
 "PowerPlantEnhancer.PowerPlants=    ; List of BuildingTypes\n"
@@ -2580,27 +2700,27 @@ msgstr ""
 "PowerPlantEnhancer.Amount=0        ; integer\n"
 "PowerPlantEnhancer.Factor=1.0      ; floating point value\n"
 
-#: ../../New-or-Enhanced-Logics.md:594
+#: ../../New-or-Enhanced-Logics.md:632
 msgid "Spy effects"
 msgstr "间谍效果"
 
-#: ../../New-or-Enhanced-Logics.md:596
+#: ../../New-or-Enhanced-Logics.md:634
 msgid "Additional espionage bonuses can be toggled with `SpyEffect.Custom`."
 msgstr "可以通过 `SpyEffect.Custom` 开启额外的间谍效果。"
 
-#: ../../New-or-Enhanced-Logics.md:597
+#: ../../New-or-Enhanced-Logics.md:635
 msgid ""
 "`SpyEffect.VictimSuperWeapon` instantly launches a Super Weapon for the "
 "owner of the infiltrated building at building's coordinates."
 msgstr "`SpyEffect.VictimSuperWeapon` 会立即在被渗透建筑的坐标以被渗透方为所属发射一个超级武器。"
 
-#: ../../New-or-Enhanced-Logics.md:598
+#: ../../New-or-Enhanced-Logics.md:636
 msgid ""
 "`SpyEffect.InfiltratorSuperWeapon` behaves the same as above, with the "
 "Super Weapon's owner being the owner of the spying unit."
 msgstr "`SpyEffect.InfiltratorSuperWeapon` 同上但超级武器的所属方来自间谍单位。"
 
-#: ../../New-or-Enhanced-Logics.md:601
+#: ../../New-or-Enhanced-Logics.md:639
 msgid ""
 "[SOMEBUILDING]                     ; BuildingType\n"
 "SpyEffect.Custom=false             ; boolean\n"
@@ -2612,66 +2732,15 @@ msgstr ""
 "SpyEffect.VictimSuperWeapon=       ; SuperWeaponType\n"
 "SpyEffect.InfiltratorSuperWeapon=  ; SuperWeaponType\n"
 
-#: ../../New-or-Enhanced-Logics.md:608
-msgid "Engineer repair customization"
-msgstr "自定义工程师维修"
-
-#: ../../New-or-Enhanced-Logics.md:610
-msgid ""
-"You can now set a maximum amount when engineer repair a building for "
-"either of them. 0 means the building will be repaired to full health."
-msgstr ""
-"现在你可以在工程师维修一个建筑时为它们设定最大修复值。0 代表满血。"
-
-#: ../../New-or-Enhanced-Logics.md:611
-#, python-format
-msgid ""
-"Negative value means percentage. For example, `EngineerRepairAmount=-50` "
-"means you can only repair 50% of the building's health per Engineer."
-msgstr ""
-"负值按百分比计算。例如 `EngineerRepairAmount=-50` 表示每名工程师每次最多修 50%。"
-
-#: ../../New-or-Enhanced-Logics.md:612
-msgid ""
-"If both the building and the engineer has `EngineerRepairAmount` set, the"
-" actual repair amount will be the minimum of them."
-msgstr ""
-"如果建筑和工程师都设置了 `EngineerRepairAmount` 则区其中更小的那个使用。"
-
-#: ../../New-or-Enhanced-Logics.md:613
-msgid ""
-"`BuildingRepairedSound` can now be set individually for each building "
-"type."
-msgstr ""
-"`BuildingRepairedSound` 现在可以为在每种建筑上单独定义。"
-
-#: ../../New-or-Enhanced-Logics.md:616
-msgid ""
-"[SOMEBUILDING]                     ; BuildingType\n"
-"EngineerRepairAmount=0             ; integer\n"
-"BuildingRepairedSound=             ; Sound entry, default to "
-"[AudioVisual] -> BuildingRepairedSound\n"
-"\n"
-"[SOMEINFANTRY]                     ; InfantryType\n"
-"EngineerRepairAmount=0             ; integer\n"
-msgstr ""
-"[SOMEBUILDING]                     ; BuildingType\n"
-"EngineerRepairAmount=0             ; integer\n"
-"BuildingRepairedSound=             ; Sound entry, default to "
-"[AudioVisual] -> BuildingRepairedSound\n"
-"\n"
-"[SOMEINFANTRY]                     ; InfantryType\n"
-"EngineerRepairAmount=0             ; integer\n"
-
-#: ../../New-or-Enhanced-Logics.md:625
+#: ../../New-or-Enhanced-Logics.md:646
 msgid "Infantry"
 msgstr "步兵"
 
-#: ../../New-or-Enhanced-Logics.md:627
+#: ../../New-or-Enhanced-Logics.md:648
 msgid "Customizable FLH when infantry is prone or deployed"
 msgstr "自定义步兵匍匐或部署状态的 FLH"
 
-#: ../../New-or-Enhanced-Logics.md:629
+#: ../../New-or-Enhanced-Logics.md:650
 msgid ""
 "Now infantry can override `PrimaryFireFLH` and `SecondaryFireFLH` if is "
 "prone (crawling) or deployed. Also works in conjunction with [burst-index"
@@ -2680,7 +2749,7 @@ msgstr ""
 "现在步兵处于匍匐（爪巴）或部署状态的 FLH 可以独立于 `PrimaryFireFLH` 和 `SecondaryFireFLH` "
 "进行设置。同样对 [Burst 开火坐标](#firing-offsets-for-specific-burst-shots) 生效。"
 
-#: ../../New-or-Enhanced-Logics.md:632
+#: ../../New-or-Enhanced-Logics.md:653
 msgid ""
 "[SOMEINFANTRY]             ; InfantryType image\n"
 "PronePrimaryFireFLH=       ; integer - Forward,Lateral,Height\n"
@@ -2694,17 +2763,17 @@ msgstr ""
 "DeployedPrimaryFireFLH=    ; integer - Forward,Lateral,Height\n"
 "DeployedSecondaryFireFLH=  ; integer - Forward,Lateral,Height\n"
 
-#: ../../New-or-Enhanced-Logics.md:640
+#: ../../New-or-Enhanced-Logics.md:661
 msgid "Customizable `SlavesFreeSound`"
 msgstr "自定义 `SlavesFreeSound`"
 
-#: ../../New-or-Enhanced-Logics.md:642
+#: ../../New-or-Enhanced-Logics.md:663
 msgid ""
 "`SlavesFreeSound` can now be set individually for each enslavable "
 "infantry type."
 msgstr "现在 `SlavesFreeSound` 可以单独为每个奴隶类步兵类型微观设置。"
 
-#: ../../New-or-Enhanced-Logics.md:646
+#: ../../New-or-Enhanced-Logics.md:667
 msgid ""
 "[SOMEINFANTRY]        ; InfantryType\n"
 "Slaved=yes\n"
@@ -2716,19 +2785,19 @@ msgstr ""
 "SlavesFreeSound=      ; Sound entry, default to [AudioVisual] -> "
 "SlavesFreeSound\n"
 
-#: ../../New-or-Enhanced-Logics.md:652
+#: ../../New-or-Enhanced-Logics.md:673
 msgid "Default disguise for individual InfantryTypes"
 msgstr "步兵类型默认伪装"
 
-#: ../../New-or-Enhanced-Logics.md:654
+#: ../../New-or-Enhanced-Logics.md:675
 msgid "Infantry can now have its `DefaultDisguise` overridden per-type."
 msgstr "现在可以为每个步兵类型设置其 `DefaultDisguise`。"
 
-#: ../../New-or-Enhanced-Logics.md:655
+#: ../../New-or-Enhanced-Logics.md:676
 msgid "This tag's priority is higher than Ares' per-side `DefaultDisguise`."
 msgstr "此标签的优先级高于 Ares 的各阵营 `DefaultDisguise`。"
 
-#: ../../New-or-Enhanced-Logics.md:658
+#: ../../New-or-Enhanced-Logics.md:679
 msgid ""
 "[SOMEINFANTRY]      ; InfantryType\n"
 "DefaultDisguise=    ; InfantryType\n"
@@ -2736,23 +2805,23 @@ msgstr ""
 "[SOMEINFANTRY]      ; InfantryType\n"
 "DefaultDisguise=    ; InfantryType\n"
 
-#: ../../New-or-Enhanced-Logics.md:663
+#: ../../New-or-Enhanced-Logics.md:684
 msgid "Random death animaton for NotHuman infantry"
 msgstr "非人步兵随机死亡动画"
 
-#: ../../New-or-Enhanced-Logics.md:665
+#: ../../New-or-Enhanced-Logics.md:686
 msgid ""
 "Infantry with `NotHuman=yes` can now play random death anim sequence "
 "between `Die1` to `Die5` instead of the hardcoded `Die1`."
 msgstr "现在拥有 `NotHuman=yes` 的步兵可以从 `Die1` 到 `Die5` 之间随机播放死亡动画序列而不再是硬编码的 `Die1`。"
 
-#: ../../New-or-Enhanced-Logics.md:666
+#: ../../New-or-Enhanced-Logics.md:687
 msgid ""
 "Do not forget to tweak infantry anim sequences before enabling this "
 "feature, otherwise it will play invisible anim sequence."
 msgstr "在启用此功能前请务必调整步兵动画序列否则可能播放不可见的动画序列。"
 
-#: ../../New-or-Enhanced-Logics.md:669
+#: ../../New-or-Enhanced-Logics.md:690
 msgid ""
 "[SOMEINFANTRY]                    ; InfantryType\n"
 "NotHuman.RandomDeathSequence=yes  ; boolean\n"
@@ -2760,35 +2829,35 @@ msgstr ""
 "[SOMEINFANTRY]                    ; InfantryType\n"
 "NotHuman.RandomDeathSequence=yes  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:674
+#: ../../New-or-Enhanced-Logics.md:695
 msgid "Slaves' house decision customization when owner is killed"
 msgstr "奴隶解放演变"
 
-#: ../../New-or-Enhanced-Logics.md:676
+#: ../../New-or-Enhanced-Logics.md:697
 msgid ""
 "You can now decide the slaves' house when the corresponding slave miner "
 "is killed using `Slaved.OwnerWhenMasterKilled`:"
 msgstr "现在你可以使用 `Slaved.OwnerWhenMasterKilled` 来决定奴隶矿场被毁后奴隶移交的所属方或行为："
 
-#: ../../New-or-Enhanced-Logics.md:677
+#: ../../New-or-Enhanced-Logics.md:698
 msgid "`suicide`: Kill each slave if the slave miner is killed."
 msgstr "`suicide`：以身殉主，奴隶矿场死亡则奴隶同步死亡。"
 
-#: ../../New-or-Enhanced-Logics.md:678
+#: ../../New-or-Enhanced-Logics.md:699
 msgid "`master`: Free the slaves but keep the house of the slave unchanged."
 msgstr "`master ` ：助纣为虐，拿起武器但所属不变。"
 
-#: ../../New-or-Enhanced-Logics.md:679
+#: ../../New-or-Enhanced-Logics.md:700
 msgid "`neutral`: The slaves belong to civilian house."
 msgstr "`neutral`：独善其身，解放后转为平民所属方开摆。"
 
-#: ../../New-or-Enhanced-Logics.md:680
+#: ../../New-or-Enhanced-Logics.md:701
 msgid ""
 "`killer`: Free the slaves and give them to the house of the slave miner's"
 " killer. (vanilla behavior)"
 msgstr "`killer ` ：揭竿而起，解放后转为奴隶矿场击杀者的所属方。（原版行为）"
 
-#: ../../New-or-Enhanced-Logics.md:683
+#: ../../New-or-Enhanced-Logics.md:704
 msgid ""
 "[SOMEINFANTRY]                       ; InfantryType\n"
 "Slaved=yes\n"
@@ -2800,17 +2869,17 @@ msgstr ""
 "Slaved.OwnerWhenMasterKilled=killer  ; enumeration (suicide | master | "
 "killer | neutral)\n"
 
-#: ../../New-or-Enhanced-Logics.md:689
+#: ../../New-or-Enhanced-Logics.md:710
 msgid "Use land sequences even in water"
 msgstr "在水中使用陆地序列"
 
-#: ../../New-or-Enhanced-Logics.md:691
+#: ../../New-or-Enhanced-Logics.md:712
 msgid ""
 "Setting `OnlyUseLandSequences` to true will make infantry display only "
 "the regular sequences used on land even if it is in water."
 msgstr "设置 `OnlyUseLandSequences` 为 true 可以使步兵即使在水中也只显示在陆地上使用的常规序列。"
 
-#: ../../New-or-Enhanced-Logics.md:694
+#: ../../New-or-Enhanced-Logics.md:715
 msgid ""
 "[SOMEINFANTRY]              ; InfantryType image\n"
 "OnlyUseLandSequences=false  ; boolean\n"
@@ -2818,15 +2887,15 @@ msgstr ""
 "[SOMEINFANTRY]              ; InfantryType image\n"
 "OnlyUseLandSequences=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:699
+#: ../../New-or-Enhanced-Logics.md:720
 msgid "Projectiles"
 msgstr "抛射体"
 
-#: ../../New-or-Enhanced-Logics.md:701
+#: ../../New-or-Enhanced-Logics.md:722
 msgid "Projectile interception logic"
 msgstr "抛射体拦截"
 
-#: ../../New-or-Enhanced-Logics.md:703
+#: ../../New-or-Enhanced-Logics.md:724
 msgid ""
 "![image](_static/images/projectile-interception-01.gif) *Interception "
 "logic used in [Tiberium Crisis](https://www.moddb.com/mods/tiberium-"
@@ -2835,7 +2904,7 @@ msgstr ""
 "![image](_static/images/projectile-interception-01.gif) "
 "*[泰伯利亚危机](https://www.moddb.com/mods/tiberium-crisis) 中的拦截抛射体*"
 
-#: ../../New-or-Enhanced-Logics.md:706
+#: ../../New-or-Enhanced-Logics.md:727
 msgid ""
 "Projectiles can now be made interceptable by certain TechnoTypes by "
 "setting `Interceptable=true` on them. The TechnoType scans for "
@@ -2855,13 +2924,13 @@ msgstr ""
 "那么从抛射体的当前血量中扣除一个等于拦截武器 `Damage` 经弹头 `Verses` "
 "和科技类型火力加成调整后的数值。无论当前抛射体血量是否被减少若拦截后其血量为 0 或更低那么抛射体将被引爆。"
 
-#: ../../New-or-Enhanced-Logics.md:707
+#: ../../New-or-Enhanced-Logics.md:728
 msgid ""
 "`Interceptor.Weapon` determines the weapon (0 = `Primary`, 1 = "
 "`Secondary`) to be used for intercepting projectiles."
 msgstr "`Interceptor.Weapon` 决定用于拦截抛射体的武器（0 = `Primary`, 1 = `Secondary`)。"
 
-#: ../../New-or-Enhanced-Logics.md:708
+#: ../../New-or-Enhanced-Logics.md:729
 msgid ""
 "The interceptor weapon may need `AG` and/or `AA` set to true on its "
 "projectile to be able to target projectiles depending on their elevation "
@@ -2871,13 +2940,13 @@ msgstr ""
 "拦截武器可能需要在其抛射体上将 `AG` 和／或 `AA` 设为 true "
 "以使其能够根据抛射体相对地面的高度来瞄准。如果你不设置这些那么武器将无法分别瞄准低空或高空飞行的抛射体。"
 
-#: ../../New-or-Enhanced-Logics.md:709
+#: ../../New-or-Enhanced-Logics.md:730
 msgid ""
 "`Interceptor.CanTargetHouses` controls which houses the projectiles (or "
 "rather their firers) can belong to be eligible for interception."
 msgstr "`Interceptor.CanTargetHouses` 控制抛射体（或其发射者）属于哪些所属方时可以被拦截。"
 
-#: ../../New-or-Enhanced-Logics.md:710
+#: ../../New-or-Enhanced-Logics.md:731
 msgid ""
 "`Interceptor.GuardRange` (and "
 "`Interceptor.(Rookie|Veteran|EliteGuardRange)`) is maximum range of the "
@@ -2887,7 +2956,7 @@ msgstr ""
 "`Interceptor.GuardRange`（以及 "
 "`Interceptor.(Rookie|Veteran|EliteGuardRange)`）是单位拦截抛射体的最大范围。不过武器的射程仍会限制单位的实际拦截范围。"
 
-#: ../../New-or-Enhanced-Logics.md:711
+#: ../../New-or-Enhanced-Logics.md:732
 msgid ""
 "`Interceptor.MinimumGuardRange` (and "
 "`Interceptor.(Rookie|Veteran|EliteMinimumGuardRange)`) is the minimum "
@@ -2897,14 +2966,14 @@ msgstr ""
 "`Interceptor.MinimumGuardRange`（以及 "
 "`Interceptor.(Rookie|Veteran|EliteMinimumGuardRange)`）是单位拦截抛射体的最小范围。任何小于此范围的抛射体都不会被拦截。"
 
-#: ../../New-or-Enhanced-Logics.md:712
+#: ../../New-or-Enhanced-Logics.md:733
 msgid ""
 "`Interceptor.ApplyFirepowerMult` determines whether or not the "
 "intercepting weapon's damage should multiply the TechnoType's firepower "
 "multipliers."
 msgstr "`Interceptor.ApplyFirepowerMult` 决定拦截武器的伤害是否受益于科技类型所拥有的火力加成。"
 
-#: ../../New-or-Enhanced-Logics.md:713
+#: ../../New-or-Enhanced-Logics.md:734
 msgid ""
 "`Interceptable.DeleteOnIntercept` determines whether or not the "
 "projectile will simply be deleted on detonation upon interception, or if "
@@ -2914,7 +2983,7 @@ msgstr ""
 "`Interceptable.DeleteOnIntercept` 决定抛射体被拦截时是被简单的移除还是直接引爆。这会被拦截者的 "
 "`Interceptor.DeleteOnIntercept` 设置覆盖。"
 
-#: ../../New-or-Enhanced-Logics.md:714
+#: ../../New-or-Enhanced-Logics.md:735
 msgid ""
 "`Interceptable.WeaponOverride` can be set to a WeaponType that will be "
 "used to override characteristics such as `Damage` and `Warhead` of the "
@@ -2924,7 +2993,7 @@ msgstr ""
 "`Interceptable.WeaponOverride` 可以设置一个武器覆盖替代此抛射体在拦截时的 `Damage` 和 `Warhead`"
 " 等特性进行引爆。这会被拦截者的 `Interceptor.WeaponOverride` 设置覆盖。"
 
-#: ../../New-or-Enhanced-Logics.md:715
+#: ../../New-or-Enhanced-Logics.md:736
 msgid ""
 "On interceptors, `Interceptor.WeaponReplaceProjectile` can be set to true"
 " to make `Interceptor.WeaponOverride` also replace the intercepted "
@@ -2936,7 +3005,7 @@ msgstr ""
 "`Interceptor.WeaponOverride` 也使用自己的抛射体类型（包括 `Image` 和其他抛射体特性）和 `Speed` "
 "替换被拦截的抛射体。不会替换附着的粒子系统（`AttachedSystem` 是一个 *Ares 功能*）。"
 
-#: ../../New-or-Enhanced-Logics.md:716
+#: ../../New-or-Enhanced-Logics.md:737
 msgid ""
 "On interceptors, `Interceptor.WeaponCumulativeDamage` can be set to true "
 "to make `Damage` from `Interceptor.WeaponOverride` weapon be added on the"
@@ -2945,7 +3014,7 @@ msgstr ""
 "在拦截者上可以将 `Interceptor.WeaponCumulativeDamage` 设为 true 以使 "
 "`Interceptor.WeaponOverride` 武器的 `Damage` 会叠加到抛射体的 `Damage` 上而不是覆盖它。"
 
-#: ../../New-or-Enhanced-Logics.md:717
+#: ../../New-or-Enhanced-Logics.md:738
 msgid ""
 "`Interceptor.KeepIntact` can be set to true to allow intercepted "
 "projectiles to continue traveling as if they were not intercepted, but "
@@ -2954,7 +3023,7 @@ msgstr ""
 "`Interceptor.KeepIntact` 可设为 true 以允许被拦截的抛射体继续飞行就像它们没有被拦截一样，不过 "
 "`Interceptor.WeaponOverride` 等效果仍会应用。"
 
-#: ../../New-or-Enhanced-Logics.md:720
+#: ../../New-or-Enhanced-Logics.md:741
 msgid ""
 "[SOMETECHNO]                               ; TechnoType\n"
 "Interceptor=false                          ; boolean\n"
@@ -3008,7 +3077,7 @@ msgstr ""
 "Strength=0                                 ; integer\n"
 "Armor=                                     ; ArmorType\n"
 
-#: ../../New-or-Enhanced-Logics.md:747
+#: ../../New-or-Enhanced-Logics.md:768
 msgid ""
 "Currently interceptor weapons with projectiles that do not have "
 "`Inviso=true` will be unable to intercept projectiles if the firer of the"
@@ -3016,15 +3085,15 @@ msgid ""
 " its target. This may change in future."
 msgstr "目前如果拦截武器的开火者提前死亡那么没有 `Inviso=true` 的拦截抛射体将无法拦截目标抛射体，这在未来可能会进行更改。"
 
-#: ../../New-or-Enhanced-Logics.md:750
+#: ../../New-or-Enhanced-Logics.md:771
 msgid "Projectile trajectories"
 msgstr "抛射体轨迹"
 
-#: ../../New-or-Enhanced-Logics.md:752
+#: ../../New-or-Enhanced-Logics.md:773
 msgid "Projectiles can now have customizable trajectories."
 msgstr "抛射体现在可以有自定义的轨迹。"
 
-#: ../../New-or-Enhanced-Logics.md:753
+#: ../../New-or-Enhanced-Logics.md:774
 msgid ""
 "`Trajectory` should not be combined with original game's projectile "
 "trajectory logics (`Arcing`, `ROT`, `Vertical` or `Inviso`). Attempt to "
@@ -3034,7 +3103,7 @@ msgstr ""
 "`Trajectory` 不应与原游戏的抛射体逻辑（`Arcing`、`ROT`、`Vertical` 或 "
 "`Inviso`）结合使用。尝试你这样做将导致其他逻辑被禁用并在日志文件中写入一条警告。"
 
-#: ../../New-or-Enhanced-Logics.md:754
+#: ../../New-or-Enhanced-Logics.md:775
 msgid ""
 "The speed of the projectile is defined by `Trajectory.Speed`, which "
 "unlike `Speed` used by `ROT` > 0 projectiles is defined on projectile not"
@@ -3043,26 +3112,26 @@ msgstr ""
 "抛射体的速度由 `Trajectory.Speed` 定义，与 `ROT` > 0 抛射体不同的是 `Trajectory.Speed` "
 "定义在抛射体上而不是武器上。"
 
-#: ../../New-or-Enhanced-Logics.md:755
+#: ../../New-or-Enhanced-Logics.md:776
 msgid ""
 "In `Trajectory=Straight`, it refers to the whole distance speed of the "
 "projectile and it has no restrictions."
 msgstr "对于 `Trajectory=Straight` 它指的是抛射体的全程速度并且没有限制。"
 
-#: ../../New-or-Enhanced-Logics.md:756
+#: ../../New-or-Enhanced-Logics.md:777
 msgid ""
 "In `Trajectory=Bombard`, it refers to the initial speed of the projectile"
 " and it has no restrictions."
 msgstr "对于 `Trajectory=Bombard` 它指的是抛射体的初始速度并且没有限制。"
 
-#: ../../New-or-Enhanced-Logics.md:757
+#: ../../New-or-Enhanced-Logics.md:778
 msgid ""
 "In `Trajectory=Parabola`, it refers to the horizontal velocity of the "
 "projectile and is only used for modes 0, 3, or 5 and it has no "
 "restrictions."
 msgstr "对于 `Trajectory=Parabola` 它指的是抛射体仅用于模式 0、3 或 5 的水平速度并且没有限制。"
 
-#: ../../New-or-Enhanced-Logics.md:760
+#: ../../New-or-Enhanced-Logics.md:781
 msgid ""
 "[SOMEPROJECTILE]        ; Projectile\n"
 "Trajectory.Speed=100.0  ; floating point value\n"
@@ -3070,11 +3139,11 @@ msgstr ""
 "[SOMEPROJECTILE]        ; Projectile\n"
 "Trajectory.Speed=100.0  ; floating point value\n"
 
-#: ../../New-or-Enhanced-Logics.md:765
+#: ../../New-or-Enhanced-Logics.md:786
 msgid "Straight trajectory"
 msgstr "直线轨迹"
 
-#: ../../New-or-Enhanced-Logics.md:767
+#: ../../New-or-Enhanced-Logics.md:788
 msgid ""
 "![Straigh trajectory blasters](_static/images/straight.gif) *Straight "
 "trajectory used to make blasters in a private mod by @brsajo#9745*"
@@ -3082,15 +3151,15 @@ msgstr ""
 "![Straigh trajectory blasters](_static/images/straight.gif) *@brsajo#9745"
 " 在私人 mod 中使用直线轨迹制作的爆能枪*"
 
-#: ../../New-or-Enhanced-Logics.md:767
+#: ../../New-or-Enhanced-Logics.md:788
 msgid "Straigh trajectory blasters"
 msgstr "直线轨迹爆能枪"
 
-#: ../../New-or-Enhanced-Logics.md:770
+#: ../../New-or-Enhanced-Logics.md:791
 msgid "Self-explanatory, is a straight-shot trajectory."
 msgstr "不言自明，这是一种直线射击轨迹。"
 
-#: ../../New-or-Enhanced-Logics.md:771
+#: ../../New-or-Enhanced-Logics.md:792
 msgid ""
 "`Trajectory.Straight.DetonationDistance` controls the maximum distance in"
 " cells from intended target (checked at start of each game frame, before "
@@ -3110,7 +3179,7 @@ msgstr ""
 "true 则任何来自开火者的武器射程加成也将在此处被使用。通过设置 `Trajectory.Straight.PassThrough=true` "
 "当值大于 0 时它指的是抛射体从自身开始移动的距离，当值小于 0 时它指的是抛射体飞跃目标后移动的距离（使用绝对值）。"
 
-#: ../../New-or-Enhanced-Logics.md:772
+#: ../../New-or-Enhanced-Logics.md:793
 msgid ""
 "`Trajectory.Straight.TargetSnapDistance` controls the maximum distance in"
 " cells from intended target the projectile can be at moment of detonation"
@@ -3120,7 +3189,7 @@ msgstr ""
 "`Trajectory.Straight.TargetSnapDistance` 控制抛射体在引爆时与目标的最大距离以使抛射体在引爆时 “瞬移” "
 "到目标。设为 0 将禁用瞬移。"
 
-#: ../../New-or-Enhanced-Logics.md:773
+#: ../../New-or-Enhanced-Logics.md:794
 msgid ""
 "`Trajectory.Straight.PassThrough` enables special case logic where the "
 "projectile does not detonate in contact with the target but instead "
@@ -3133,7 +3202,7 @@ msgstr ""
 "`Trajectory.Straight.DetonationDistance` "
 "定义的距离。注意抛射体发射角度会受此影响，如果与目标处于同一高度那么直接向前发射。"
 
-#: ../../New-or-Enhanced-Logics.md:774
+#: ../../New-or-Enhanced-Logics.md:795
 msgid ""
 "`Trajectory.Straight.PassDetonate` enables extra detonations when the "
 "projectile is traveling. (You can use this when you want the projectile "
@@ -3142,7 +3211,7 @@ msgstr ""
 "`Trajectory.Straight.PassDetonate` "
 "启用抛射体在飞行过程中的额外爆炸。（如果你希望抛射体在飞行过程中每隔一定距离／时间引爆一次那么可以使用此功能）。"
 
-#: ../../New-or-Enhanced-Logics.md:775
+#: ../../New-or-Enhanced-Logics.md:796
 msgid ""
 "`Trajectory.Straight.PassDetonateWarhead` defines the warhead detonated "
 "by `Trajectory.Straight.PassDetonate`, and "
@@ -3154,7 +3223,7 @@ msgstr ""
 "引爆的弹头，`Trajectory.Straight.PassDetonateDamage` 定义由 "
 "`Trajectory.Straight.PassDetonateWarhead` 引爆的伤害。"
 
-#: ../../New-or-Enhanced-Logics.md:776
+#: ../../New-or-Enhanced-Logics.md:797
 msgid ""
 "`Trajectory.Straight.PassDetonateDelay` controls the delay for detonating"
 " the warhead defined by `Trajectory.Straight.Warhead`."
@@ -3162,7 +3231,7 @@ msgstr ""
 "`Trajectory.Straight.PassDetonateDelay` 控制 `Trajectory.Straight.Warhead` "
 "所定义弹头的引爆间隔。"
 
-#: ../../New-or-Enhanced-Logics.md:777
+#: ../../New-or-Enhanced-Logics.md:798
 msgid ""
 "`Trajectory.Straight.PassDetonateInitialDelay` controls the initial delay"
 " for detonating the warhead defined by "
@@ -3171,7 +3240,7 @@ msgstr ""
 "`Trajectory.Straight.PassDetonateInitialDelay` 控制 "
 "`Trajectory.Straight.PassDetonateWarhead` 所定义弹头的初始引爆间隔。"
 
-#: ../../New-or-Enhanced-Logics.md:778
+#: ../../New-or-Enhanced-Logics.md:799
 msgid ""
 "`Trajectory.Straight.PassDetonateLocal` controls whether "
 "`Trajectory.Straight.PassDetonateWarhead` and weapon's `Warhead` are "
@@ -3183,7 +3252,7 @@ msgstr ""
 "`Trajectory.Straight.PassDetonateWarhead` 和武器 `Warhead` "
 "是否始终在下方地面引爆。它还将不再限制抛射体在使用 `Trajectory.Straight.ConfineAtHeight` 时的垂直速度。"
 
-#: ../../New-or-Enhanced-Logics.md:779
+#: ../../New-or-Enhanced-Logics.md:800
 msgid ""
 "`Trajectory.Straight.LeadTimeCalculate` controls whether the projectile "
 "need to calculate the lead time of the target when firing. Note that this"
@@ -3192,7 +3261,7 @@ msgstr ""
 "`Trajectory.Straight.LeadTimeCalculate` "
 "控制抛射体在射击时是否需要计算目标的提前量。注意这不会影响炮塔的朝向。"
 
-#: ../../New-or-Enhanced-Logics.md:780
+#: ../../New-or-Enhanced-Logics.md:801
 msgid ""
 "`Trajectory.Straight.OffsetCoord` controls the offsets of the target. "
 "Projectile will aim at this position to attack. It also supports "
@@ -3202,7 +3271,7 @@ msgstr ""
 "`Trajectory.Straight.OffsetCoord` 控制锁定目标的偏移量。抛射体将瞄准此位置进行攻击。在此基础上它也支持 "
 "`Inaccurate=yes` 和 `Trajectory.Straight.LeadTimeCalculate=true`。"
 
-#: ../../New-or-Enhanced-Logics.md:781
+#: ../../New-or-Enhanced-Logics.md:802
 msgid ""
 "`Trajectory.Straight.RotateCoord` controls whether to rotate the "
 "projectile's firing direction within the angle bisector of "
@@ -3212,7 +3281,7 @@ msgstr ""
 "`Trajectory.Straight.RotateCoord` 控制是否根据武器的 `Burst` 在以 "
 "`Trajectory.Straight.OffsetCoord` 为角平分线的角度内旋转抛射体的发射方向。设为 0 以禁用此功能。"
 
-#: ../../New-or-Enhanced-Logics.md:782
+#: ../../New-or-Enhanced-Logics.md:803
 msgid ""
 "`Trajectory.Straight.MirrorCoord` controls whether "
 "`Trajectory.Straight.OffsetCoord` need to mirror the lateral value to "
@@ -3225,7 +3294,7 @@ msgstr ""
 "是否需要镜像水平方向值以适应当前的连发索引。同时，`Trajectory.Straight.RotateCoord` "
 "计算出的旋转方向也将被反转，每侧相邻抛射体之间的旋转角度不会受此改变。"
 
-#: ../../New-or-Enhanced-Logics.md:783
+#: ../../New-or-Enhanced-Logics.md:804
 msgid ""
 "`Trajectory.Straight.UseDisperseBurst` controls whether the calculation "
 "of `Trajectory.Straight.RotateCoord` is based on its superior's "
@@ -3237,7 +3306,7 @@ msgstr ""
 "`Trajectory.Straight.RotateCoord` 的计算是否基于其上级武器的 "
 "`Trajectory.Disperse.WeaponBurst` 而不是武器的 `Burst`。此值不合适将导致不理想的视觉效果。"
 
-#: ../../New-or-Enhanced-Logics.md:784
+#: ../../New-or-Enhanced-Logics.md:805
 msgid ""
 "`Trajectory.Straight.AxisOfRotation` controls the rotation axis when "
 "calculating `Trajectory.Straight.RotateCoord`. The axis will rotates with"
@@ -3247,7 +3316,7 @@ msgstr ""
 "`Trajectory.Straight.AxisOfRotation` 控制计算 "
 "`Trajectory.Straight.RotateCoord` 的转轴。随单位朝向或目标位置到源位置的向量旋转。"
 
-#: ../../New-or-Enhanced-Logics.md:785
+#: ../../New-or-Enhanced-Logics.md:806
 msgid ""
 "`Trajectory.Straight.ProximityImpact` controls the initial proximity fuse"
 " times. When there are enough remaining times and the projectile "
@@ -3267,7 +3336,7 @@ msgstr ""
 "`Versus` 的武器 `Warhead` 以瞄准目标，使用 `Trajectory.Straight.ProximityWarhead` "
 "造成实际伤害。（你可以使用此功能在抛射体飞行期间对遇到的所有单位造成非重复伤害。）"
 
-#: ../../New-or-Enhanced-Logics.md:786
+#: ../../New-or-Enhanced-Logics.md:807
 msgid ""
 "`Trajectory.Straight.ProximityWarhead` defines the warhead detonated by "
 "`Trajectory.Straight.ProximityImpact`, and "
@@ -3279,19 +3348,19 @@ msgstr ""
 "引爆的弹头，`Trajectory.Straight.ProximityDamage` 定义由 "
 "`Trajectory.Straight.ProximityWarhead` 引爆的伤害。"
 
-#: ../../New-or-Enhanced-Logics.md:787
+#: ../../New-or-Enhanced-Logics.md:808
 msgid ""
 "`Trajectory.Straight.ProximityRadius` controls the range of proximity "
 "fuse. It can NOT be set as a negative integer."
 msgstr "`Trajectory.Straight.ProximityRadius` 控制近炸引信的范围。不支持负整数。"
 
-#: ../../New-or-Enhanced-Logics.md:788
+#: ../../New-or-Enhanced-Logics.md:809
 msgid ""
 "`Trajectory.Straight.ProximityDirect` controls whether let the target "
 "receive damage instead of detonating the warhead."
 msgstr "`Trajectory.Straight.ProximityDirect` 控制是否直接伤害目标而不是引爆弹头。"
 
-#: ../../New-or-Enhanced-Logics.md:789
+#: ../../New-or-Enhanced-Logics.md:810
 msgid ""
 "`Trajectory.Straight.ProximityMedial` controls whether to detonate "
 "`Trajectory.Straight.ProximityWarhead` at the bullet's location rather "
@@ -3303,19 +3372,19 @@ msgstr ""
 "`Trajectory.Straight.ProximityDirect` 设为 true，这只会影响 "
 "`Trajectory.Straight.EdgeAttenuation` 的计算结果。"
 
-#: ../../New-or-Enhanced-Logics.md:790
+#: ../../New-or-Enhanced-Logics.md:811
 msgid ""
 "`Trajectory.Straight.ProximityAllies` controls whether allies will also "
 "trigger the proximity fuse."
 msgstr "`Trajectory.Straight.ProximityAllies` 控制友军是否也会触发近炸引信。"
 
-#: ../../New-or-Enhanced-Logics.md:791
+#: ../../New-or-Enhanced-Logics.md:812
 msgid ""
 "`Trajectory.Straight.ProximityFlight` controls whether to count units in "
 "the air."
 msgstr "`Trajectory.Straight.ProximityFlight` 控制是否考虑空中的单位。"
 
-#: ../../New-or-Enhanced-Logics.md:792
+#: ../../New-or-Enhanced-Logics.md:813
 msgid ""
 "`Trajectory.Straight.ThroughVehicles` controls whether the projectile "
 "will not be obstructed by vehicles or aircrafts on the ground. When it is"
@@ -3328,7 +3397,7 @@ msgstr ""
 "`Trajectory.Straight.ProximityImpact` 次数还没耗尽，它也会在障碍物位置引爆一个 "
 "`Trajectory.Straight.ProximityImpact`。"
 
-#: ../../New-or-Enhanced-Logics.md:793
+#: ../../New-or-Enhanced-Logics.md:814
 msgid ""
 "`Trajectory.Straight.ThroughBuilding` controls whether the projectile "
 "will not be obstructed by buildings. When it is obstructed, it will be "
@@ -3340,7 +3409,7 @@ msgstr ""
 " `Trajectory.Straight.ProximityImpact` 次数还没耗尽，它也会在障碍物位置引爆一个 "
 "`Trajectory.Straight.ProximityImpact`。"
 
-#: ../../New-or-Enhanced-Logics.md:794
+#: ../../New-or-Enhanced-Logics.md:815
 msgid ""
 "`Trajectory.Straight.SubjectToGround` controls whether the projectile "
 "should explode when it hits the ground. Note that this will not make AI "
@@ -3349,7 +3418,7 @@ msgstr ""
 "`Trajectory.Straight.SubjectToGround` 控制抛射体在击中地面时是否爆炸。注意这并不能让 AI "
 "去寻找合适的攻击位置。"
 
-#: ../../New-or-Enhanced-Logics.md:795
+#: ../../New-or-Enhanced-Logics.md:816
 msgid ""
 "`Trajectory.Straight.ConfineAtHeight` controls the height above ground "
 "that projectile will try to travel as it can. It can not move down from "
@@ -3361,7 +3430,7 @@ msgstr ""
 "`SubjectToCliffs=true` 可以使其不得从悬崖上向下移动。可以通过设置为非正整数来取消。如果 "
 "`Trajectory.Speed` 大于 256，它将被强制取消。"
 
-#: ../../New-or-Enhanced-Logics.md:796
+#: ../../New-or-Enhanced-Logics.md:817
 msgid ""
 "`Trajectory.Straight.EdgeAttenuation` controls the edge attenuation ratio"
 " of projectile damage (includes all types of the trajectory's damage), "
@@ -3372,7 +3441,7 @@ msgstr ""
 "`Trajectory.Straight.EdgeAttenuation` "
 "控制抛射体杀伤的边缘衰减比例（包括轨迹添加的所有伤害类型），即实际造成的伤害是将此值乘以当前距离与武器射程的比值。不能设为负整数。"
 
-#: ../../New-or-Enhanced-Logics.md:797
+#: ../../New-or-Enhanced-Logics.md:818
 msgid ""
 "`Trajectory.Straight.CountAttenuation` controls the attenuation "
 "coefficient of projectile damage (includes all types of the trajectory's "
@@ -3382,7 +3451,7 @@ msgstr ""
 "`Trajectory.Straight.CountAttenuation` "
 "控制抛射体杀伤的衰减系数（包括轨迹添加的所有伤害类型），即每次造成伤害后的下一次伤害会翻多少倍。不能设为负整数。"
 
-#: ../../New-or-Enhanced-Logics.md:800
+#: ../../New-or-Enhanced-Logics.md:821
 msgid ""
 "[SOMEPROJECTILE]                                ; Projectile\n"
 "Trajectory=Straight                             ; Trajectory type\n"
@@ -3454,13 +3523,13 @@ msgstr ""
 "Trajectory.Straight.EdgeAttenuation=1.0         ; floating point value\n"
 "Trajectory.Straight.CountAttenuation=1.0        ; floating point value\n"
 
-#: ../../New-or-Enhanced-Logics.md:836
+#: ../../New-or-Enhanced-Logics.md:857
 msgid ""
 "Make sure you set a low `Trajectory.Straight.ProximityRadius` value "
 "unless necessary."
 msgstr "除非实在必要否则请设置较低的 `Trajectory.Straight.ProximityRadius` 值。"
 
-#: ../../New-or-Enhanced-Logics.md:837
+#: ../../New-or-Enhanced-Logics.md:858
 msgid ""
 "The listed Warheads in `Trajectory.Straight.PassDetonateWarhead` and "
 "`Trajectory.Straight.ProximityWarhead` must be listed in `[Warheads]` for"
@@ -3469,11 +3538,11 @@ msgstr ""
 "列于 `Trajectory.Straight.PassDetonateWarhead` 和 "
 "`Trajectory.Straight.ProximityWarhead` 的弹头必须在 `[Warheads]` 中列出才能生效。"
 
-#: ../../New-or-Enhanced-Logics.md:840
+#: ../../New-or-Enhanced-Logics.md:861
 msgid "Bombard trajectory"
 msgstr "轰击轨迹"
 
-#: ../../New-or-Enhanced-Logics.md:842
+#: ../../New-or-Enhanced-Logics.md:863
 msgid ""
 "Similar trajectory to `Straight`, but targets a coordinate between the "
 "attacker and intended target first. When the projectile approaches that "
@@ -3481,11 +3550,11 @@ msgid ""
 "hits the target or ground."
 msgstr "类似于 `Straight` 但首先瞄准攻击者和目标间的某个坐标。当抛射体接近该拐点后它才会转向目标并在击中目标或地面时引爆。"
 
-#: ../../New-or-Enhanced-Logics.md:843
+#: ../../New-or-Enhanced-Logics.md:864
 msgid "`Trajectory.Bombard.Height` controls the height of the turning point."
 msgstr "`Trajectory.Bombard.Height` 控制拐点的高度。"
 
-#: ../../New-or-Enhanced-Logics.md:844
+#: ../../New-or-Enhanced-Logics.md:865
 msgid ""
 "`Trajectory.Bombard.FallPercent` controls the distance of the turning "
 "point by its percentage of the total distance between attacker and "
@@ -3495,7 +3564,7 @@ msgstr ""
 "`Trajectory.Bombard.FallPercent` 通过拐点位置占发射位置与目标位置间总距离的百分比来控制拐点的距离。如果设为 0%"
 " 则它将在开火位置的正上方。如果设为 100% 则它将位于目标正上方。"
 
-#: ../../New-or-Enhanced-Logics.md:845
+#: ../../New-or-Enhanced-Logics.md:866
 msgid ""
 "For each launch the turning point percentage could add or minus a random "
 "value, which is not greater than `Trajectory.Bombard.FallPercentShift`. "
@@ -3504,7 +3573,7 @@ msgstr ""
 "每次发射时拐点位置的百分比值可以随机浮动，该值不大于 `Trajectory.Bombard.FallPercentShift`。如果设为 0 "
 "则随机调整将被禁用。"
 
-#: ../../New-or-Enhanced-Logics.md:846
+#: ../../New-or-Enhanced-Logics.md:867
 msgid ""
 "You can also makes the turning point scatter randomly in a circle with "
 "`Trajectory.Bombard.FallScatter.Max` as its radius. If set to 0, random "
@@ -3519,7 +3588,7 @@ msgstr ""
 "`Trajectory.Bombard.FallScatter.Linear` 设为 "
 "true，则随机散布范围将被限制在发射位置与目标位置之间连线的垂面。"
 
-#: ../../New-or-Enhanced-Logics.md:847
+#: ../../New-or-Enhanced-Logics.md:868
 msgid ""
 "`Trajectory.Bombard.FreeFallOnTarget` controls how it'll hit the intended"
 " target. If set to true, the projectile will be respawned above the "
@@ -3529,14 +3598,14 @@ msgstr ""
 "`Trajectory.Bombard.FreeFallOnTarget` 控制它将如何击中目标。如果设为 "
 "true，则抛射体将在目标上方重新生成并自由落体。如果设为 false，则抛射体将正常从拐点位置飞向目标。"
 
-#: ../../New-or-Enhanced-Logics.md:848
+#: ../../New-or-Enhanced-Logics.md:869
 msgid ""
 "`Trajectory.Bombard.NoLaunch` controls whether the attacker will fire the"
 " projectile by itself. If set to true, projectile will directly fall from"
 " the turning point."
 msgstr "`Trajectory.Bombard.NoLaunch` 控制攻击者是否会自行发射抛射体。如果设为 true，则抛射体将直接从拐点位置下落。"
 
-#: ../../New-or-Enhanced-Logics.md:849
+#: ../../New-or-Enhanced-Logics.md:870
 msgid ""
 "`Trajectory.Bombard.FallSpeed` controls the initial speed of the "
 "projectile after it turns. If set to 0.0, then it'll use "
@@ -3547,7 +3616,7 @@ msgstr ""
 "`Trajectory.Speed`。当 `Trajectory.Bombard.FreeFallOnTarget` 设为 true "
 "时将无法工作。"
 
-#: ../../New-or-Enhanced-Logics.md:850
+#: ../../New-or-Enhanced-Logics.md:871
 msgid ""
 "`Trajectory.Bombard.DetonationDistance` controls the maximum distance in "
 "cells from intended target (checked at start of each game frame, before "
@@ -3558,7 +3627,7 @@ msgstr ""
 "`Trajectory.Bombard.DetonationDistance` "
 "控制强制引爆位置相对于目标单元格的距离阈值（在每次游戏帧开始时检查，抛射体移动之前）。设为 0 可以禁用强制引爆（注意这可能导致抛射体越过目标）。"
 
-#: ../../New-or-Enhanced-Logics.md:851
+#: ../../New-or-Enhanced-Logics.md:872
 msgid ""
 "`Trajectory.Bombard.DetonationHeight` controls when the projectile is in "
 "a descending state and below the height of the launch position plus this "
@@ -3572,7 +3641,7 @@ msgstr ""
 "`Trajectory.Bombard.EarlyDetonation` 设为 "
 "true，则它将在上升段生效，这表示当抛射体高度高于发射位置加上此值时将引爆。"
 
-#: ../../New-or-Enhanced-Logics.md:852
+#: ../../New-or-Enhanced-Logics.md:873
 msgid ""
 "`Trajectory.Bombard.TargetSnapDistance` controls the maximum distance in "
 "cells from intended target the projectile can be at moment of detonation "
@@ -3582,7 +3651,7 @@ msgstr ""
 "`Trajectory.Bombard.TargetSnapDistance` 控制抛射体在引爆时与目标的最大距离以使抛射体在引爆时 “瞬移” "
 "到目标。设为 0 将禁用瞬移。"
 
-#: ../../New-or-Enhanced-Logics.md:853
+#: ../../New-or-Enhanced-Logics.md:874
 msgid ""
 "`Trajectory.Bombard.TurningPointAnims`, if set, will play an anim when "
 "the projectile reaches the turning point. If "
@@ -3597,20 +3666,20 @@ msgstr ""
 "`Trajectory.Bombard.NoLaunch` 设为 "
 "true，则无论抛射体是否自由落体，它都将在抛射体下落的位置播放动画。如果列出了多个动画，则将随机选择一个。"
 
-#: ../../New-or-Enhanced-Logics.md:854
+#: ../../New-or-Enhanced-Logics.md:875
 msgid ""
 "`Trajectory.Bombard.LeadTimeCalculate` controls whether the projectile "
 "need to calculate the lead time of the target when firing. Note that this"
 " will not affect the facing of the turret."
 msgstr "`Trajectory.Bombard.LeadTimeCalculate` 控制抛射体在射击时是否需要计算目标的提前量。注意这不会影响炮塔的朝向。"
 
-#: ../../New-or-Enhanced-Logics.md:855
+#: ../../New-or-Enhanced-Logics.md:876
 msgid ""
 "The following tags further customize the projectile's descending "
 "behaviors when `Trajectory.Bombard.FreeFallOnTarget` set to false."
 msgstr "以下标签在 `Trajectory.Bombard.FreeFallOnTarget` 设为 false 时进一步自定义抛射体的下落行为。"
 
-#: ../../New-or-Enhanced-Logics.md:856
+#: ../../New-or-Enhanced-Logics.md:877
 msgid ""
 "`Trajectory.Bombard.OffsetCoord` controls the offsets of the target. "
 "Projectile will aim at this position to attack. It also supports "
@@ -3620,7 +3689,7 @@ msgstr ""
 "`Trajectory.Bombard.OffsetCoord` 控制锁定目标的偏移量。抛射体将瞄准此位置进行攻击。在此基础上它也支持 "
 "`Inaccurate=yes` 和 `Trajectory.Bombard.LeadTimeCalculate=true`。"
 
-#: ../../New-or-Enhanced-Logics.md:857
+#: ../../New-or-Enhanced-Logics.md:878
 msgid ""
 "`Trajectory.Bombard.RotateCoord` controls whether to rotate the "
 "projectile's firing direction within the angle bisector of "
@@ -3630,7 +3699,7 @@ msgstr ""
 "`Trajectory.Bombard.RotateCoord` 控制是否根据武器的 `Burst` 在以 "
 "`Trajectory.Bombard.OffsetCoord` 为角平分线的角度内旋转抛射体的发射方向。设为 0 以禁用此功能。"
 
-#: ../../New-or-Enhanced-Logics.md:858
+#: ../../New-or-Enhanced-Logics.md:879
 msgid ""
 "`Trajectory.Bombard.MirrorCoord` controls whether "
 "`Trajectory.Bombard.OffsetCoord` need to mirror the lateral value to "
@@ -3643,7 +3712,7 @@ msgstr ""
 "是否需要镜像水平方向值以适应当前的连发索引。同时，`Trajectory.Straight.RotateCoord` "
 "计算出的旋转方向也将被反转，每侧相邻抛射体之间的旋转角度不会受此改变。"
 
-#: ../../New-or-Enhanced-Logics.md:859
+#: ../../New-or-Enhanced-Logics.md:880
 msgid ""
 "`Trajectory.Bombard.UseDisperseBurst` controls whether the calculation of"
 " `Trajectory.Bombard.RotateCoord` is based on its superior's "
@@ -3655,7 +3724,7 @@ msgstr ""
 " 的计算是否基于其上级武器的 `Trajectory.Disperse.WeaponBurst` 而不是武器的 "
 "`Burst`。此值不合适将导致不理想的视觉效果。"
 
-#: ../../New-or-Enhanced-Logics.md:860
+#: ../../New-or-Enhanced-Logics.md:881
 msgid ""
 "`Trajectory.Bombard.AxisOfRotation` controls the rotation axis when "
 "calculating `Trajectory.Bombard.RotateCoord`. The axis will rotates with "
@@ -3665,7 +3734,7 @@ msgstr ""
 "`Trajectory.Bombard.AxisOfRotation` 控制计算 `Trajectory.Bombard.RotateCoord`"
 " 的转轴。随单位朝向或目标位置到源位置的向量旋转。"
 
-#: ../../New-or-Enhanced-Logics.md:861
+#: ../../New-or-Enhanced-Logics.md:882
 msgid ""
 "`Trajectory.Bombard.SubjectToGround` controls whether the projectile "
 "should explode when it hits the ground. Note that this will not make AI "
@@ -3674,7 +3743,7 @@ msgstr ""
 "`Trajectory.Bombard.SubjectToGround` 控制抛射体在击中地面时是否爆炸。注意这并不能让 AI "
 "去寻找合适的攻击位置。"
 
-#: ../../New-or-Enhanced-Logics.md:864
+#: ../../New-or-Enhanced-Logics.md:885
 msgid ""
 "[SOMEPROJECTILE]                              ; Projectile\n"
 "Trajectory=Bombard                            ; Trajectory type\n"
@@ -3728,18 +3797,18 @@ msgstr ""
 "Forward,Lateral,Height\n"
 "Trajectory.Bombard.SubjectToGround=false      ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:890
+#: ../../New-or-Enhanced-Logics.md:911
 msgid "Parabola trajectory"
 msgstr "抛物线轨迹"
 
-#: ../../New-or-Enhanced-Logics.md:892
+#: ../../New-or-Enhanced-Logics.md:913
 msgid ""
 "As the name says, this is a completely reset `Arcing` with different "
 "enhanced functions. Without doubt, It supported linkage with "
 "`Trajectory=Disperse`."
 msgstr "顾名思义，这是一种完全重置且拥有不同增强功能的类 `Arcing` 轨迹，它支持与 `Trajectory=Disperse` 的联动。"
 
-#: ../../New-or-Enhanced-Logics.md:893
+#: ../../New-or-Enhanced-Logics.md:914
 msgid ""
 "`Trajectory.Parabola.DetonationDistance` controls the maximum distance in"
 " cells from intended target (checked at start of each game frame, before "
@@ -3754,7 +3823,7 @@ msgstr ""
 "可以禁用强制引爆（注意这可能导致抛射体越过目标）。更具体地说，当它被设为负值时，如果目标可移动，它将改变其目标到目标所在单元格的位置（这是为 "
 "`Disperse` 和 `Airburst` 而扩展的功能）。"
 
-#: ../../New-or-Enhanced-Logics.md:894
+#: ../../New-or-Enhanced-Logics.md:915
 msgid ""
 "`Trajectory.Parabola.TargetSnapDistance` controls the maximum distance in"
 " cells from intended target the projectile can be at moment of detonation"
@@ -3764,20 +3833,20 @@ msgstr ""
 "`Trajectory.Parabola.TargetSnapDistance` 控制抛射体在引爆时与目标的最大距离以使抛射体在引爆时 “瞬移” "
 "到目标。设为 0 将禁用瞬移。"
 
-#: ../../New-or-Enhanced-Logics.md:895
+#: ../../New-or-Enhanced-Logics.md:916
 msgid ""
 "`Trajectory.Parabola.OpenFireMode` controls how should the projectile be "
 "launched. This has the following 6 modes."
 msgstr "`Trajectory.Parabola.OpenFireMode` 控制抛射体应该如何发射，它有如下 6 种模式："
 
-#: ../../New-or-Enhanced-Logics.md:896
+#: ../../New-or-Enhanced-Logics.md:917
 msgid ""
 "Speed - Automatic calculation mode with fixed horizontal velocity, using "
 "`Trajectory.Speed` and target coordinates as calculation conditions, i.e."
 " the flight time of the projectile is permanently fixed."
 msgstr "Speed - 固定水平速度的自动计算模式，使用 `Trajectory.Speed` 和目标坐标作为计算条件，即抛射体的飞行时间将永久固定。"
 
-#: ../../New-or-Enhanced-Logics.md:897
+#: ../../New-or-Enhanced-Logics.md:918
 msgid ""
 "Height - Automatic calculation mode with fixed maximum height, useing "
 "`Trajectory.Parabola.ThrowHeight` and target coordinates as calculation "
@@ -3787,7 +3856,7 @@ msgstr ""
 "Height - 固定最大高度的自动计算模式，使用 `Trajectory.Parabola.ThrowHeight` "
 "和目标坐标作为计算条件，即抛射体的引爆时间将相对固定。"
 
-#: ../../New-or-Enhanced-Logics.md:898
+#: ../../New-or-Enhanced-Logics.md:919
 msgid ""
 "Angle - Automatic calculation mode with fixed fire angle, useing "
 "`Trajectory.Parabola.LaunchAngle` and target coordinates as calculation "
@@ -3799,7 +3868,7 @@ msgstr ""
 "和目标坐标作为计算条件。在此模式下，性能消耗较高且可能无法解决。不建议在启用 `SubjectToCliffs` 或启用 `AA` 且 "
 "`MinimumRange` 较小时使用此模式。"
 
-#: ../../New-or-Enhanced-Logics.md:899
+#: ../../New-or-Enhanced-Logics.md:920
 msgid ""
 "SpeedAndHeight - Fixed horizontal velocity and maximum height mode, using"
 " `Trajectory.Speed` and `Trajectory.Parabola.ThrowHeight` as calculation "
@@ -3809,7 +3878,7 @@ msgstr ""
 "SpeedAndHeight - 固定水平速度和最大高度模式，使用 `Trajectory.Speed` 和 "
 "`Trajectory.Parabola.ThrowHeight` 作为计算条件，即抛射体将只进行高度变化，高度随目标高度变化。"
 
-#: ../../New-or-Enhanced-Logics.md:900
+#: ../../New-or-Enhanced-Logics.md:921
 msgid ""
 "HeightAndAngle - Fixed maximum height and fire angle mode, using "
 "`Trajectory.Parabola.ThrowHeight` and `Trajectory.Parabola.LaunchAngle` "
@@ -3819,7 +3888,7 @@ msgstr ""
 "HeightAndAngle - 固定最大高度和开火角度模式，使用 `Trajectory.Parabola.ThrowHeight` 和 "
 "`Trajectory.Parabola.LaunchAngle` 作为计算条件，即抛射体将随高度变化而水平变化。"
 
-#: ../../New-or-Enhanced-Logics.md:901
+#: ../../New-or-Enhanced-Logics.md:922
 msgid ""
 "SpeedAndAngle - Fixed horizontal velocity and fire angle mode, using "
 "`Trajectory.Speed` and `Trajectory.Parabola.LaunchAngle` as calculation "
@@ -3828,7 +3897,7 @@ msgstr ""
 "SpeedAndAngle - 固定水平速度和开火角度模式，使用 `Trajectory.Speed` 和 "
 "`Trajectory.Parabola.LaunchAngle` 作为计算条件，即抛射体轨迹恒定。"
 
-#: ../../New-or-Enhanced-Logics.md:902
+#: ../../New-or-Enhanced-Logics.md:923
 msgid ""
 "`Trajectory.Parabola.ThrowHeight` controls the maximum height of the "
 "projectile and is only used for modes 1, 3, or 4. The specific height "
@@ -3839,7 +3908,7 @@ msgstr ""
 "`Trajectory.Parabola.ThrowHeight` 控制抛射体的最大高度，仅用于模式 1、3 或 "
 "4。具体高度将由取发射高度和目标高度中的较大值然后增加此值决定。不支持非正数。"
 
-#: ../../New-or-Enhanced-Logics.md:903
+#: ../../New-or-Enhanced-Logics.md:924
 msgid ""
 "`Trajectory.Parabola.LaunchAngle` controls the fire angle of the "
 "projectile and is only used for modes 2, 4, or 5. Only supports -90.0 ~ "
@@ -3849,7 +3918,7 @@ msgstr ""
 "`Trajectory.Parabola.LaunchAngle` 控制抛射体的开火角度，仅用于模式 2、4 或 5。在模式 2 或 5 中仅支持"
 " -90.0 ~ 90.0（不能使用边界值），在模式 4 中则是 0.0 ~ 90.0（不能使用边界值）。"
 
-#: ../../New-or-Enhanced-Logics.md:904
+#: ../../New-or-Enhanced-Logics.md:925
 msgid ""
 "`Trajectory.Parabola.LeadTimeCalculate` controls whether the projectile "
 "need to calculate the lead time of the target when firing. Note that this"
@@ -3858,7 +3927,7 @@ msgstr ""
 "`Trajectory.Parabola.LeadTimeCalculate` "
 "控制抛射体在射击时是否需要计算目标的提前量。注意这不会影响炮塔的朝向。"
 
-#: ../../New-or-Enhanced-Logics.md:905
+#: ../../New-or-Enhanced-Logics.md:926
 msgid ""
 "`Trajectory.Parabola.DetonationAngle` controls when the angle between the"
 " projectile in the current velocity direction and the horizontal plane is"
@@ -3868,7 +3937,7 @@ msgstr ""
 "`Trajectory.Parabola.DetonationAngle` "
 "控制当抛射体当前速度方向与水平方向的角度小于此值时，它将提前引爆。当值为 -90.0 ~ 90.0（不能使用边界值）时生效。"
 
-#: ../../New-or-Enhanced-Logics.md:906
+#: ../../New-or-Enhanced-Logics.md:927
 msgid ""
 "`Trajectory.Parabola.DetonationHeight` controls when the projectile is in"
 " a descending state and below the height of the launch position plus this"
@@ -3878,7 +3947,7 @@ msgstr ""
 "`Trajectory.Parabola.DetonationHeight` "
 "控制当抛射体处于下落段且低于发射位置的高度加上此值时会提前引爆。设置为非负数时生效。"
 
-#: ../../New-or-Enhanced-Logics.md:907
+#: ../../New-or-Enhanced-Logics.md:928
 msgid ""
 "`Trajectory.Parabola.BounceTimes` controls how many times can it bounce "
 "back when the projectile hits the ground or cliff. Be aware that "
@@ -3893,19 +3962,19 @@ msgstr ""
 " 与此不会冲突，它们将同时生效。因此，如果你想让子弹只在弹跳次数用尽后爆炸，你应该将 "
 "`Trajectory.Parabola.DetonationDistance` 设置为非正数。"
 
-#: ../../New-or-Enhanced-Logics.md:908
+#: ../../New-or-Enhanced-Logics.md:929
 msgid ""
 "`Trajectory.Parabola.BounceOnWater` controls whether it can bounce on the"
 " water surface."
 msgstr "`Trajectory.Parabola.BounceOnWater` 控制能否在水面上弹跳。"
 
-#: ../../New-or-Enhanced-Logics.md:909
+#: ../../New-or-Enhanced-Logics.md:930
 msgid ""
 "`Trajectory.Parabola.BounceDetonate` controls whether it detonates the "
 "warhead once extra during each bounce."
 msgstr "`Trajectory.Parabola.BounceDetonate` 控制是否在每次弹跳时额外引爆一次弹头。"
 
-#: ../../New-or-Enhanced-Logics.md:910
+#: ../../New-or-Enhanced-Logics.md:931
 msgid ""
 "`Trajectory.Parabola.BounceAttenuation` controls the attenuation "
 "coefficient of projectile bounce damage, that is, how many times the next"
@@ -3915,14 +3984,14 @@ msgstr ""
 "`Trajectory.Parabola.BounceAttenuation` "
 "控制抛射体弹跳伤害的衰减系数，即每次造成伤害后的下一次伤害会翻多少倍。这也将影响最终引爆的伤害。"
 
-#: ../../New-or-Enhanced-Logics.md:911
+#: ../../New-or-Enhanced-Logics.md:932
 msgid ""
 "`Trajectory.Parabola.BounceCoefficient` controls the attenuation "
 "coefficient of projectile bounce elasticity, that is, how many times the "
 "speed after each bounce is the speed before bouncing."
 msgstr "`Trajectory.Parabola.BounceCoefficient` 控制抛射体弹跳弹性的衰减系数，即每次弹跳后的速度会翻多少倍。"
 
-#: ../../New-or-Enhanced-Logics.md:912
+#: ../../New-or-Enhanced-Logics.md:933
 msgid ""
 "`Trajectory.Parabola.OffsetCoord` controls the offsets of the target. "
 "Projectile will aim at this position to attack. It also supports "
@@ -3932,7 +4001,7 @@ msgstr ""
 "`Trajectory.Parabola.OffsetCoord` 控制锁定目标的偏移量。抛射体将瞄准此位置进行攻击。在此基础上它也支持 "
 "`Inaccurate=yes` 和 `Trajectory.Parabola.LeadTimeCalculate=true`。"
 
-#: ../../New-or-Enhanced-Logics.md:913
+#: ../../New-or-Enhanced-Logics.md:934
 msgid ""
 "`Trajectory.Parabola.RotateCoord` controls whether to rotate the "
 "projectile's firing direction within the angle bisector of "
@@ -3942,7 +4011,7 @@ msgstr ""
 "`Trajectory.Parabola.RotateCoord` 控制是否根据武器的 `Burst` 在以 "
 "`Trajectory.Parabola.OffsetCoord` 为角平分线的角度内旋转抛射体的发射方向。设为 0 以禁用此功能。"
 
-#: ../../New-or-Enhanced-Logics.md:914
+#: ../../New-or-Enhanced-Logics.md:935
 msgid ""
 "`Trajectory.Parabola.MirrorCoord` controls whether "
 "`Trajectory.Parabola.OffsetCoord` need to mirror the lateral value to "
@@ -3955,7 +4024,7 @@ msgstr ""
 "是否需要镜像水平方向值以适应当前的连发索引。同时，`Trajectory.Straight.RotateCoord` "
 "计算出的旋转方向也将被反转，每侧相邻抛射体之间的旋转角度不会受此改变。"
 
-#: ../../New-or-Enhanced-Logics.md:915
+#: ../../New-or-Enhanced-Logics.md:936
 msgid ""
 "`Trajectory.Parabola.UseDisperseBurst` controls whether the calculation "
 "of `Trajectory.Parabola.RotateCoord` is based on its superior's "
@@ -3967,7 +4036,7 @@ msgstr ""
 "`Trajectory.Parabola.RotateCoord` 的计算是否基于其上级武器的 "
 "`Trajectory.Disperse.WeaponBurst` 而不是武器的 `Burst`。此值不合适将导致不理想的视觉效果。"
 
-#: ../../New-or-Enhanced-Logics.md:916
+#: ../../New-or-Enhanced-Logics.md:937
 msgid ""
 "`Trajectory.Parabola.AxisOfRotation` controls the rotation axis when "
 "calculating `Trajectory.Parabola.RotateCoord`. The axis will rotates with"
@@ -3977,7 +4046,7 @@ msgstr ""
 "`Trajectory.Parabola.AxisOfRotation` 控制计算 "
 "`Trajectory.Parabola.RotateCoord` 的转轴。随单位朝向或目标位置到源位置的向量旋转。"
 
-#: ../../New-or-Enhanced-Logics.md:919
+#: ../../New-or-Enhanced-Logics.md:940
 msgid ""
 "[SOMEPROJECTILE]                                ; Projectile\n"
 "Trajectory=Parabola                             ; Trajectory type\n"
@@ -4029,21 +4098,21 @@ msgstr ""
 "Trajectory.Parabola.AxisOfRotation=0,0,1        ; integer - "
 "Forward,Lateral,Height\n"
 
-#: ../../New-or-Enhanced-Logics.md:943
+#: ../../New-or-Enhanced-Logics.md:964
 msgid ""
 "Compared to vanilla `Arcing`, this can also be used for aircrafts and "
 "airburst weapon."
 msgstr "与原有的 `Arcing` 相比，它还可以用于战机和空爆武器。"
 
-#: ../../New-or-Enhanced-Logics.md:944
+#: ../../New-or-Enhanced-Logics.md:965
 msgid "Certainly, `Gravity` can also affect the trajectory."
 msgstr "当然，`Gravity` 仍会影响轨迹。"
 
-#: ../../New-or-Enhanced-Logics.md:947
+#: ../../New-or-Enhanced-Logics.md:968
 msgid "Projectiles blocked by land or water"
 msgstr "使抛射体被陆地或水域阻挡"
 
-#: ../../New-or-Enhanced-Logics.md:949
+#: ../../New-or-Enhanced-Logics.md:970
 msgid ""
 "It is now possible to make projectiles consider either land or water as "
 "obstacles that block their path by setting `SubjectTo(Land/Water)` to "
@@ -4058,14 +4127,14 @@ msgstr ""
 "以使抛射体将陆地或水域视为阻挡其路径的障碍物。发射此类抛射体的武器将把这些障碍物阻挡的目标视为超出射程并尝试重新移动自己的位置以便在不受这些障碍阻挡的情况下开火。如果"
 " `SubjectTo(Land/Water).Detonate` 设置为 true，那么抛射体设法与上述障碍交叠时将会爆炸。"
 
-#: ../../New-or-Enhanced-Logics.md:950
+#: ../../New-or-Enhanced-Logics.md:971
 msgid ""
 "`Level=true` projectiles detonate on tiles belonging to non-water "
 "tilesets by default, but will not consider such tiles as true obstacles. "
 "This behaviour can be overridden by setting these keys."
 msgstr "默认情况下 `Level=true` 的抛射体在非水域的地块上爆炸，但不会将这些地块视为真正的障碍物。通过设置这些标签可以覆盖此行为。"
 
-#: ../../New-or-Enhanced-Logics.md:951
+#: ../../New-or-Enhanced-Logics.md:972
 msgid ""
 "As for `SubjectToGround`, if set it to true ,it will predict the height "
 "of the connecting straight line from the bullet's source coordinates to "
@@ -4080,7 +4149,7 @@ msgstr ""
 "那么开火者会将所在高度低于开火位置下方地面高度的目标视为超出射程并调整自身所在位置以能够开火。由于技术原因，该功能对空军和建筑无效。在 "
 "`OpenTopped=true` 的载具内开火的科技类型也不会受到影响。"
 
-#: ../../New-or-Enhanced-Logics.md:954
+#: ../../New-or-Enhanced-Logics.md:975
 msgid ""
 "[SOMEPROJECTILE]              ; Projectile\n"
 "SubjectToLand=                ; boolean\n"
@@ -4096,11 +4165,11 @@ msgstr ""
 "SubjectToWater.Detonate=true  ; boolean\n"
 "SubjectToGround=false         ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:963
+#: ../../New-or-Enhanced-Logics.md:984
 msgid "Return weapon"
 msgstr "归返武器"
 
-#: ../../New-or-Enhanced-Logics.md:965
+#: ../../New-or-Enhanced-Logics.md:986
 msgid ""
 "It is now possible to make another weapon & projectile go off from a "
 "detonated projectile (in somewhat similar manner to `AirburstWeapon` or "
@@ -4112,13 +4181,13 @@ msgstr ""
 "`ShrapnelWeapon` 的方式）发射另一个武器和抛射体返回到发射者。如果发射者在初始抛射体引爆前死亡则 `ReturnWeapon` "
 "不会发射。"
 
-#: ../../New-or-Enhanced-Logics.md:966
+#: ../../New-or-Enhanced-Logics.md:987
 msgid ""
 "`ReturnWeapon.ApplyFirepowerMult` determines whether or not the auxiliary"
 " weapon's damage should multiply the firer's firepower multipliers."
 msgstr "`ReturnWeapon.ApplyFirepowerMult` 决定归返武器的伤害是否受益于科技类型所拥有的火力加成。"
 
-#: ../../New-or-Enhanced-Logics.md:969
+#: ../../New-or-Enhanced-Logics.md:990
 msgid ""
 "[SOMEPROJECTILE]                        ; Projectile\n"
 "ReturnWeapon=                           ; WeaponType\n"
@@ -4128,15 +4197,15 @@ msgstr ""
 "ReturnWeapon=                           ; WeaponType\n"
 "ReturnWeapon.ApplyFirepowerMult=false   ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:975
+#: ../../New-or-Enhanced-Logics.md:996
 msgid "Super Weapons"
 msgstr "超级武器"
 
-#: ../../New-or-Enhanced-Logics.md:977
+#: ../../New-or-Enhanced-Logics.md:998
 msgid "AI Superweapon delay timer"
 msgstr "AI 超级武器发射延迟"
 
-#: ../../New-or-Enhanced-Logics.md:979
+#: ../../New-or-Enhanced-Logics.md:1000
 msgid ""
 "By default AI houses only process superweapon logic e.g checks if it can "
 "fire any superweapons firing them at randomized intervals of 106 to 112 "
@@ -4148,7 +4217,7 @@ msgstr ""
 "个游戏帧的随机间隔内发射该超武。这一行为现在可以自定义设置为明确的间隔时间或予以禁用。0 及更小的值会禁用间隔并导致 AI "
 "所属方每帧检查超级武器。"
 
-#: ../../New-or-Enhanced-Logics.md:982
+#: ../../New-or-Enhanced-Logics.md:1003
 msgid ""
 "[General]\n"
 "AISuperWeaponDelay=  ; integer, game frames\n"
@@ -4156,18 +4225,18 @@ msgstr ""
 "[General]\n"
 "AISuperWeaponDelay=  ; integer, game frames\n"
 
-#: ../../New-or-Enhanced-Logics.md:987
+#: ../../New-or-Enhanced-Logics.md:1008
 msgid "Convert TechnoType"
 msgstr "单位转换超武"
 
-#: ../../New-or-Enhanced-Logics.md:989 ../../New-or-Enhanced-Logics.md:1969
+#: ../../New-or-Enhanced-Logics.md:1010 ../../New-or-Enhanced-Logics.md:1991
 msgid ""
 "Warheads can now change TechnoTypes of affected units to other Types in "
 "the same category (infantry to infantry, vehicles to vehicles, aircraft "
 "to aircraft)."
 msgstr "现在弹头可以将受影响单位的科技类型更改为同大类的其他科技类型（步兵到步兵，车辆到车辆，战机到战机）。"
 
-#: ../../New-or-Enhanced-Logics.md:990 ../../New-or-Enhanced-Logics.md:1970
+#: ../../New-or-Enhanced-Logics.md:1011 ../../New-or-Enhanced-Logics.md:1992
 msgid ""
 "`ConvertN.From` (where N is 0, 1, 2...) specifies which TechnoTypes are "
 "valid for conversion. This entry can have many types listed, meanging "
@@ -4177,15 +4246,15 @@ msgstr ""
 "`ConvertN.From`（此处 N 为 0, 1, "
 "2...）指定哪些科技类型可用于转换。此条目可以列出许多类型以一次全部转换。当没有包含任何类型时将影响所有有效目标。"
 
-#: ../../New-or-Enhanced-Logics.md:991 ../../New-or-Enhanced-Logics.md:1971
+#: ../../New-or-Enhanced-Logics.md:1012 ../../New-or-Enhanced-Logics.md:1993
 msgid "`ConvertN.To` specifies the TechnoType which is the result of conversion."
 msgstr "`ConvertN.To` 指定转换后的科技类型。"
 
-#: ../../New-or-Enhanced-Logics.md:992 ../../New-or-Enhanced-Logics.md:1972
+#: ../../New-or-Enhanced-Logics.md:1013 ../../New-or-Enhanced-Logics.md:1994
 msgid "`ConvertN.AffectedHouses` specifies whose units can be converted."
 msgstr "`ConvertN.AffectedHouses` 指定哪些所属方的单位可以被转换。"
 
-#: ../../New-or-Enhanced-Logics.md:993 ../../New-or-Enhanced-Logics.md:1973
+#: ../../New-or-Enhanced-Logics.md:1014 ../../New-or-Enhanced-Logics.md:1995
 msgid ""
 "`Convert.From`, `Convert.To` and `Convert.AffectedHouses` (without "
 "numbers) are a valid alternative to `Convert0.From`, `Convert0.To` and "
@@ -4194,7 +4263,7 @@ msgstr ""
 "若只指定一组转换则 `Convert.From`、`Convert.To` 和 `Convert.AffectedHouses`（不带序号）相当于"
 " `Convert0.From`、`Convert0.To` 和 `Convert0.AffectedHouses`的别称。"
 
-#: ../../New-or-Enhanced-Logics.md:994
+#: ../../New-or-Enhanced-Logics.md:1015
 msgid ""
 "Conversion affects *all* existing units of set TechnoTypes, this includes"
 " units in: transports, occupied buildings, buildings with "
@@ -4203,13 +4272,13 @@ msgstr ""
 "转换影响被指定的 **所有** 当前存在的科技类型，包括处于运输工具中的、驻扎在建筑内的、处于 `InfantryAbsorb=yes` 或 "
 "`UnitAbsorb=yes` 的建筑中的、正在 `Bunker=yes` 建筑里的。"
 
-#: ../../New-or-Enhanced-Logics.md:996
+#: ../../New-or-Enhanced-Logics.md:1017
 msgid ""
 "In example, this superweapon would convert all owned and friendly "
 "`SOLDIERA` and `SOLDIERB` to `NEWSOLDIER`:"
 msgstr "例如，这个超级武器可以将所有被影响的己方和友方 `SOLDIERA` 和 `SOLDIERB` 转换为 `NEWSOLDIER`："
 
-#: ../../New-or-Enhanced-Logics.md:997
+#: ../../New-or-Enhanced-Logics.md:1018
 msgid ""
 "[ExampleSW]\n"
 "Convert.From=SOLDIERA,SOLDIERB\n"
@@ -4221,7 +4290,7 @@ msgstr ""
 "Convert.To=NEWSOLDIER\n"
 "Convert.AffectedHouses=team\n"
 
-#: ../../New-or-Enhanced-Logics.md:1005
+#: ../../New-or-Enhanced-Logics.md:1026
 msgid ""
 "[SOMESW]                        ; SuperWeaponType\n"
 "ConvertN.From=                  ; List of TechnoTypes\n"
@@ -4247,7 +4316,7 @@ msgstr ""
 "Convert.AffectedHouses=owner    ; List of Affected House Enumeration "
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1018 ../../New-or-Enhanced-Logics.md:1997
+#: ../../New-or-Enhanced-Logics.md:1039 ../../New-or-Enhanced-Logics.md:2019
 msgid ""
 "This feature has the same limitations as [Ares' Type Conversion](https"
 "://ares-developers.github.io/Ares-docs/new/typeconversion.html). This "
@@ -4256,29 +4325,29 @@ msgstr ""
 "此功能与 [Ares 的单位转换](https://ares-developers.github.io/Ares-"
 "docs/new/typeconversion.html) 存在同样的限制。此功能不支持建筑类型。"
 
-#: ../../New-or-Enhanced-Logics.md:1022 ../../New-or-Enhanced-Logics.md:2001
+#: ../../New-or-Enhanced-Logics.md:1043 ../../New-or-Enhanced-Logics.md:2023
 msgid ""
 "This feature requires Ares 3.0 or higher to function! When Ares 3.0+ is "
 "not detected, not all properties of a unit may be updated."
 msgstr "此功能需要 3.0 及以上版本的 Ares！如果未检测到 Ares 3.0+，单位的某些属性可能不会被更新。"
 
-#: ../../New-or-Enhanced-Logics.md:1025
+#: ../../New-or-Enhanced-Logics.md:1046
 msgid "Customize SuperWeapon TabIndex"
 msgstr "自定义超级武器所在栏"
 
-#: ../../New-or-Enhanced-Logics.md:1027
+#: ../../New-or-Enhanced-Logics.md:1048
 msgid ""
 "You can now assign a Super Weapon's cameo to any sidebar tab using "
 "`TabIndex`."
 msgstr "现在你可以通过 `TabIndex` 将超级武器的图标分配到侧边栏的任意标签页下。"
 
-#: ../../New-or-Enhanced-Logics.md:1028
+#: ../../New-or-Enhanced-Logics.md:1049
 msgid ""
 "Valid values are: 0 (buildings tab), 1 (arsenal tab), 2 (infantry tab), 3"
 " (vehicle tab)."
 msgstr "有效值为：0（建筑栏）、1（防御栏）、2（步兵栏）、3（载具栏）。"
 
-#: ../../New-or-Enhanced-Logics.md:1031
+#: ../../New-or-Enhanced-Logics.md:1052
 msgid ""
 "[SOMESW]    ; SuperWeaponType\n"
 "TabIndex=1  ; integer\n"
@@ -4286,11 +4355,11 @@ msgstr ""
 "[SOMESW]    ; SuperWeaponType\n"
 "TabIndex=1  ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1036
+#: ../../New-or-Enhanced-Logics.md:1057
 msgid "EMPulse settings"
 msgstr "EMPulse 设置"
 
-#: ../../New-or-Enhanced-Logics.md:1038
+#: ../../New-or-Enhanced-Logics.md:1059
 msgid ""
 "It is possible to customize which weapon a building with "
 "`EMPulseCannon=true` fires when an associated `Type=EMPulse` superweapon "
@@ -4300,7 +4369,7 @@ msgstr ""
 "可以通过设置 `EMPulse.WeaponIndex` 来自定义具有 `EMPulseCannon=true` 的建筑在发射其所关联的 "
 "`Type=EMPulse` 类超级武器时（**仅**当 `EMPulse.TargetSelf=false` 或省略时）所使用的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1039
+#: ../../New-or-Enhanced-Logics.md:1060
 msgid ""
 "Note that if you fire another `Type=EMPulse` superweapon with different "
 "weapon index that the same building is capable of launching before the "
@@ -4308,7 +4377,7 @@ msgid ""
 "precedence."
 msgstr "注意如果在同一个建筑发射第一种武器前发射另一种具有不同武器索引的 `Type=EMPulse` 超级武器那么较晚者的设置将优先生效。"
 
-#: ../../New-or-Enhanced-Logics.md:1040
+#: ../../New-or-Enhanced-Logics.md:1061
 msgid ""
 "Additionally, due to technical limitations the targeting constraints will"
 " always default to primary weapon's `Range/MinimumRange` unless "
@@ -4317,7 +4386,7 @@ msgstr ""
 "此外由于技术限制目前除非手动列出了 `SW.RangeMinimum`／`SW.RangeMaximum` 否则始终默认使用主武器的 "
 "`Range/MinimumRange` 执行瞄准限制。"
 
-#: ../../New-or-Enhanced-Logics.md:1041
+#: ../../New-or-Enhanced-Logics.md:1062
 msgid ""
 "Is is now also possible to have all other `Type=EMPulse` superweapons "
 "that can be fired by same buildings as current one be put on hold until "
@@ -4327,7 +4396,7 @@ msgstr ""
 "现在如果发射的超级武器拥有 `EMPulse.SuspendOthers=true` 那么在第一个建筑发射之前，所有其他可以由同一建筑发射的 "
 "`Type=EMPulse` 超级武器将被暂停直到第一个建筑发射完毕。"
 
-#: ../../New-or-Enhanced-Logics.md:1044
+#: ../../New-or-Enhanced-Logics.md:1065
 msgid ""
 "[SOMESW]                     ; SuperWeaponType\n"
 "EMPulse.WeaponIndex=0        ; integer, weapon slot index\n"
@@ -4337,7 +4406,7 @@ msgstr ""
 "EMPulse.WeaponIndex=0        ; integer, weapon slot index\n"
 "EMPulse.SuspendOthers=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1051
+#: ../../New-or-Enhanced-Logics.md:1072
 msgid ""
 "`Type=EMPulse` superweapon and any associated keys are [Ares "
 "features](https://ares-developers.github.io/Ares-"
@@ -4346,54 +4415,54 @@ msgstr ""
 "`Type=EMPulse` 超级武器及其任何关联标签是 [Ares 功能](https://ares-developers.github.io"
 "/Ares-docs/new/superweapons/types/empulse.html)。"
 
-#: ../../New-or-Enhanced-Logics.md:1054
+#: ../../New-or-Enhanced-Logics.md:1075
 msgid "LimboDelivery"
 msgstr "虚拟投放"
 
-#: ../../New-or-Enhanced-Logics.md:1056
+#: ../../New-or-Enhanced-Logics.md:1077
 msgid ""
 "Superweapons can now deliver off-map buildings that act as if they were "
 "on the field."
 msgstr "现在超级武器可以在地图外投放与在场上时表现一致的建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:1057
+#: ../../New-or-Enhanced-Logics.md:1078
 msgid ""
 "`LimboDelivery.Types` is the list of BuildingTypes that will be created "
 "when the Superweapons fire. Superweapon `Type` and coordinates do not "
 "matter."
 msgstr "`LimboDelivery.Types` 是超级武器发射时将创建的建筑类型列表。与超级武器的 `Type` 和坐标无关。"
 
-#: ../../New-or-Enhanced-Logics.md:1058
+#: ../../New-or-Enhanced-Logics.md:1079
 msgid ""
 "`LimboDelivery.IDs` is the list of numeric IDs that will be assigned to "
 "buildings. Necessary for LimboKill to work."
 msgstr "`LimboDelivery.IDs` 是分配给建筑的数字 ID列表。这是虚拟击杀功能所必需的。"
 
-#: ../../New-or-Enhanced-Logics.md:1060
+#: ../../New-or-Enhanced-Logics.md:1081
 msgid ""
 "Created buildings are not affected by any on-map threats. The only way to"
 " remove them from the game is by using a Superweapon with `LimboKill.IDs`"
 " set."
 msgstr "创建的建筑不受地图上任何威胁的影响。从游戏中移除它们的唯一方法是使用设置了 `LimboKill.IDs` 的超级武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1061
+#: ../../New-or-Enhanced-Logics.md:1082
 msgid "`LimboKill.Affected` sets which houses are affected by this feature."
 msgstr "`LimboKill.Affected` 设置那个所属方受此效果影响。"
 
-#: ../../New-or-Enhanced-Logics.md:1062
+#: ../../New-or-Enhanced-Logics.md:1083
 msgid ""
 "`LimboKill.IDs` lists IDs that will be targeted. Buildings with these IDs"
 " will be removed from the game instantly."
 msgstr "`LimboKill.IDs` 是建筑 ID列表，这些建筑将被立即从游戏中移除。"
 
-#: ../../New-or-Enhanced-Logics.md:1064
+#: ../../New-or-Enhanced-Logics.md:1085
 msgid ""
 "Delivery can be made random with these optional tags. The game will "
 "randomly choose only a single building from the list for each roll chance"
 " provided."
 msgstr "使用这些标签可以使投放变得随机。游戏将根据每个提供的 “掷骰子” 概率随机选择列表中的一个建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:1065
+#: ../../New-or-Enhanced-Logics.md:1086
 msgid ""
 "`LimboDelivery.RollChances` lists chances of each \"dice roll\" "
 "happening. Valid values range from 0% (never happens) to 100% (always "
@@ -4402,7 +4471,7 @@ msgstr ""
 "`LimboDelivery.RollChances` 是 “掷骰子” 发生的概率列表。有效值的范围为 0%（从不发生）到 "
 "100%（总是发生）。默认为单次必出。"
 
-#: ../../New-or-Enhanced-Logics.md:1066
+#: ../../New-or-Enhanced-Logics.md:1087
 msgid ""
 "`LimboDelivery.RandomWeightsN` lists the weights for each \"dice roll\" "
 "that increase the probability of picking a specific building. Valid "
@@ -4415,29 +4484,29 @@ msgstr ""
 "100%（总是发生）。`RandomWeights` 是 `RandomWeights0` "
 "的有效别名。如果掷骰尝试没有指定权重，则使用最后一个权重。"
 
-#: ../../New-or-Enhanced-Logics.md:1069
+#: ../../New-or-Enhanced-Logics.md:1090
 msgid ""
 "This feature might not support every building flag. Flags that are "
 "confirmed to work correctly are listed below:"
 msgstr "此功能可能不支持所有建筑标签。以下列出了已确认可正常工作的标签："
 
-#: ../../New-or-Enhanced-Logics.md:1070
+#: ../../New-or-Enhanced-Logics.md:1091
 msgid "FactoryPlant"
 msgstr "FactoryPlant"
 
-#: ../../New-or-Enhanced-Logics.md:1071
+#: ../../New-or-Enhanced-Logics.md:1092
 msgid "OrePurifier"
 msgstr "OrePurifier"
 
-#: ../../New-or-Enhanced-Logics.md:1072
+#: ../../New-or-Enhanced-Logics.md:1093
 msgid "SpySat"
 msgstr "SpySat"
 
-#: ../../New-or-Enhanced-Logics.md:1073
+#: ../../New-or-Enhanced-Logics.md:1094
 msgid "KeepAlive (Ares 3.0)"
 msgstr "KeepAlive (Ares 3.0)"
 
-#: ../../New-or-Enhanced-Logics.md:1074
+#: ../../New-or-Enhanced-Logics.md:1095
 msgid ""
 "Prerequisite, PrerequisiteOverride, Prerequisite.List# (Ares 0.1), "
 "Prerequisite.Negative (Ares 0.1), GenericPrerequisites (Ares 0.1)"
@@ -4445,7 +4514,7 @@ msgstr ""
 "Prerequisite、PrerequisiteOverride、Prerequisite.List# (Ares "
 "0.1)、Prerequisite.Negative (Ares 0.1)、GenericPrerequisites (Ares 0.1)"
 
-#: ../../New-or-Enhanced-Logics.md:1075
+#: ../../New-or-Enhanced-Logics.md:1096
 msgid ""
 "SuperWeapon, SuperWeapon2, SuperWeapons (Ares 0.9), SW.AuxBuildings (Ares"
 " 0.9), SW.NegBuildings (Ares 0.9)"
@@ -4453,14 +4522,14 @@ msgstr ""
 "SuperWeapon、SuperWeapon2、SuperWeapons (Ares 0.9)、SW.AuxBuildings (Ares "
 "0.9)、SW.NegBuildings (Ares 0.9)"
 
-#: ../../New-or-Enhanced-Logics.md:1077
+#: ../../New-or-Enhanced-Logics.md:1098
 msgid ""
 "In order for this feature to work with AITriggerTypes conditions "
 "(\"Owning house owns ???\" and \"Enemy house owns ???\"), `LegalTarget` "
 "must be set to true."
 msgstr "为使此功能与 AITriggerTypes 条件（“拥有者拥有？” 和 “敌人拥有？”）一起工作，`LegalTarget` 必须设置为 true。"
 
-#: ../../New-or-Enhanced-Logics.md:1081
+#: ../../New-or-Enhanced-Logics.md:1102
 msgid ""
 "[SOMESW]                        ; SuperWeaponType\n"
 "LimboDelivery.Types=            ; List of BuildingTypes\n"
@@ -4482,7 +4551,7 @@ msgstr ""
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "LimboKill.IDs=                  ; List of numeric IDs.\n"
 
-#: ../../New-or-Enhanced-Logics.md:1092
+#: ../../New-or-Enhanced-Logics.md:1113
 msgid ""
 "Remember that Limbo Delivered buildings don't exist physically! This "
 "means they should never have enabled machanics that require interaction "
@@ -4493,11 +4562,11 @@ msgstr ""
 "谨记虚拟投放的建筑并不真实存在于地图上！这意味着它们不应启用需要与游戏战场内交互的机制（例如工厂、克隆、维修厂、停机坪）。它们还 **应该设为 "
 "`KeepAlive=no` 或者可以被虚拟击杀** - 否则游戏永远不会结束。"
 
-#: ../../New-or-Enhanced-Logics.md:1095
+#: ../../New-or-Enhanced-Logics.md:1116
 msgid "Next"
 msgstr "Next"
 
-#: ../../New-or-Enhanced-Logics.md:1097
+#: ../../New-or-Enhanced-Logics.md:1118
 msgid ""
 "![image](_static/images/swnext.gif) *Use `SW.Next` to link multiple "
 "ChronoSphere and ChronoWarp superweapons into a chained SuperWeapon "
@@ -4507,14 +4576,14 @@ msgstr ""
 "*[虚幻](https://www.moddb.com/mods/Cylearun) 中通过 `SW.Next` 将多个 ChronoSphere"
 " 与 ChronoWarp 类型的超武组成链式超武系统*"
 
-#: ../../New-or-Enhanced-Logics.md:1100
+#: ../../New-or-Enhanced-Logics.md:1121
 msgid ""
 "Superweapons can now launch other superweapons at the same target. "
 "Launched types can be additionally randomized using the same rules as "
 "with LimboDelivery (see above)."
 msgstr "现在超级武器可以向同一目标地点发射其他超级武器。发射的类型可以使用与虚拟投放相同的规则进行随机化（见上文）。"
 
-#: ../../New-or-Enhanced-Logics.md:1101
+#: ../../New-or-Enhanced-Logics.md:1122
 msgid ""
 "`SW.Next.RealLaunch` controls whether the owner who fired the initial "
 "superweapon must own all listed superweapons and sufficient funds to "
@@ -4523,7 +4592,7 @@ msgstr ""
 "`SW.Next.RealLaunch` 控制发射初始超级武器的所有者是否必须拥有所列出的超级武器和足够 `Money.Amout` "
 "的资金来支持。否则强制发射。"
 
-#: ../../New-or-Enhanced-Logics.md:1102
+#: ../../New-or-Enhanced-Logics.md:1123
 msgid ""
 "`SW.Next.IgnoreInhibitors` ignores `SW.Inhibitors`/`SW.AnyInhibitor` of "
 "each superweapon, otherwise only non-inhibited superweapons are launched."
@@ -4531,7 +4600,7 @@ msgstr ""
 "`SW.Next.IgnoreInhibitors` 设置是否忽略每个超级武器的 "
 "`SW.Inhibitors`／`SW.AnyInhibitor`，否则只有未被抑制的超级武器会被发射。"
 
-#: ../../New-or-Enhanced-Logics.md:1103
+#: ../../New-or-Enhanced-Logics.md:1124
 msgid ""
 "`SW.Next.IgnoreDesignators` ignores `SW.Designators` / `SW.AnyDesignator`"
 " respectively."
@@ -4539,7 +4608,7 @@ msgstr ""
 "`SW.Next.IgnoreDesignators` 设置是否忽略每个超级武器的 "
 "`SW.Designators`／`SW.AnyDesignator`。"
 
-#: ../../New-or-Enhanced-Logics.md:1106
+#: ../../New-or-Enhanced-Logics.md:1127
 msgid ""
 "[SOMESW]                        ; SuperWeaponType\n"
 "SW.Next=                        ; List of SuperWeaponTypes\n"
@@ -4557,23 +4626,23 @@ msgstr ""
 "SW.Next.RollChances=            ; List of percentages.\n"
 "SW.Next.RandomWeightsN=         ; List of integers.\n"
 
-#: ../../New-or-Enhanced-Logics.md:1116
+#: ../../New-or-Enhanced-Logics.md:1137
 msgid "Warhead or Weapon detonation at target cell"
 msgstr "在目标单元格处引爆弹头或武器"
 
-#: ../../New-or-Enhanced-Logics.md:1118
+#: ../../New-or-Enhanced-Logics.md:1139
 msgid ""
 "Any superweapon can now detonate a Warhead or a weapon at superweapon's "
 "target cell."
 msgstr "现在任何超级武器都可以在超级武器的目标单元格处引爆弹头或武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1119
+#: ../../New-or-Enhanced-Logics.md:1140
 msgid ""
 "If both `Detonate.Warhead` and `Detonate.Weapon` are set, latter takes "
 "precedence."
 msgstr "如果同时拥有 `Detonate.Warhead` 和 `Detonate.Weapon`，那么后者优先。"
 
-#: ../../New-or-Enhanced-Logics.md:1120
+#: ../../New-or-Enhanced-Logics.md:1141
 msgid ""
 "`Detonate.Warhead.Full` customizes whether or not the Warhead is "
 "detonated fully (as part of a dummy weapon) or simply deals area damage "
@@ -4582,7 +4651,7 @@ msgstr ""
 "`Detonate.Warhead.Full` 可用于设置弹头是否在目标上完全引爆（作为虚拟武器的一部分）或者只能对所在区域造成杀伤并应用 "
 "Phobos 的弹头效果"
 
-#: ../../New-or-Enhanced-Logics.md:1121
+#: ../../New-or-Enhanced-Logics.md:1142
 msgid ""
 "`Detonate.Damage`, if not set, defaults to weapon `Damage` for "
 "`Detonate.Weapon` and 0 for `Detonate.Warhead`."
@@ -4590,7 +4659,7 @@ msgstr ""
 "`Detonate.Damage` 如果未设置则默认为 `Detonate.Weapon` 的 `Damage`，对于 "
 "`Detonate.Warhead` 则是 0。"
 
-#: ../../New-or-Enhanced-Logics.md:1122
+#: ../../New-or-Enhanced-Logics.md:1143
 msgid ""
 "Both the weapon and Warhead behave as if fired by whatever building fired"
 " the Superweapon. This respects controls like `SW.RangeMinimum/Maximum` "
@@ -4602,7 +4671,7 @@ msgstr ""
 "之类的控制语句（在这方面类似于 Ares 的 GenericWarhead "
 "超级武器）。即便找不到发射建筑也仍会使用超级武器所属于的所属方来造成伤害并应用 Phobos 引入的弹头效果。"
 
-#: ../../New-or-Enhanced-Logics.md:1123
+#: ../../New-or-Enhanced-Logics.md:1144
 msgid ""
 "If `Detonate.AtFirer` is set to true, the weapon or Warhead is detonated "
 "at the firing building instead of the superweapon's target cell. If there"
@@ -4611,7 +4680,7 @@ msgstr ""
 "如果 `Detonate.AtFirer` 设置为 "
 "true，那么武器或弹头将在发射建筑上而不是超级武器的目标单元格处引爆。如果找不到发射建筑则不会引爆。"
 
-#: ../../New-or-Enhanced-Logics.md:1126
+#: ../../New-or-Enhanced-Logics.md:1147
 msgid ""
 "[SOMESW]                    ; SuperWeaponType\n"
 "Detonate.Warhead=           ; WarheadType\n"
@@ -4627,27 +4696,27 @@ msgstr ""
 "Detonate.Damage=            ; integer\n"
 "Detonate.AtFirer=false      ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1135
+#: ../../New-or-Enhanced-Logics.md:1156
 msgid "Technos"
 msgstr "科技类型"
 
-#: ../../New-or-Enhanced-Logics.md:1137
+#: ../../New-or-Enhanced-Logics.md:1158
 msgid "Aggressive attack move mission"
 msgstr "侵略性移动攻击命令"
 
-#: ../../New-or-Enhanced-Logics.md:1139
+#: ../../New-or-Enhanced-Logics.md:1160
 msgid ""
 "`AttackMove.Aggressive` allows your technos to attack the enemy's unarmed"
 " buildings more aggressively when in attack move mission (Ctrl+Shift)."
 msgstr "`AttackMove.Aggressive` 允许你的单位在执行移动攻击（Ctrl+Shift）任务时主动攻击敌方的无武装建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:1140
+#: ../../New-or-Enhanced-Logics.md:1161
 msgid ""
 "`AttackMove.UpdateTarget` allows your technos to automatically change and"
 " select a higher threat target when in attack move mission (Ctrl+Shift)."
 msgstr "`AttackMove.UpdateTarget` 允许你的单位在执行移动攻击（Ctrl+Shift）任务时自动切换威胁值更高的目标。"
 
-#: ../../New-or-Enhanced-Logics.md:1143
+#: ../../New-or-Enhanced-Logics.md:1164
 msgid ""
 "[General]\n"
 "AttackMove.Aggressive=false    ; boolean\n"
@@ -4669,11 +4738,11 @@ msgstr ""
 "AttackMove.UpdateTarget=       ; boolean, default to [General] -> "
 "AttackMove.UpdateTarget\n"
 
-#: ../../New-or-Enhanced-Logics.md:1153
+#: ../../New-or-Enhanced-Logics.md:1174
 msgid "Aircraft spawner customizations"
 msgstr "自定义子机发射器"
 
-#: ../../New-or-Enhanced-Logics.md:1155
+#: ../../New-or-Enhanced-Logics.md:1176
 msgid ""
 "![image](_static/images/spawnrange-01.gif) *Limited pursue range for "
 "spawns in [Fantasy ADVENTURE](https://www.moddb.com/mods/fantasy-"
@@ -4682,64 +4751,64 @@ msgstr ""
 "![image](_static/images/spawnrange-01.gif) "
 "*[幻想奇遇](https://www.moddb.com/mods/fantasy-adventure) 中的有限追击范围子机*"
 
-#: ../../New-or-Enhanced-Logics.md:1158
+#: ../../New-or-Enhanced-Logics.md:1179
 msgid ""
 "If `Spawner.LimitRange` is set, the spawned units will abort their "
 "pursuit if the enemy is out of the range of the largest weapon `Range` of"
 " a `Spawner=true` weapon of the spawner."
 msgstr "如果设置 `Spawner.LimitRange` 则子机将在敌人超出子机发射器武器 `Range` 设定的最大值范围后停止追击。"
 
-#: ../../New-or-Enhanced-Logics.md:1159
+#: ../../New-or-Enhanced-Logics.md:1180
 msgid ""
 "`Spawner.ExtraLimitRange` adds extra pursuit range on top of the weapon "
 "range."
 msgstr "`Spawner.ExtraLimitRange` 是追击范围相对于武器射程进行调整的参量。"
 
-#: ../../New-or-Enhanced-Logics.md:1160
+#: ../../New-or-Enhanced-Logics.md:1181
 msgid ""
 "`Spawner.DelayFrames` can be used to set the minimum number of game "
 "frames in between each spawn ejecting from the spawner. By default this "
 "is 9 frames for missiles and 20 for everything else."
 msgstr "`Spawner.DelayFrames` 可用于设置每次从子机发射器中生成单位的最小游戏帧数。对于导弹默认是 9 帧，其他默认是 20 帧。"
 
-#: ../../New-or-Enhanced-Logics.md:1161
+#: ../../New-or-Enhanced-Logics.md:1182
 msgid ""
 "If `Spawner.AttackImmediately` is set to true, spawned aircraft will "
 "assume attack mission immediately after being spawned instead of waiting "
 "for the remaining aircraft to spawn first."
 msgstr "如果 `Spawner.AttackImmediately` 设为 true，战机子机将在生成后立即执行攻击任务而不是先等待其余战机生成和集结。"
 
-#: ../../New-or-Enhanced-Logics.md:1162
+#: ../../New-or-Enhanced-Logics.md:1183
 msgid ""
 "`Spawner.UseTurretFacing`, if set, makes spawned aircraft face the same "
 "way as turret does upon being created if the spawner has a turret."
 msgstr "若启用 `Spawner.UseTurretFacing` 则子机发射器单位拥有炮塔时子机生成时的初始方向使用炮塔方向而非车体方向。"
 
-#: ../../New-or-Enhanced-Logics.md:1163
+#: ../../New-or-Enhanced-Logics.md:1184
 msgid ""
 "`Spawner.RecycleRange` defines the range (in cell) that the spawned is "
 "considered close enough to the spawner to be recycled."
 msgstr "`Spawner.RecycleRange` 决定子机在距离母舰多少格以内可以被进行回收。"
 
-#: ../../New-or-Enhanced-Logics.md:1164
+#: ../../New-or-Enhanced-Logics.md:1185
 msgid ""
 "`Spawner.RecycleAnim` can be used to play an anim on the spawned location"
 " when it is recycled."
 msgstr "`Spawner.RecycleAnim` 用于设置回收时在子机位置播放的动画。"
 
-#: ../../New-or-Enhanced-Logics.md:1165
+#: ../../New-or-Enhanced-Logics.md:1186
 msgid ""
 "`Spawner.RecycleCoord` defines the relative position to the carrier that "
 "the spawned aircraft will head to."
 msgstr "`Spawner.RecycleCoord` 定义了子机将要前往母舰的哪个位置。"
 
-#: ../../New-or-Enhanced-Logics.md:1166
+#: ../../New-or-Enhanced-Logics.md:1187
 msgid ""
 "`Spawner.RecycleOnTurret` defines if the FLH is relative to the turret "
 "rather than the body."
 msgstr "`Spawner.RecycleOnTurret` 定义这个位置是否相对于炮塔而非车体。"
 
-#: ../../New-or-Enhanced-Logics.md:1169
+#: ../../New-or-Enhanced-Logics.md:1190
 msgid ""
 "[SOMETECHNO]                       ; TechnoType\n"
 "Spawner.LimitRange=false           ; boolean\n"
@@ -4763,35 +4832,35 @@ msgstr ""
 "Spawner.RecycleCoord=0,0,0         ; integer - Forward,Lateral,Height\n"
 "Spawner.RecycleOnTurret=false      ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1183
+#: ../../New-or-Enhanced-Logics.md:1204
 msgid ""
 "If you set recycle FLH, it is best to set a recycle range of at least "
 "`0.5` at the same time. Otherwise, the spawner may not recycle correctly."
 msgstr "如果你设置了回收的 FLH，那么最好一并设置一个至少为 `0.5` 格的回收范围。否则子机发射器可能无法正确回收子机。"
 
-#: ../../New-or-Enhanced-Logics.md:1186
+#: ../../New-or-Enhanced-Logics.md:1207
 msgid "Automatic passenger deletion"
 msgstr "自动删除乘客"
 
-#: ../../New-or-Enhanced-Logics.md:1188
+#: ../../New-or-Enhanced-Logics.md:1209
 msgid ""
 "Transports can erase passengers over time. Passengers are deleted in "
 "order of entering the transport, from first to last."
 msgstr "运输工具可以随时间删除乘客。乘客将按照进入运输工具顺序的先后被删除。"
 
-#: ../../New-or-Enhanced-Logics.md:1189
+#: ../../New-or-Enhanced-Logics.md:1210
 msgid ""
 "`PassengerDeletion.Rate` determines the interval in game frames that it "
 "takes to erase a single passenger."
 msgstr "`PassengerDeletion.Rate` 决定删除单个乘客所需的游戏帧数。"
 
-#: ../../New-or-Enhanced-Logics.md:1190
+#: ../../New-or-Enhanced-Logics.md:1211
 msgid ""
 "If `PassengerDeletion.Rate.SizeMultiply` is set to true, this time "
 "interval is multiplied by the passenger's `Size`."
 msgstr "如果 `PassengerDeletion.Rate.SizeMultiply` 设为 true 则此时间间隔将乘算乘客的 `Size`。"
 
-#: ../../New-or-Enhanced-Logics.md:1191
+#: ../../New-or-Enhanced-Logics.md:1212
 msgid ""
 "`PassengerDeletion.UseCostAsRate`, if set to true, changes the time "
 "interval for erasing a passenger to be based on the passenger's `Cost`. "
@@ -4800,25 +4869,25 @@ msgstr ""
 "如果 `PassengerDeletion.UseCostAsRate` 设为 true 则删除乘客的间隔将基于乘客的 `Cost` "
 "计算。这不考虑 `FactoryPlant` 等修正。"
 
-#: ../../New-or-Enhanced-Logics.md:1192
+#: ../../New-or-Enhanced-Logics.md:1213
 msgid ""
 "`PassengerDeletion.CostMultiplier` can be used to modify the cost-based "
 "time interval."
 msgstr "`PassengerDeletion.CostMultiplier` 可用于设置基于成本的时间间隔倍率。"
 
-#: ../../New-or-Enhanced-Logics.md:1193
+#: ../../New-or-Enhanced-Logics.md:1214
 msgid ""
 "`PassengerDeletion.CostRateCap` can be used to set a cap to the cost-"
 "based time interval."
 msgstr "`PassengerDeletion.CostRateCap` 可用于设置基于成本计算的时间间隔上限。"
 
-#: ../../New-or-Enhanced-Logics.md:1194
+#: ../../New-or-Enhanced-Logics.md:1215
 msgid ""
 "`PassengerDeletion.AllowedHouses` determines which houses passengers can "
 "belong to be eligible for deletion."
 msgstr "`PassengerDeletion.AllowedHouses` 决定了哪些所属方的乘客会被删除。"
 
-#: ../../New-or-Enhanced-Logics.md:1195
+#: ../../New-or-Enhanced-Logics.md:1216
 msgid ""
 "`PassengerDeletion.DontScore`, if set to true, makes it so that the "
 "deleted passengers are not counted as having been killed by the transport"
@@ -4827,7 +4896,7 @@ msgstr ""
 "如果 `PassengerDeletion.DontScore` 设为 true "
 "则删除的乘客不会被视为被运输工具击杀（没有经验，不会计入所属方击杀数等）。"
 
-#: ../../New-or-Enhanced-Logics.md:1196
+#: ../../New-or-Enhanced-Logics.md:1217
 msgid ""
 "If `PassengerDeletion.Soylent` is set to true, an amount of credits is "
 "refunded to the owner of the transport. The exact amount refunded is "
@@ -4837,19 +4906,19 @@ msgstr ""
 "如果 `PassengerDeletion.Soylent` 设为 true 则会向运输工具的所有者返还一定数量的资金。具体金额由乘客的 "
 "`Soylent` 决定，若为设置则由 `Cost` 决定（这里可受到 `FactoryPlant` 等修正的影响）。"
 
-#: ../../New-or-Enhanced-Logics.md:1197
+#: ../../New-or-Enhanced-Logics.md:1218
 msgid ""
 "`PassengerDeletion.SoylentMultiplier` is a direct multiplier applied to "
 "the refunded amount of credits."
 msgstr "`PassengerDeletion.SoylentMultiplier` 是直接应用于返还资金的倍率。"
 
-#: ../../New-or-Enhanced-Logics.md:1198
+#: ../../New-or-Enhanced-Logics.md:1219
 msgid ""
 "`PassengerDeletion.SoylentAllowedHouses` determines which houses "
 "passengers can belong to be eligible for refunding."
 msgstr "`PassengerDeletion.SoylentAllowedHouses` 决定了哪些所属方的乘客会造成资金返还。"
 
-#: ../../New-or-Enhanced-Logics.md:1199
+#: ../../New-or-Enhanced-Logics.md:1220
 msgid ""
 "`PassengerDeletion.DisplaySoylent` can be set to true to display the "
 "amount of credits refunded on the transport. "
@@ -4861,7 +4930,7 @@ msgstr ""
 "以在运输工具上显示返还的资金金额。`PassengerDeletion.DisplaySoylentToHouses` "
 "决定了哪些所属方可以看到此消息，`PassengerDeletion.DisplaySoylentOffset` 可用于调整显示坐标偏移。"
 
-#: ../../New-or-Enhanced-Logics.md:1200
+#: ../../New-or-Enhanced-Logics.md:1221
 msgid ""
 "`PassengerDeletion.ReportSound` and `PassengerDeletion.Anim` can be used "
 "to specify a sound and animation to play when a passenger is erased, "
@@ -4870,13 +4939,13 @@ msgstr ""
 "`PassengerDeletion.ReportSound` 和 `PassengerDeletion.Anim` "
 "可用于分别指定在删除乘客时播放的声音和动画。"
 
-#: ../../New-or-Enhanced-Logics.md:1201
+#: ../../New-or-Enhanced-Logics.md:1222
 msgid ""
 "If `PassengerDeletion.UnderEMP` is set to true, the deletion will be "
 "processed when the transport is under EMP or deactivated."
 msgstr "如果 `PassengerDeletion.UnderEMP` 设为 true 则在运输工具受 EMP 影响或瘫痪时继续执行删除操作。"
 
-#: ../../New-or-Enhanced-Logics.md:1204
+#: ../../New-or-Enhanced-Logics.md:1225
 msgid ""
 "[SOMETECHNO]                                    ; TechnoType\n"
 "PassengerDeletion.Rate=0                        ; integer, game frames\n"
@@ -4926,11 +4995,11 @@ msgstr ""
 "PassengerDeletion.Anim=                         ; AnimationType\n"
 "PassengerDeletion.UnderEMP=false                ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1224
+#: ../../New-or-Enhanced-Logics.md:1245
 msgid "Automatic passenger owner change to match transport owner"
 msgstr "自动同步载员所属方"
 
-#: ../../New-or-Enhanced-Logics.md:1226
+#: ../../New-or-Enhanced-Logics.md:1247
 msgid ""
 "Transports with `Passengers.SyncOwner` set to true will have the owner of"
 " their passengers changed to match the transport if transport's owner "
@@ -4939,14 +5008,14 @@ msgstr ""
 "如果运输工具的 `Passengers.SyncOwner` 设为 true "
 "则当运输工具的所有者发生改变那么其载员的所有者也将会更改以与运输工具同步。"
 
-#: ../../New-or-Enhanced-Logics.md:1227
+#: ../../New-or-Enhanced-Logics.md:1248
 msgid ""
 "On `OpenTopped=true` transports this will also disable checks that "
 "prevent target acquisition by passengers when the transport is "
 "temporarily mind controlled."
 msgstr "对于 `OpenTopped=true` 的运输工具这还将禁用在运输工具暂时被心灵控制时阻止载员对目标进行攻击的检查。"
 
-#: ../../New-or-Enhanced-Logics.md:1228
+#: ../../New-or-Enhanced-Logics.md:1249
 msgid ""
 "`Passengers.SyncOwner.RevertOnExit`, if set to true (which is the "
 "default), changes the passengers' owner back to whatever it was "
@@ -4955,13 +5024,13 @@ msgstr ""
 "如果 `Passengers.SyncOwner.RevertOnExit` 设为 "
 "true（默认行为），当载员被弹出时，其所属方将恢复为载员进入时所属方。"
 
-#: ../../New-or-Enhanced-Logics.md:1229
+#: ../../New-or-Enhanced-Logics.md:1250
 msgid ""
 "Does not work on passengers acquired through use of `Abductor=true` "
 "weapon *(Ares feature)*."
 msgstr "不适用于通过 `Abductor=true` 武器（*Ares 功能*）获取的载员。"
 
-#: ../../New-or-Enhanced-Logics.md:1232
+#: ../../New-or-Enhanced-Logics.md:1253
 msgid ""
 "[SOMETECHNO]                            ; TechnoType\n"
 "Passengers.SyncOwner=false              ; boolean\n"
@@ -4971,11 +5040,11 @@ msgstr ""
 "Passengers.SyncOwner=false              ; boolean\n"
 "Passengers.SyncOwner.RevertOnExit=true  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1238
+#: ../../New-or-Enhanced-Logics.md:1259
 msgid "Automatically firing weapons"
 msgstr "自动发射武器"
 
-#: ../../New-or-Enhanced-Logics.md:1240
+#: ../../New-or-Enhanced-Logics.md:1261
 msgid ""
 "You can now make TechnoType automatically fire its weapon(s) without "
 "having to scan for suitable targets by setting `AutoFire`, on either its "
@@ -4987,7 +5056,7 @@ msgstr ""
 "现在你可以设置 `AutoFire` 使科技类型根据 `AutoFire.TargetSelf` "
 "选择当前单元格或开火者自身自动发射其武器而无需检索一个合适的目标。"
 
-#: ../../New-or-Enhanced-Logics.md:1243
+#: ../../New-or-Enhanced-Logics.md:1264
 msgid ""
 "[SOMETECHNO]               ; TechnoType\n"
 "AutoFire=false             ; boolean\n"
@@ -4997,15 +5066,15 @@ msgstr ""
 "AutoFire=false             ; boolean\n"
 "AutoFire.TargetSelf=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1249
+#: ../../New-or-Enhanced-Logics.md:1270
 msgid "Build limit group"
 msgstr "建造限制组"
 
-#: ../../New-or-Enhanced-Logics.md:1251
+#: ../../New-or-Enhanced-Logics.md:1272
 msgid "You can now make different technos share build limit in a group."
 msgstr "现在你可以使不同的科技类型在一个组内共享建造限制。"
 
-#: ../../New-or-Enhanced-Logics.md:1252
+#: ../../New-or-Enhanced-Logics.md:1273
 msgid ""
 "`BuildLimitGroup.Types` determines the technos that'll be used for build "
 "limit conditions of the selected techno. Note that the limit won't be "
@@ -5015,7 +5084,7 @@ msgstr ""
 "`BuildLimitGroup.Types` "
 "决定了将用于所选科技类型建造条件的其他科技类型。注意该语句并不提供任何限制效果。要实现这点你需要手动位每个科技类型设置建造限制。"
 
-#: ../../New-or-Enhanced-Logics.md:1253
+#: ../../New-or-Enhanced-Logics.md:1274
 msgid ""
 "`BuildLimitGroup.Nums` determines the amount of technos that would reach "
 "the build limit. If using a single integer, it'll use the sum of all "
@@ -5028,7 +5097,7 @@ msgstr ""
 " `BuildLimitGroup.Types` 数量相同的整数列表，则会为每个科技类型计算建造限制，其值的位置与 "
 "`BuildLimitGroup.Types` 中的位置对应。"
 
-#: ../../New-or-Enhanced-Logics.md:1254
+#: ../../New-or-Enhanced-Logics.md:1275
 msgid ""
 "`BuildLimitGroup.Factor` determines each of this techno instance will "
 "count as what value when calculating build limit."
@@ -5036,13 +5105,13 @@ msgstr ""
 "`BuildLimitGroup.Factor` 决定了每个此类科技类型在计算建造限制时将被视为多少来进行计算（类似一个用于 "
 "`BuildLimit` 的 `Size`）。"
 
-#: ../../New-or-Enhanced-Logics.md:1255
+#: ../../New-or-Enhanced-Logics.md:1276
 msgid ""
 "This is only used by BuildLimitGroup. No other place will use it when "
 "counting owned objects, including `BuildLimitGroup.ExtraLimit`."
 msgstr "这仅由 BuildLimitGroup 使用。其他地方不会使用它来计算，包括 `BuildLimitGroup.ExtraLimit`。"
 
-#: ../../New-or-Enhanced-Logics.md:1256
+#: ../../New-or-Enhanced-Logics.md:1277
 msgid ""
 "`BuildLimitGroup.ContentIfAnyMatch` determines the rule of calculating "
 "build limit per techno. If set to true, build limit will be content if "
@@ -5054,7 +5123,7 @@ msgstr ""
 "true，则当组内任意科技类型的数量达到其 `BuildLimitGroup.Nums` 值时视为全组达到建造限制。如果设置为 "
 "false，则只有当组内所有科技类型的数量达到时建造限制才有效。"
 
-#: ../../New-or-Enhanced-Logics.md:1257
+#: ../../New-or-Enhanced-Logics.md:1278
 msgid ""
 "`BuildLimitGroup.NotBuildableIfQueueMatch` determines the moment to stop "
 "the techno's production. If set to true, its production will be stopped "
@@ -5065,19 +5134,19 @@ msgstr ""
 "`BuildLimitGroup.NotBuildableIfQueueMatch` 决定了禁用科技类型生产的时刻，如果设为 true "
 "则已存在的科技类型与处于生产序列中的科技类型只和满足条件就会停止生产。如果设为 false 则只有地图上实际存在的科技类型满足条件才会停止生产。"
 
-#: ../../New-or-Enhanced-Logics.md:1258
+#: ../../New-or-Enhanced-Logics.md:1279
 msgid ""
 "You can also add an extra value into `BuildLimitGroup.Nums`, determined "
 "by the amount of specific technos owned by its house."
 msgstr "你还可以根据其所属方拥有的特定科技类型数量向 `BuildLimitGroup.Nums` 添加一个额外调整值。"
 
-#: ../../New-or-Enhanced-Logics.md:1259
+#: ../../New-or-Enhanced-Logics.md:1280
 msgid ""
 "`BuildLimitGroup.ExtraLimit.Types` determines the technos that'll be used"
 " for extra value calculation."
 msgstr "`BuildLimitGroup.ExtraLimit.Types` 决定了将用于额外值计算的科技类型。"
 
-#: ../../New-or-Enhanced-Logics.md:1260
+#: ../../New-or-Enhanced-Logics.md:1281
 msgid ""
 "`BuildLimitGroup.ExtraLimit.Nums` determines the actual value of "
 "increment. Value matching the position in "
@@ -5089,7 +5158,7 @@ msgstr ""
 "`BuildLimitGroup.ExtraLimit.Types` "
 "中对应位置的科技类型一一对应。每个列表中的科技类型会使建造限制增加其场上存在的数量 * 该列表中对应值。"
 
-#: ../../New-or-Enhanced-Logics.md:1261
+#: ../../New-or-Enhanced-Logics.md:1282
 msgid ""
 "`BuildLimitGroup.ExtraLimit.MaxCount` determines the maximum amount of "
 "technos being counted into the extra value calculation. Value matching "
@@ -5101,7 +5170,7 @@ msgstr ""
 "`BuildLimitGroup.ExtraLimit.Types` 中对应位置的科技类型一一对应。如果未设置或设为小于 1 "
 "的值，则视为无最大数量限制。"
 
-#: ../../New-or-Enhanced-Logics.md:1262
+#: ../../New-or-Enhanced-Logics.md:1283
 msgid ""
 "`BuildLimitGroup.ExtraLimit.MaxNum` determines the maximum of values in "
 "`BuildLimitGroup.Nums` after extra limit calculation. If not set or set "
@@ -5110,7 +5179,7 @@ msgstr ""
 "`BuildLimitGroup.ExtraLimit.MaxNum` 决定了在计算额外值后 `BuildLimitGroup.Nums` "
 "的最大值。如果未设置或设为小于 1 的值，则视为无最大值。"
 
-#: ../../New-or-Enhanced-Logics.md:1265
+#: ../../New-or-Enhanced-Logics.md:1286
 msgid ""
 "[SOMETECHNO]                                    ; TechnoType\n"
 "BuildLimitGroup.Types=                          ; List of TechnoTypes\n"
@@ -5136,17 +5205,17 @@ msgstr ""
 "BuildLimitGroup.ExtraLimit.MaxCount=            ; List of integers\n"
 "BuildLimitGroup.ExtraLimit.MaxNum=0             ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1278
+#: ../../New-or-Enhanced-Logics.md:1299
 msgid "Convert TechnoType on owner house change"
 msgstr "根据操作者变形"
 
-#: ../../New-or-Enhanced-Logics.md:1280
+#: ../../New-or-Enhanced-Logics.md:1301
 msgid ""
 "You can now change a unit's type when changing ownership from human to "
 "computer or from computer to human."
 msgstr "现在你可以在操作者从人类改为 AI 玩家或从 AI 玩家改为人类玩家时执行单位转换。"
 
-#: ../../New-or-Enhanced-Logics.md:1283
+#: ../../New-or-Enhanced-Logics.md:1304
 msgid ""
 "[SOMETECHNO]                ; TechnoType\n"
 "Convert.HumanToComputer=    ; TechnoType\n"
@@ -5156,11 +5225,11 @@ msgstr ""
 "Convert.HumanToComputer=    ; TechnoType\n"
 "Convert.ComputerToHuman=    ; TechnoType\n"
 
-#: ../../New-or-Enhanced-Logics.md:1289
+#: ../../New-or-Enhanced-Logics.md:1310
 msgid "Custom tint on TechnoTypes"
 msgstr "染色"
 
-#: ../../New-or-Enhanced-Logics.md:1291
+#: ../../New-or-Enhanced-Logics.md:1312
 msgid ""
 "A tint effect similar to that used by Iron Curtain / Force Shield or "
 "`Psychedelic=true` Warheads can be applied to TechnoTypes naturally by "
@@ -5169,13 +5238,13 @@ msgstr ""
 "通过设置 `Tint.Color` 和／或 `Tint Intensity` 可以为拥有护盾的科技类型使用类似于铁幕／力场护盾或 "
 "`Psychedelic=true` 弹头的染色效果。"
 
-#: ../../New-or-Enhanced-Logics.md:1294
+#: ../../New-or-Enhanced-Logics.md:1315
 msgid ""
 "Tint effects can also be applied by [attached effects](#attached-effects)"
 " and on [shields](#shields)."
 msgstr "染色效果也可以通过 [Attach Effect](#attached-effects) 和[护盾](#shields)应用。"
 
-#: ../../New-or-Enhanced-Logics.md:1297
+#: ../../New-or-Enhanced-Logics.md:1318
 msgid ""
 "[SOMETECHNO]              ; TechnoType\n"
 "Tint.Color=               ; integer - R,G,B\n"
@@ -5189,17 +5258,17 @@ msgstr ""
 "Tint.VisibleToHouses=all  ; List of Affected House Enumeration "
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1304
+#: ../../New-or-Enhanced-Logics.md:1325
 msgid "Customizable OpenTopped properties"
 msgstr "自定义 `OpenTopped` 属性"
 
-#: ../../New-or-Enhanced-Logics.md:1306
+#: ../../New-or-Enhanced-Logics.md:1327
 msgid ""
 "You can now override global `OpenTopped` transport properties per "
 "TechnoType."
 msgstr "现在你可以为每个科技类型微观设定全局 `OpenTopped` 运输工具的属性。"
 
-#: ../../New-or-Enhanced-Logics.md:1307
+#: ../../New-or-Enhanced-Logics.md:1328
 msgid ""
 "`OpenTopped.IgnoreRangefinding` can be used to disable `OpenTopped` "
 "transport rangefinding behaviour where smallest weapon range between "
@@ -5209,7 +5278,7 @@ msgstr ""
 "`OpenTopped.IgnoreRangefinding` 可用于禁用 `OpenTopped` "
 "运输工具在接近超出射程的目标和扫描潜在目标时使用运输工具与所有载员之间的 `Range` 最小武器的射程这一测距行为。"
 
-#: ../../New-or-Enhanced-Logics.md:1308
+#: ../../New-or-Enhanced-Logics.md:1329
 msgid ""
 "`OpenTopped.AllowFiringIfDeactivated` can be used to customize whether or"
 " not passengers can fire out when the transport is deactivated (EMP, "
@@ -5218,13 +5287,13 @@ msgstr ""
 "`OpenTopped.AllowFiringIfDeactivated` 可用于自定义当运输工具被瘫痪（EMP、`PoweredUnit` "
 "等）时载员是否可以开火。"
 
-#: ../../New-or-Enhanced-Logics.md:1309
+#: ../../New-or-Enhanced-Logics.md:1330
 msgid ""
 "`OpenTopped.ShareTransportTarget` controls whether or not the current "
 "target of the transport itself is passed to the passengers as well."
 msgstr "`OpenTopped.ShareTransportTarget` 控制运输工具的当前目标是否传递给乘客。"
 
-#: ../../New-or-Enhanced-Logics.md:1311
+#: ../../New-or-Enhanced-Logics.md:1332
 msgid ""
 "[SOMETECHNO]                              ; TechnoType\n"
 "OpenTopped.RangeBonus=                    ; integer, override of the "
@@ -5248,30 +5317,30 @@ msgstr ""
 "OpenTopped.AllowFiringIfDeactivated=true  ; boolean\n"
 "OpenTopped.ShareTransportTarget=true      ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1321
+#: ../../New-or-Enhanced-Logics.md:1342
 msgid "Customizable spawns queue"
 msgstr "自定义子机序列"
 
-#: ../../New-or-Enhanced-Logics.md:1322
+#: ../../New-or-Enhanced-Logics.md:1343
 msgid ""
 "It is now possible to spawn multiple types of spawnees from a spawner "
 "with `Spawns.Queue`. The order of spawnees in this queue is the order of "
 "their respawn."
 msgstr "现在可以通过 `Spawns.Queue` 从子机发射器生成多种子机。该序列中的子机顺序即为其重新生成顺序。"
 
-#: ../../New-or-Enhanced-Logics.md:1323
+#: ../../New-or-Enhanced-Logics.md:1344
 msgid ""
 "`Spawns` still needs to be set to enable the spawner logic and act as a "
 "default spawnee."
 msgstr "仍需设置 `Spawns` 以启用子机逻辑并作为默认子机。"
 
-#: ../../New-or-Enhanced-Logics.md:1324
+#: ../../New-or-Enhanced-Logics.md:1345
 msgid ""
 "`SpawnsNumber` still needs to be set to determine the amount of spawnee "
 "slots."
 msgstr "仍需设置 `SpawnsNumber` 以决定子机数量。"
 
-#: ../../New-or-Enhanced-Logics.md:1325
+#: ../../New-or-Enhanced-Logics.md:1346
 msgid ""
 "If the length of the queue is longer than the spawner's `SpawnsNumber`, "
 "spawnee after this length will be omitted. If the length is shorter "
@@ -5281,7 +5350,7 @@ msgstr ""
 "如果队列长度超过子机发射器的 `SpawnsNumber`，超出部分的子机将被忽略。如果队列长度过短则剩余部分由 `Spawns` "
 "定义的子机填补。因此建议将它们设为等长。"
 
-#: ../../New-or-Enhanced-Logics.md:1328
+#: ../../New-or-Enhanced-Logics.md:1349
 msgid ""
 "[SOMETECHNO]        ; TechnoType\n"
 "Spawns.Queue=       ; List of AircraftTypes, in order\n"
@@ -5289,24 +5358,24 @@ msgstr ""
 "[SOMETECHNO]        ; TechnoType\n"
 "Spawns.Queue=       ; List of AircraftTypes, in order\n"
 
-#: ../../New-or-Enhanced-Logics.md:1334
+#: ../../New-or-Enhanced-Logics.md:1355
 msgid ""
 "Note that all spawnees in a queue should have `MissileSpawn` set to the "
 "same value (all to true or false). Mixing them will make missile spawnees"
 " can't hit their targets."
 msgstr "注意队列中的所有子机应当拥有相同的 `MissileSpawn` 值（均为 true 或均为 false）。混合使用会导致导弹类子机无法命中目标。"
 
-#: ../../New-or-Enhanced-Logics.md:1337
+#: ../../New-or-Enhanced-Logics.md:1358
 msgid "Customize EVA voice and `SellSound` when selling units"
 msgstr "单位出售音效"
 
-#: ../../New-or-Enhanced-Logics.md:1339
+#: ../../New-or-Enhanced-Logics.md:1360
 msgid ""
 "When a building or a unit is sold, a sell sound as well as an EVA is "
 "played to the owner. These configurations have been deglobalized."
 msgstr "当建筑或单位被出售时将向所有者播放出售音效和 EVA 语音。这些设置以允许微观定义。"
 
-#: ../../New-or-Enhanced-Logics.md:1340
+#: ../../New-or-Enhanced-Logics.md:1361
 msgid ""
 "`EVA.Sold` is used to customize the EVA voice when selling, default to "
 "`EVA_StructureSold` for buildings and `EVA_UnitSold` for vehicles."
@@ -5314,7 +5383,7 @@ msgstr ""
 "`EVA.Sold` 用于自定义出售时的 EVA 语音，建筑默认为 `EVA_StructureSold` 载具默认为 "
 "`EVA_UnitSold`。"
 
-#: ../../New-or-Enhanced-Logics.md:1341
+#: ../../New-or-Enhanced-Logics.md:1362
 msgid ""
 "`SellSound` is used to customize the report sound when selling, default "
 "to `[AudioVisual] -> SellSound`. Note that vanilla game played vehicles' "
@@ -5324,7 +5393,7 @@ msgstr ""
 "`SellSound` 用于自定义出售时的音效，默认为 `[AudioVisual] -> SellSound`。请注意，原版游戏中出售载具的 "
 "`SellSound` 是全局的。这已改为与建筑出售的 `SellSound` 保持一致。"
 
-#: ../../New-or-Enhanced-Logics.md:1344
+#: ../../New-or-Enhanced-Logics.md:1365
 msgid ""
 "[SOMETECHNO]    ; BuildingType or VehicleType\n"
 "EVA.Sold=       ; EVA entry\n"
@@ -5334,11 +5403,11 @@ msgstr ""
 "EVA.Sold=       ; EVA entry\n"
 "SellSound=      ; Sound entry\n"
 
-#: ../../New-or-Enhanced-Logics.md:1350
+#: ../../New-or-Enhanced-Logics.md:1371
 msgid "Disabling fallback to (Elite)Secondary weapon"
 msgstr "禁用副武器自动推算"
 
-#: ../../New-or-Enhanced-Logics.md:1352
+#: ../../New-or-Enhanced-Logics.md:1373
 msgid ""
 "It is now possible to disable the fallback to `(Elite)Secondary` weapon "
 "from `(Elite)Primary` weapon if it cannot fire at the chosen target by "
@@ -5354,35 +5423,35 @@ msgstr ""
 "武器。`NoSecondaryWeaponFallback.AllowAA` 控制对抛射体拥有 `AA` 且应对空中目标的情况。这不适用于总是选择"
 " `(Elite)Secondary` 武器的特殊情况，包括但不限于以下几种："
 
-#: ../../New-or-Enhanced-Logics.md:1353
+#: ../../New-or-Enhanced-Logics.md:1374
 msgid ""
 "`OpenTransportWeapon=1` on an unit firing from inside `OpenTopped=true` "
 "transport."
 msgstr "`OpenTransportWeapon=1` 的单位在一个 `OpenTopped=true` 的运输工具内开火。"
 
-#: ../../New-or-Enhanced-Logics.md:1354
+#: ../../New-or-Enhanced-Logics.md:1375
 msgid ""
 "`NoAmmoWeapon=1` on an unit with `Ammo` value higher than 0 and current "
 "ammo count lower or  equal to `NoAmmoAmount`."
 msgstr "`NoAmmoWeapon=1` 的单位在 `Ammo` 大于 0 且当前弹药数量小于等于 `NoAmmoAmount`。"
 
-#: ../../New-or-Enhanced-Logics.md:1355
+#: ../../New-or-Enhanced-Logics.md:1376
 msgid ""
 "Deployed `IsSimpleDeployer=true` units with `DeployFireWeapon=1` set or "
 "omitted."
 msgstr "拥有 `DeployFireWeapon=1` 的 `IsSimpleDeployer=true` 单位处于部署状态。"
 
-#: ../../New-or-Enhanced-Logics.md:1356
+#: ../../New-or-Enhanced-Logics.md:1377
 msgid "`DrainWeapon=true` weapons against enemy `Drainable=yes` buildings."
 msgstr "`DrainWeapon=true` 的武器应对敌方 `Drainable=yes` 的建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:1357
+#: ../../New-or-Enhanced-Logics.md:1378
 msgid ""
 "Units with `IsLocomotor=true` set on `Warhead` of `(Elite)Primary` weapon"
 " against buildings."
 msgstr "单位使用一个 `Warhead` 拥有 `IsLocomotor=true` 设置的 `(Elite)Primary` 应对建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:1358
+#: ../../New-or-Enhanced-Logics.md:1379
 msgid ""
 "Weapons with `ElectricAssault=true` set on `Warhead` against "
 "`Overpowerable=true` buildings belonging to owner or allies."
@@ -5390,17 +5459,17 @@ msgstr ""
 "对所有者或盟友的 `Overpowerable=true` 建筑使用 `Warhead` 拥有 `ElectricAssault=true` "
 "设置的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1359
+#: ../../New-or-Enhanced-Logics.md:1380
 msgid "`Overpowerable=true` buildings that are currently overpowered."
 msgstr "`Overpowerable=true` 的建筑当前处于过载状态。"
 
-#: ../../New-or-Enhanced-Logics.md:1360
+#: ../../New-or-Enhanced-Logics.md:1381
 msgid ""
 "Any system using `(Elite)WeaponX`, f.ex `Gunner=true` or "
 "`IsGattling=true` is also wholly exempt."
 msgstr "任何使用 `(Elite)WeaponX` 的系统也完全不受影响，例如 `Gunner=true` 或 `IsGattling=true`。"
 
-#: ../../New-or-Enhanced-Logics.md:1363
+#: ../../New-or-Enhanced-Logics.md:1384
 msgid ""
 "[SOMETECHNO]                             ; TechnoType\n"
 "NoSecondaryWeaponFallback=false          ; boolean\n"
@@ -5410,13 +5479,13 @@ msgstr ""
 "NoSecondaryWeaponFallback=false          ; boolean\n"
 "NoSecondaryWeaponFallback.AllowAA=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1369
+#: ../../New-or-Enhanced-Logics.md:1390
 msgid ""
 "Disguise logic additions (disguise-based movement speed, disguise "
 "blinking visibility)"
 msgstr "伪装逻辑增强"
 
-#: ../../New-or-Enhanced-Logics.md:1371
+#: ../../New-or-Enhanced-Logics.md:1392
 msgid ""
 "`DisguiseBlinkingVisibility` can be used to customize which players can "
 "see disguises blinking on units. This does not affect targeting but does "
@@ -5426,7 +5495,7 @@ msgstr ""
 "`DisguiseBlinkingVisibility` "
 "可用于自定义哪些玩家可以看到单位的伪装闪烁。这不影响目标选择，但会影响军衔的可见性——闪烁的伪装意味着始终可见原单位的军衔而不是伪装单位的。"
 
-#: ../../New-or-Enhanced-Logics.md:1372
+#: ../../New-or-Enhanced-Logics.md:1393
 msgid ""
 "Another thing to note is that in singleplayer missions, for purposes of "
 "the disguise blinking, disguised objects owned by any player-controlled "
@@ -5438,7 +5507,7 @@ msgstr ""
 "另一个需要注意的是在单人任务中，就伪装闪烁而言，任何玩家所控制的所属方所拥有的伪装单位即使与玩家所属方不是盟友视为当前玩家所有，这意味着玩家始终可以看到它们的伪装闪烁，除非"
 " `DisguiseBlinkingVisibility` 设置为 `none` 或 `enemies`。"
 
-#: ../../New-or-Enhanced-Logics.md:1373
+#: ../../New-or-Enhanced-Logics.md:1394
 msgid ""
 "`UseDisguiseMovementSpeed`, if set, makes disguised unit adjust its "
 "movement speed to match that of the disguise, if applicable. Note that "
@@ -5448,7 +5517,7 @@ msgstr ""
 "`UseDisguiseMovementSpeed` "
 "如果设置则在可行的情况下伪装单位将调整其移动速度以匹配伪装目标的速度。注意即使伪装被识破只要未被解除此设置就依旧生效。"
 
-#: ../../New-or-Enhanced-Logics.md:1376
+#: ../../New-or-Enhanced-Logics.md:1397
 msgid ""
 "[General]\n"
 "DisguiseBlinkingVisibility=owner  ; List of Affected House Enumeration "
@@ -5464,27 +5533,27 @@ msgstr ""
 "[SOMETECHNO]                      ; TechnoType\n"
 "UseDisguiseMovementSpeed=false    ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1384
+#: ../../New-or-Enhanced-Logics.md:1405
 msgid "Extended gattling rate down logic"
 msgstr "拓展的盖特掉档逻辑"
 
-#: ../../New-or-Enhanced-Logics.md:1386
+#: ../../New-or-Enhanced-Logics.md:1407
 msgid "Now you can customize some effects of `RateDown`."
 msgstr "现在你可以自定义 `RateDown` 的一些效果。"
 
-#: ../../New-or-Enhanced-Logics.md:1387
+#: ../../New-or-Enhanced-Logics.md:1408
 msgid ""
 "`RateDown.Delay` controls the delay before using `RateDown` to reduce the"
 " gattling value."
 msgstr "`RateDown.Delay` 控制使用 `RateDown` 减少盖特计时器的间隔。"
 
-#: ../../New-or-Enhanced-Logics.md:1388
+#: ../../New-or-Enhanced-Logics.md:1409
 msgid ""
 "`RateDown.Reset` controls whether to reset the gattling value directly "
 "when the techno has no target or changes targets."
 msgstr "`RateDown.Reset` 控制当科技类型失去目标或更换目标时是否立即清空盖特计时器。"
 
-#: ../../New-or-Enhanced-Logics.md:1389
+#: ../../New-or-Enhanced-Logics.md:1410
 msgid ""
 "`RateDown.Cover.Value` replaces the original `RateDown` when techno's "
 "ammo is lower than `RateDown.Cover.AmmoBelow`."
@@ -5492,7 +5561,7 @@ msgstr ""
 "`RateDown.Cover.Value` 用于在科技类型的弹药低于 `RateDown.Cover.AmmoBelow` 时替代 "
 "`RateDown` 使用。"
 
-#: ../../New-or-Enhanced-Logics.md:1392
+#: ../../New-or-Enhanced-Logics.md:1413
 msgid ""
 "[SOMETECHNO]                  ; TechnoType, with IsGattling=yes\n"
 "RateDown.Delay=0              ; integer, game frames\n"
@@ -5506,11 +5575,11 @@ msgstr ""
 "RateDown.Cover.Value=0        ; integer\n"
 "RateDown.Cover.AmmoBelow=-2   ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1400
+#: ../../New-or-Enhanced-Logics.md:1421
 msgid "Firing offsets for specific Burst shots"
 msgstr "Burst 开火坐标"
 
-#: ../../New-or-Enhanced-Logics.md:1402
+#: ../../New-or-Enhanced-Logics.md:1423
 msgid ""
 "You can now specify separate firing offsets for each of the shots fired "
 "by weapon with `Burst` via using "
@@ -5528,14 +5597,14 @@ msgstr ""
 "开始的连发索引，这些值将按顺序解析，直到没有常规或精英武器的值为止，如果精英武器缺少值则默认使用常规武器的 "
 "FLH。如果特定连发索引缺少值，则使用基础标签（例如 `PrimaryFireFLH`）的值。"
 
-#: ../../New-or-Enhanced-Logics.md:1403
+#: ../../New-or-Enhanced-Logics.md:1424
 msgid ""
 "Burst-index specific firing offsets are absolute firing offsets and the "
 "lateral shifting based on burst index that occurs with the base firing "
 "offsets is not applied."
 msgstr "特定连发索引使用的是不会根据连发索引而将 L 值镜像的绝对坐标。"
 
-#: ../../New-or-Enhanced-Logics.md:1406
+#: ../../New-or-Enhanced-Logics.md:1427
 msgid ""
 "[SOMETECHNO]    ; TechnoType Image\n"
 "FLHKEY.BurstN=  ; integer - Forward,Lateral,Height. FLHKey refers to "
@@ -5545,11 +5614,11 @@ msgstr ""
 "FLHKEY.BurstN=  ; integer - Forward,Lateral,Height. FLHKey refers to "
 "weapon-specific FLH key name and N is zero-based burst shot index.\n"
 
-#: ../../New-or-Enhanced-Logics.md:1411
+#: ../../New-or-Enhanced-Logics.md:1432
 msgid "Forcing specific weapon against certain targets"
 msgstr "对特定目标使用特定武器"
 
-#: ../../New-or-Enhanced-Logics.md:1413
+#: ../../New-or-Enhanced-Logics.md:1434
 msgid ""
 "![image](_static/images/underwater-new-attack-tag.gif) *Naval underwater "
 "target behavior with `ForceWeapon.Naval.Decloaked` in [C&C: "
@@ -5559,7 +5628,7 @@ msgstr ""
 "Reloaded](https://www.moddb.com/mods/cncreloaded) 中使用 "
 "`ForceWeapon.Naval.Decloaked` 的海军对水下目标行为*"
 
-#: ../../New-or-Enhanced-Logics.md:1416
+#: ../../New-or-Enhanced-Logics.md:1437
 msgid ""
 "![image](_static/images/forceweapon_emp.gif) *Enemy behavior against EMP "
 "targets with `ForceWeapon.UnderEMP` in [C&C: "
@@ -5569,7 +5638,7 @@ msgstr ""
 "Reloaded](https://www.moddb.com/mods/cncreloaded) 中敌人使用 "
 "`ForceWeapon.UnderEMP` 攻击 EMP 状态目标的行为*"
 
-#: ../../New-or-Enhanced-Logics.md:1419
+#: ../../New-or-Enhanced-Logics.md:1440
 msgid ""
 "Can be used to override normal weapon selection logic to force specific "
 "weapons to use against certain targets. If multiple are set and target "
@@ -5577,7 +5646,7 @@ msgid ""
 "effect."
 msgstr "可用于覆盖正常的武器选择逻辑，以强制对特定目标使用特定武器。目标满足条件则按所列出规则的顺序使用第一个满足条件的规则。"
 
-#: ../../New-or-Enhanced-Logics.md:1420
+#: ../../New-or-Enhanced-Logics.md:1441
 msgid ""
 "`ForceWeapon.Naval.Decloaked` forces specified weapon to be used against "
 "uncloaked naval targets. Useful if your naval unit has one weapon only "
@@ -5586,25 +5655,25 @@ msgstr ""
 "`ForceWeapon.Naval.Decloaked` "
 "强制指定对未隐形（下潜）状态海军目标使用的武器。如果你的海军单位有一个武器仅用于水下目标另一个武器用于水面目标那么这个规则会很有用。"
 
-#: ../../New-or-Enhanced-Logics.md:1421
+#: ../../New-or-Enhanced-Logics.md:1442
 msgid ""
 "`ForceWeapon.Cloaked` forces specified weapon to be used against any "
 "cloaked targets."
 msgstr "`ForceWeapon.Cloaked` 强制对隐形（下潜）状态目标使用的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1422
+#: ../../New-or-Enhanced-Logics.md:1443
 msgid ""
 "`ForceWeapon.Disguised` forces specified weapon to be used against any "
 "disguised targets."
 msgstr "`ForceWeapon.Disguised` 强制针对伪装目标所使用的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1423
+#: ../../New-or-Enhanced-Logics.md:1444
 msgid ""
 "`ForceWeapon.UnderEMP` forces specified weapon to be used if the target "
 "is under EMP effect."
 msgstr "`ForceWeapon.UnderEMP` 强制指定对与被 EMP 瘫痪了的目标所使用的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1424
+#: ../../New-or-Enhanced-Logics.md:1445
 msgid ""
 "`ForceWeapon.InRange` forces specified a list of weapons to be used once "
 "the target is within their `Range`. If `ForceWeapon.InRange.TechnoOnly` "
@@ -5619,7 +5688,7 @@ msgstr ""
 "则仅在目标为单位时才能像其他强制武器效果那样生效，否则在攻击空地时也会生效。该单位会按列表顺序选取首个符合条件的武器。在未设置 "
 "`ForceAAWeapon.InRange` 的情况下这同时用于地面和空中目标。"
 
-#: ../../New-or-Enhanced-Logics.md:1425
+#: ../../New-or-Enhanced-Logics.md:1446
 msgid ""
 "`ForceAAWeapon.InRange` does the same thing but only for air target. "
 "Taking priority to `ForceWeapon.InRange`, which means that it can only be"
@@ -5628,7 +5697,7 @@ msgstr ""
 "`ForceAAWeapon.InRange` 是 `ForceWeapon.InRange` 的对空版本。当两个参数同时存在时 "
 "`ForceWeapon.InRange` 仅用于对地面目标。"
 
-#: ../../New-or-Enhanced-Logics.md:1426
+#: ../../New-or-Enhanced-Logics.md:1447
 msgid ""
 "`Force(AA)Weapon.InRange.Overrides` overrides the range when decides "
 "which weapon to use. Value from position matching the position from "
@@ -5639,7 +5708,7 @@ msgstr ""
 "`Force(AA)Weapon.InRange` 中的武器序号一一对应，如果一个武器的对应的值小于 0 或不存在那么使用武器自身的 "
 "`Range`。"
 
-#: ../../New-or-Enhanced-Logics.md:1427
+#: ../../New-or-Enhanced-Logics.md:1448
 msgid ""
 "If `Force(AA)Weapon.InRange.ApplyRangeModifiers` is set to true, any "
 "applicable weapon range modifiers from the firer are applied to the "
@@ -5648,7 +5717,7 @@ msgstr ""
 "如果 `Force(AA)Weapon.InRange.ApplyRangeModifiers` 设为 true "
 "则任何来自开火者的武器射程加成也将参与射程判定。"
 
-#: ../../New-or-Enhanced-Logics.md:1430
+#: ../../New-or-Enhanced-Logics.md:1451
 msgid ""
 "[SOMETECHNO]                                    ; TechnoType\n"
 "ForceWeapon.Naval.Decloaked=-1                  ; integer. 0 for primary "
@@ -5692,7 +5761,7 @@ msgstr ""
 "values\n"
 "ForceAAWeapon.InRange.ApplyRangeModifiers=false ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1446
+#: ../../New-or-Enhanced-Logics.md:1467
 msgid ""
 "Specifically, if a position has `Force(AA)Weapon.InRange` set to -1 and "
 "`Force(AA)Weapon.InRange.Overrides` set to a positive value, it'll use "
@@ -5701,18 +5770,18 @@ msgstr ""
 "特别说明，如果某个位置的 `Force(AA)Weapon.InRange` 设为 -1 而 "
 "`Force(AA)Weapon.InRange.Overrides` 为正值，那么在满足条件时使用默认的武器选取规则。"
 
-#: ../../New-or-Enhanced-Logics.md:1449
+#: ../../New-or-Enhanced-Logics.md:1470
 msgid "Initial spawns number"
 msgstr "初始子机数量"
 
-#: ../../New-or-Enhanced-Logics.md:1450
+#: ../../New-or-Enhanced-Logics.md:1471
 msgid ""
 "It is now possible to set the initial amount of spawnees for a spawner, "
 "instead of always being filled. Won't work if it's larger than "
 "`SpawnsNumber`."
 msgstr "现在可以设置子机发射器的初始子机数量，而不再总是初始满载。如果初始数量大于 `SpawnsNumber` 则无效。"
 
-#: ../../New-or-Enhanced-Logics.md:1453
+#: ../../New-or-Enhanced-Logics.md:1474
 msgid ""
 "[SOMETECHNO]              ; TechnoType\n"
 "InitialSpawnsNumber=      ; integer\n"
@@ -5720,11 +5789,11 @@ msgstr ""
 "[SOMETECHNO]              ; TechnoType\n"
 "InitialSpawnsNumber=      ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1458
+#: ../../New-or-Enhanced-Logics.md:1479
 msgid "Initial strength for TechnoTypes and cloned infantry"
 msgstr "科技类型与克隆步兵的初始血量"
 
-#: ../../New-or-Enhanced-Logics.md:1460
+#: ../../New-or-Enhanced-Logics.md:1481
 msgid ""
 "![image](_static/images/initialstrength.cloning-01.png) *Initial strength"
 " for cloned infantry example in [C&C: "
@@ -5733,13 +5802,13 @@ msgstr ""
 "![image](_static/images/initialstrength.cloning-01.png) *[C&C: "
 "Reloaded](https://www.moddb.com/mods/cncreloaded) 中克隆步兵的初始血量示例*"
 
-#: ../../New-or-Enhanced-Logics.md:1463
+#: ../../New-or-Enhanced-Logics.md:1484
 msgid ""
 "`InitialStrength` can be used to set how many hitpoints a TechnoType "
 "starts with."
 msgstr "`InitialStrength` 可用于设置科技类型的初始血量。"
 
-#: ../../New-or-Enhanced-Logics.md:1464
+#: ../../New-or-Enhanced-Logics.md:1485
 msgid ""
 "`InitialStrength.Cloning` can be used to specify a percentage of "
 "hitpoints (single value or a range from which a random value is picked) "
@@ -5748,7 +5817,7 @@ msgstr ""
 "`InitialStrength.Cloning` 可以用于指定克隆步兵由 `Cloning=true` "
 "建筑创建时的初始血量百分比（单个值或从其中随机选取的一对值）。"
 
-#: ../../New-or-Enhanced-Logics.md:1467
+#: ../../New-or-Enhanced-Logics.md:1488
 msgid ""
 "[SOMETECHNO]              ; TechnoType\n"
 "InitialStrength=          ; integer\n"
@@ -5764,7 +5833,7 @@ msgstr ""
 "InitialStrength.Cloning=  ; floating point value - single or comma-sep. "
 "range (percentages)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1476
+#: ../../New-or-Enhanced-Logics.md:1497
 msgid ""
 "Both `InitialStrength` and `InitialStrength.Cloning` never surpass the "
 "type's `Strength`, even if your values are bigger than it."
@@ -5772,67 +5841,67 @@ msgstr ""
 "`InitialStrength` 和 `InitialStrength.Cloning` 都不会超过单位的 "
 "`Strength`，即使你设置了一个比它更大的值。"
 
-#: ../../New-or-Enhanced-Logics.md:1479
+#: ../../New-or-Enhanced-Logics.md:1500
 msgid "Kill Object Automatically"
 msgstr "自毁"
 
-#: ../../New-or-Enhanced-Logics.md:1481
+#: ../../New-or-Enhanced-Logics.md:1502
 msgid ""
 "Objects can be destroyed automatically if *any* of these conditions is "
 "met:"
 msgstr "如果满足以下 **任何** 条件对象将会自毁："
 
-#: ../../New-or-Enhanced-Logics.md:1482
+#: ../../New-or-Enhanced-Logics.md:1503
 msgid "`OnAmmoDepletion`: The object will die if the remaining ammo reaches 0."
 msgstr "`OnAmmoDepletion`：如果剩余弹药达到 0 则对象死亡。"
 
-#: ../../New-or-Enhanced-Logics.md:1483
+#: ../../New-or-Enhanced-Logics.md:1504
 msgid "`AfterDelay`: The object will die if the countdown (in frames) reaches 0."
 msgstr "`AfterDelay`：如果倒计时（以帧为单位）达到 0 则对象死亡。"
 
-#: ../../New-or-Enhanced-Logics.md:1484
+#: ../../New-or-Enhanced-Logics.md:1505
 msgid ""
 "`TechnosExist` / `TechnosDontExist`: The object will die if TechnoTypes "
 "exist or do not exist, respectively."
 msgstr "`TechnosExist`／`TechnosDontExist`：如果科技类型分别存在或不存在则对象死亡。"
 
-#: ../../New-or-Enhanced-Logics.md:1485
+#: ../../New-or-Enhanced-Logics.md:1506
 msgid ""
 "`Technos(Dont)Exist.Any` controls whether or not a single listed "
 "TechnoType is enough to satisfy the requirement or if all are required."
 msgstr "`Technos(Dont)Exist.Any` 控制需要列出的单个科技类型还是所有科技类型来满足条件。"
 
-#: ../../New-or-Enhanced-Logics.md:1486
+#: ../../New-or-Enhanced-Logics.md:1507
 msgid ""
 "`Technos(Dont)Exist.AllowLimboed` controls whether or not limboed "
 "TechnoTypes (f.ex those in transports) are counted."
 msgstr "`Technos(Dont)Exist.AllowLimboed` 控制是否计入虚拟的科技类型（例如在运输工具中的那些）。"
 
-#: ../../New-or-Enhanced-Logics.md:1487
+#: ../../New-or-Enhanced-Logics.md:1508
 msgid "`Technos(Dont)Exist.Houses` controls which houses are checked."
 msgstr "`Technos(Dont)Exist.Houses` 控制检查哪些所属方。"
 
-#: ../../New-or-Enhanced-Logics.md:1489
+#: ../../New-or-Enhanced-Logics.md:1510
 msgid "The auto-death behavior can be chosen from the following:"
 msgstr "自毁行为有以下选择："
 
-#: ../../New-or-Enhanced-Logics.md:1490
+#: ../../New-or-Enhanced-Logics.md:1511
 msgid "`kill`: The object will be destroyed normally."
 msgstr "`kill`：对象将正常摧毁。"
 
-#: ../../New-or-Enhanced-Logics.md:1491
+#: ../../New-or-Enhanced-Logics.md:1512
 msgid ""
 "`vanish`: The object will be directly removed from the game peacefully "
 "instead of actually getting killed."
 msgstr "`vanish`：对象将被直接从游戏中静默移除而不是真正击杀。"
 
-#: ../../New-or-Enhanced-Logics.md:1492
+#: ../../New-or-Enhanced-Logics.md:1513
 msgid ""
 "`sell`: If the object is a **building** with buildup, it will be sold "
 "instead of destroyed."
 msgstr "`sell`：如果对象是拥有建造动画的 **建筑**，它将被出售而不是被摧毁。"
 
-#: ../../New-or-Enhanced-Logics.md:1494
+#: ../../New-or-Enhanced-Logics.md:1515
 msgid ""
 "If this option is not set, the self-destruction logic will not be "
 "enabled. `AutoDeath.VanishAnimation` can be set to animation to play at "
@@ -5841,14 +5910,14 @@ msgstr ""
 "如果未设置此项那么自毁逻辑将不会启用。如果选择 `vanish` 行为，那么可以使用 `AutoDeath.VanishAnimation` "
 "设置自毁时播放的动画。"
 
-#: ../../New-or-Enhanced-Logics.md:1497
+#: ../../New-or-Enhanced-Logics.md:1518
 msgid ""
 "Please notice that if the object is a unit which carries passengers, they"
 " will not be released even with the `kill` option **if you are not using "
 "Ares 3.0+**."
 msgstr "请注意 **如果你没有使用 Ares 3.0+** 那么对于携带载员的单位即使使用 `kill` 行为载员也不会被释放。"
 
-#: ../../New-or-Enhanced-Logics.md:1500
+#: ../../New-or-Enhanced-Logics.md:1521
 msgid ""
 "This logic also supports buildings delivered by "
 "[LimboDelivery](#limbodelivery). However in this case, all "
@@ -5858,7 +5927,7 @@ msgstr ""
 "此逻辑还支持通过 [虚拟投放](#limbodelivery) 提供的建筑。不过这种情况下所有 `AutoDeath.Behavior` "
 "值都将只是使建筑简单地移除。"
 
-#: ../../New-or-Enhanced-Logics.md:1503
+#: ../../New-or-Enhanced-Logics.md:1524
 msgid ""
 "[SOMETECHNO]                                   ; TechnoType\n"
 "AutoDeath.Behavior=                            ; enumeration (kill | "
@@ -5894,11 +5963,11 @@ msgstr ""
 "AutoDeath.TechnosExist.Houses=owner            ; Affected House "
 "Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1519
+#: ../../New-or-Enhanced-Logics.md:1540
 msgid "Mind Control enhancement"
 msgstr "心灵控制增强"
 
-#: ../../New-or-Enhanced-Logics.md:1521
+#: ../../New-or-Enhanced-Logics.md:1542
 msgid ""
 "![image](_static/images/mindcontrol-max-range-01.gif) *Mind Control Range"
 " Limit used in [Fantasy ADVENTURE](https://www.moddb.com/mods/fantasy-"
@@ -5911,26 +5980,26 @@ msgstr ""
 "![image](_static/images/mindcontrol-multiple-01.gif) "
 "*[幻想奇遇](https://www.moddb.com/mods/fantasy-adventure) 中的多重心控单位自动释放第一个受害者*"
 
-#: ../../New-or-Enhanced-Logics.md:1526
+#: ../../New-or-Enhanced-Logics.md:1547
 msgid ""
 "Mind controllers now can have the upper limit of the control distance. "
 "Tag values greater than 0 will activate this feature."
 msgstr "心灵控制者现在可以设置控制距离的上限。标签值大于 0 将激活此功能。"
 
-#: ../../New-or-Enhanced-Logics.md:1527
+#: ../../New-or-Enhanced-Logics.md:1548
 msgid ""
 "Mind controllers now can decide which house can see the link drawn "
 "between itself and the controlled units."
 msgstr "心灵控制者现在可以设置哪些所属方可以看到它与被心灵控制单位之间的连线。"
 
-#: ../../New-or-Enhanced-Logics.md:1528
+#: ../../New-or-Enhanced-Logics.md:1549
 msgid ""
 "Mind controllers with multiple controlling slots can now release the "
 "first controlled unit when they have reached the control limit and are "
 "ordered to control a new target."
 msgstr "多重心控单位现在可以达到控制上限而又要控制一个新目标时释放第一个被控制的单位。"
 
-#: ../../New-or-Enhanced-Logics.md:1531
+#: ../../New-or-Enhanced-Logics.md:1552
 msgid ""
 "[SOMETECHNO]                          ; TechnoType\n"
 "MindControlRangeLimit=-1.0            ; floating point value\n"
@@ -5944,23 +6013,23 @@ msgstr ""
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "MultiMindControl.ReleaseVictim=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1538
+#: ../../New-or-Enhanced-Logics.md:1559
 msgid "No Manual Move"
 msgstr "禁止手动移动"
 
-#: ../../New-or-Enhanced-Logics.md:1540
+#: ../../New-or-Enhanced-Logics.md:1561
 msgid ""
 "You can now specify whether a TechnoType is unable to receive move "
 "command."
 msgstr "现在你可以指定一个科技类型是否无法接收移动指令。"
 
-#: ../../New-or-Enhanced-Logics.md:1541
+#: ../../New-or-Enhanced-Logics.md:1562
 msgid ""
 "Set this to `true` on a building with `UndeploysInto` set could prevent "
 "it from undeploying when setting the rally point."
 msgstr "在一个拥有 `UndeploysInto` 的建筑上将此设为 true 可以阻止其在设置集结点时反部署。"
 
-#: ../../New-or-Enhanced-Logics.md:1544
+#: ../../New-or-Enhanced-Logics.md:1565
 msgid ""
 "[SOMETECHNO]        ; TechnoType\n"
 "NoManualMove=false  ; boolean\n"
@@ -5968,18 +6037,18 @@ msgstr ""
 "[SOMETECHNO]        ; TechnoType\n"
 "NoManualMove=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1550
+#: ../../New-or-Enhanced-Logics.md:1571
 msgid ""
 "Note that you can still undeploy the building by using a "
 "`BuildingUndeploy=true` warhead or by setting a rally point and selling "
 "it."
 msgstr "注意你仍可使用一个 `BuildingUndeploy=true` 的弹头或设置集结点后出售建筑来解除部署。"
 
-#: ../../New-or-Enhanced-Logics.md:1553
+#: ../../New-or-Enhanced-Logics.md:1574
 msgid "No rearm and reload in EMP or temporal"
 msgstr "EMP 或超时空停止 CD"
 
-#: ../../New-or-Enhanced-Logics.md:1555
+#: ../../New-or-Enhanced-Logics.md:1576
 msgid ""
 "Now you can make technos unable to rearm and reload when they are in EMP "
 "or locked by a temporal weapon. Defaults to values in `[General]`. This "
@@ -5988,7 +6057,7 @@ msgstr ""
 "现在你可以让科技类型在 EMP 或被超时空武器冻结时武器 ROF 与弹药 Reload 也同步停止。默认值取自 "
 "`[General]`。这对机场战机的重新装填无效。"
 
-#: ../../New-or-Enhanced-Logics.md:1558
+#: ../../New-or-Enhanced-Logics.md:1579
 msgid ""
 "[General]\n"
 "NoRearm.UnderEMP=false   ; boolean\n"
@@ -6014,17 +6083,17 @@ msgstr ""
 "NoReload.UnderEMP=       ; boolean\n"
 "NoReload.Temporal=       ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1572
+#: ../../New-or-Enhanced-Logics.md:1593
 msgid "Overload characteristic dehardcoded"
 msgstr "自定义脑车过载"
 
-#: ../../New-or-Enhanced-Logics.md:1574
+#: ../../New-or-Enhanced-Logics.md:1595
 msgid ""
 "It is now possible to customize `Overload` behaviors for a TechnoType "
 "with `InfiniteMindControl=yes` weapon."
 msgstr "现在可以为一个使用 `InfiniteMindControl=yes` 武器的单位自定义其过载相关特性。"
 
-#: ../../New-or-Enhanced-Logics.md:1577
+#: ../../New-or-Enhanced-Logics.md:1598
 msgid ""
 "\n"
 "[SOMETECHNO]                  ; TechnoType\n"
@@ -6054,11 +6123,11 @@ msgstr ""
 "[CombatDamage] -> DefaultSparkSystem\n"
 "Overload.ParticleSysCount=5   ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1588
+#: ../../New-or-Enhanced-Logics.md:1609
 msgid "Promoted Spawns"
 msgstr "子机升级"
 
-#: ../../New-or-Enhanced-Logics.md:1590
+#: ../../New-or-Enhanced-Logics.md:1611
 msgid ""
 "![image](_static/images/promotedspawns-01.gif) *Promoted Spawns in "
 "[Fantasy ADVENTURE](https://www.moddb.com/mods/fantasy-adventure)*"
@@ -6066,11 +6135,11 @@ msgstr ""
 "![image](_static/images/promotedspawns-01.gif) "
 "*[幻想奇遇](https://www.moddb.com/mods/fantasy-adventure) 中的子机同步升级*"
 
-#: ../../New-or-Enhanced-Logics.md:1593
+#: ../../New-or-Enhanced-Logics.md:1614
 msgid "The spawned units will promote as their owner's veterancy."
 msgstr "生成的单位可以根据其所有者的等级进行同步升级。"
 
-#: ../../New-or-Enhanced-Logics.md:1596
+#: ../../New-or-Enhanced-Logics.md:1617
 msgid ""
 "[SOMETECHNO]                 ; TechnoType\n"
 "Promote.IncludeSpawns=false  ; boolean\n"
@@ -6078,15 +6147,15 @@ msgstr ""
 "[SOMETECHNO]                 ; TechnoType\n"
 "Promote.IncludeSpawns=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1601
+#: ../../New-or-Enhanced-Logics.md:1622
 msgid "Promotion animation"
 msgstr "升级动画"
 
-#: ../../New-or-Enhanced-Logics.md:1603
+#: ../../New-or-Enhanced-Logics.md:1624
 msgid "You can now specify an animation on the unit or structure promotion."
 msgstr "现在你可以在单位或建筑升级时播放指定动画。"
 
-#: ../../New-or-Enhanced-Logics.md:1604
+#: ../../New-or-Enhanced-Logics.md:1625
 msgid ""
 "`Promote.VeteranAnimation` is used when unit or structure is promoted to "
 "veteran. If this is set for a TechnoType, it'll override the global "
@@ -6095,20 +6164,20 @@ msgstr ""
 "`Promote.VeteranAnimation` 用于单位或建筑升级为老兵时。若为单位设置本句则覆盖全局 `[AudioVisual]` "
 "中的设置。"
 
-#: ../../New-or-Enhanced-Logics.md:1605
+#: ../../New-or-Enhanced-Logics.md:1626
 msgid ""
 "`Promote.EliteAnimation` is used when unit or structure is promoted to "
 "elite. If this is set for a TechnoType, it'll override the global setting"
 " in `[AudioVisual]`."
 msgstr "`Promote.EliteAnimation` 用于单位或建筑升级为精英时。若为单位设置本句则覆盖全局 `[AudioVisual]` 中的设置。"
 
-#: ../../New-or-Enhanced-Logics.md:1606
+#: ../../New-or-Enhanced-Logics.md:1627
 msgid ""
 "If `Promote.EliteAnimation` is not defined, `Promote.VeteranAnimation` "
 "will play instead when unit or structure is promoted to elite."
 msgstr "如果未定义 `Promote.EliteAnimation` 则使用 `Promote.VeteranAnimation`。"
 
-#: ../../New-or-Enhanced-Logics.md:1609
+#: ../../New-or-Enhanced-Logics.md:1630
 msgid ""
 "[AudioVisual]\n"
 "Promote.VeteranAnimation=         ; AnimationType\n"
@@ -6130,11 +6199,11 @@ msgstr ""
 "Promote.EliteAnimation=           ; AnimationType, default to "
 "Promote.EliteAnimation in [AudioVisual]\n"
 
-#: ../../New-or-Enhanced-Logics.md:1619
+#: ../../New-or-Enhanced-Logics.md:1640
 msgid "Raise alert when technos are taking damage"
 msgstr "单位受伤警报"
 
-#: ../../New-or-Enhanced-Logics.md:1621
+#: ../../New-or-Enhanced-Logics.md:1642
 msgid ""
 "In Vanilla, non-building technos will not generate radar events or EVAs "
 "when attacked, so players can hardly notice them until they are "
@@ -6145,17 +6214,17 @@ msgstr ""
 "在原版，非建筑科技类型在收到攻击时不会生成雷达事件或 EVA "
 "播报，因此它们很难在被摧毁前被玩家注意到。现在当你的单位受到攻击时可以收到雷达事件（以及可选的声音效果），以便及时应战。"
 
-#: ../../New-or-Enhanced-Logics.md:1622
+#: ../../New-or-Enhanced-Logics.md:1643
 msgid ""
 "`[AudioVisual] -> CombatAlert` is a global switch, set it to `true` to "
 "enable the entire logic."
 msgstr "`[AudioVisual] -> CombatAlert` 是一个全局开关，将其设置为 `true` 以启用整个逻辑。"
 
-#: ../../New-or-Enhanced-Logics.md:1623
+#: ../../New-or-Enhanced-Logics.md:1644
 msgid "These flags controlls when to trigger a combat alert."
 msgstr "这些标签控制什么时候触发战斗警报。"
 
-#: ../../New-or-Enhanced-Logics.md:1624
+#: ../../New-or-Enhanced-Logics.md:1645
 msgid ""
 "You can disable this logic on specific techno by setting `[TechnoType] ->"
 " CombatAlert` to `false`, which default to `[AudioVisual] -> "
@@ -6166,7 +6235,7 @@ msgstr ""
 "`[AudioVisual] -> CombatAlert.Default`。如果 `CombatAlert.Default` 也为空，则默认为对"
 " `Insignificant=yes` 或 `Spawned=yes` 的科技类型禁用。"
 
-#: ../../New-or-Enhanced-Logics.md:1625
+#: ../../New-or-Enhanced-Logics.md:1646
 msgid ""
 "`[AudioVisual] -> CombatAlert.IgnoreBuilding` will turn the logic off on "
 "buildings. You can override it for specific building by setting "
@@ -6177,13 +6246,13 @@ msgstr ""
 "`[TechnoType] -> CombatAlert.NotBuilding` 为 `true` "
 "来为特定建筑覆盖设置。你可能希望将其用于载具性质的建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:1626
+#: ../../New-or-Enhanced-Logics.md:1647
 msgid ""
 "`[AudioVisual] -> CombatAlert.SuppressIfInScreen` decides whether to "
 "disable the logic for the units in the current screen."
 msgstr "`[AudioVisual] -> CombatAlert.SuppressIfInScreen` 决定是否为当前屏幕中的单位禁用此逻辑。"
 
-#: ../../New-or-Enhanced-Logics.md:1627
+#: ../../New-or-Enhanced-Logics.md:1648
 msgid ""
 "`[AudioVisual] -> CombatAlert.Interval` decides the time interval (in "
 "frames) between alerts, to prevent the alert from being anonying. It is "
@@ -6192,13 +6261,13 @@ msgstr ""
 "`[AudioVisual] -> CombatAlert.Interval` 决定警报之间的间隔（以帧为单位），以防止警报过于频繁。默认为 "
 "150 帧。"
 
-#: ../../New-or-Enhanced-Logics.md:1628
+#: ../../New-or-Enhanced-Logics.md:1649
 msgid ""
 "`[AudioVisual] -> CombatAlert.SuppressIfAllyDamage` decides whether to "
 "disable the logic for the damage from allys."
 msgstr "`[AudioVisual] -> CombatAlert.SuppressIfAllyDamage` 决定是否为盟友造成的伤害禁用此逻辑。"
 
-#: ../../New-or-Enhanced-Logics.md:1629
+#: ../../New-or-Enhanced-Logics.md:1650
 msgid ""
 "Technos hitted by a warhead with `[WarheadType] -> CombatAlert.Suppress` "
 "setted to `true` will not raise a radar event or EVA. This flag is "
@@ -6209,11 +6278,11 @@ msgstr ""
 "的弹头击中将不会触发雷达事件或 EVA。此标签默认为 Ares 标签 `[WarheadType] -> Malicious` 的相反值和 "
 "`[WarheadType] -> Nonprovocative` 的值。"
 
-#: ../../New-or-Enhanced-Logics.md:1630
+#: ../../New-or-Enhanced-Logics.md:1651
 msgid "And the following flags controlls the effect of a combat alert."
 msgstr "以下标签控制战斗警报的效果。"
 
-#: ../../New-or-Enhanced-Logics.md:1631
+#: ../../New-or-Enhanced-Logics.md:1652
 msgid ""
 "`[AudioVisual] -> CombatAlert.MakeAVoice` decides whether to play some "
 "sound effect with the combat alert. Set it to `true` will enable the "
@@ -6222,7 +6291,7 @@ msgstr ""
 "`[AudioVisual] -> CombatAlert.MakeAVoice` 决定是否与战斗警报一起播放一些音效。将其设为 true "
 "以启用以下标签，否则它们将被忽略。"
 
-#: ../../New-or-Enhanced-Logics.md:1632
+#: ../../New-or-Enhanced-Logics.md:1653
 msgid ""
 "`[TechnoType] -> CombatAlert.UseFeedbackVoice` decides whether to use the"
 " sound defined by `VoiceFeedback`. Default to `[AudioVisual] -> "
@@ -6231,7 +6300,7 @@ msgstr ""
 "`[TechnoType] -> CombatAlert.UseFeedbackVoice` 决定是否使用 `VoiceFeedback` "
 "定义的声音。默认为 `[AudioVisual] -> CombatAlert.UseFeedbackVoice`。"
 
-#: ../../New-or-Enhanced-Logics.md:1633
+#: ../../New-or-Enhanced-Logics.md:1654
 msgid ""
 "`[TechnoType] -> CombatAlert.UseAttackVoice` decides whether to use the "
 "sound defined by `VoiceAttack`. Default to `[AudioVisual] -> "
@@ -6240,7 +6309,7 @@ msgstr ""
 "`[TechnoType] -> CombatAlert.UseAttackVoice` 决定是否使用 `VoiceAttack` "
 "定义的声音。默认为 `[AudioVisual] -> CombatAlert.UseAttackVoice`。"
 
-#: ../../New-or-Enhanced-Logics.md:1634
+#: ../../New-or-Enhanced-Logics.md:1655
 msgid ""
 "`[TechnoType] -> CombatAlert.UseEVA` decides whether to play an EVA. "
 "Default to `[AudioVisual] -> CombatAlert.UseEVA`. The EVA to play is "
@@ -6251,7 +6320,7 @@ msgstr ""
 "CombatAlert.UseEVA`。所用的 EVA 默认为 `EVA_UnitsInCombat`，可以通过 `[TechnoType] ->"
 " CombatAlert.EVA` 指定。"
 
-#: ../../New-or-Enhanced-Logics.md:1635
+#: ../../New-or-Enhanced-Logics.md:1656
 msgid ""
 "The sound effect is taken **at order**, feedback first, attack then, eva "
 "finally. The flags in `[AudioVisual]` controlls whether to check it "
@@ -6260,7 +6329,7 @@ msgstr ""
 "声音效果 **依次** 被使用，首先是反馈，然后是攻击，最后是 EVA。在 `[AudioVisual]` "
 "中的标签控制是否全局检查，可以为每个科技类型单独指定。"
 
-#: ../../New-or-Enhanced-Logics.md:1636
+#: ../../New-or-Enhanced-Logics.md:1657
 msgid ""
 "An example: You set `CombatAlert.UseFeedbackVoice` and "
 "`CombatAlert.UseEVA` to `true` and `CombatAlert.UseAttackVoice` to "
@@ -6273,7 +6342,7 @@ msgstr ""
 "`VoiceFeedback`、`VoiceAttack` 和 `CombatAlert.EVA` 的单位将播放 "
 "`VoiceFeedback`。拥有 `VoiceAttack` 的单位将播放 `EVA_UnitsInCombat`。"
 
-#: ../../New-or-Enhanced-Logics.md:1639
+#: ../../New-or-Enhanced-Logics.md:1660
 msgid ""
 "[AudioVisual]\n"
 "CombatAlert=false                      ; boolean\n"
@@ -6321,11 +6390,11 @@ msgstr ""
 "[SOMEWARHEAD]                          ; WarheadType\n"
 "CombatAlert.Suppress=                  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1664
+#: ../../New-or-Enhanced-Logics.md:1685
 msgid "Recount burst index"
 msgstr "重置连发索引"
 
-#: ../../New-or-Enhanced-Logics.md:1666
+#: ../../New-or-Enhanced-Logics.md:1687
 msgid ""
 "You can now make technos recount their current burst index when they have"
 " changed the firing weapon or have maintained for a period of time "
@@ -6336,7 +6405,7 @@ msgstr ""
 "现在你可以让单位在更换了开火武器或一段时间（取上一次发射武器的 `ROF` 与 30 帧之间的较大值）内没有目标的情况下重置当前的连发索引。默认为"
 " `[General] -> RecountBurst`，其默认为 false。"
 
-#: ../../New-or-Enhanced-Logics.md:1669
+#: ../../New-or-Enhanced-Logics.md:1690
 msgid ""
 "[General]\n"
 "RecountBurst=false  ; boolean\n"
@@ -6350,11 +6419,11 @@ msgstr ""
 "[SOMETECHNO]        ; TechnoType\n"
 "RecountBurst=       ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1677
+#: ../../New-or-Enhanced-Logics.md:1698
 msgid "Revenge weapon"
 msgstr "复仇武器"
 
-#: ../../New-or-Enhanced-Logics.md:1679
+#: ../../New-or-Enhanced-Logics.md:1700
 msgid ""
 "Similar to `DeathWeapon` in that it is fired after a TechnoType is "
 "killed, but with the difference that it will be fired on whoever dealt "
@@ -6366,20 +6435,20 @@ msgstr ""
 "`DeathWeapon`，它在科技类型被击杀后发射，但不同的是它将发射给造成伤害并杀死科技类型的人。如果科技类型不是由于其他科技类型造成的直接伤害而死亡，那么"
 " `RevengeWeapon` 将不会被发射。"
 
-#: ../../New-or-Enhanced-Logics.md:1680
+#: ../../New-or-Enhanced-Logics.md:1701
 msgid ""
 "`RevengeWeapon.AffectsHouses` can be used to filter which houses the "
 "damage that killed the TechnoType is allowed to come from to fire the "
 "weapon."
 msgstr "`RevengeWeapon.AffectsHouses` 可用于筛选可以对哪些所属方的击杀者发射武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1681
+#: ../../New-or-Enhanced-Logics.md:1702
 msgid ""
 "It is possible to grant revenge weapons through [attached effects"
 "](#attached-effects) as well."
 msgstr "也可以通过 [Attach Effect](#attached-effects) 来授予复仇武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1682
+#: ../../New-or-Enhanced-Logics.md:1703
 msgid ""
 "If a Warhead has `SuppressRevengeWeapons` set to true, it will not "
 "trigger revenge weapons. `SuppressRevengeWeapons.Types` can be used to "
@@ -6390,7 +6459,7 @@ msgstr ""
 "则不会触发复仇武器。`SuppressRevengeWeapons.Types` "
 "可用于列出受影响的武器类型，如果没有列出，则所有武器类型都受影响。"
 
-#: ../../New-or-Enhanced-Logics.md:1685
+#: ../../New-or-Enhanced-Logics.md:1706
 msgid ""
 "[SOMETECHNO]                    ; TechnoType\n"
 "RevengeWeapon=                  ; WeaponType\n"
@@ -6410,11 +6479,11 @@ msgstr ""
 "SuppressRevengeWeapons=false    ; boolean\n"
 "SuppressRevengeWeapons.Types=   ; List of WeaponTypes\n"
 
-#: ../../New-or-Enhanced-Logics.md:1695
+#: ../../New-or-Enhanced-Logics.md:1716
 msgid "Shared Ammo"
 msgstr "共享弹药"
 
-#: ../../New-or-Enhanced-Logics.md:1697
+#: ../../New-or-Enhanced-Logics.md:1718
 msgid ""
 "Transports with `OpenTopped=yes` and `Ammo.Shared=yes` will transfer ammo"
 " to passengers that have `Ammo.Shared=yes`. In addition, a transport can "
@@ -6426,17 +6495,17 @@ msgstr ""
 "的载员共享弹药。此外如果载员拥有与运输工具相同的 `Ammo.Shared.Group=<integer>` "
 "值则运输工具可以筛选谁将接收弹药而忽略不拥有同组值的其他载员。"
 
-#: ../../New-or-Enhanced-Logics.md:1699
+#: ../../New-or-Enhanced-Logics.md:1720
 msgid ""
 "Transports with `Ammo.Shared.Group=-1` will transfer ammo to any "
 "passenger with `Ammo.Shared=yes` ignoring the group."
 msgstr "拥有 `Ammo.Shared.Group=-1` 的运输工具将像任何拥有 `Ammo.Shared=yes` 的载员共享弹药。"
 
-#: ../../New-or-Enhanced-Logics.md:1700
+#: ../../New-or-Enhanced-Logics.md:1721
 msgid "Transports must have ammo and should be able to reload ammo."
 msgstr "运输工具必须拥有弹药并应当能够自行重装弹药。"
 
-#: ../../New-or-Enhanced-Logics.md:1703
+#: ../../New-or-Enhanced-Logics.md:1724
 msgid ""
 "[SOMETECHNO1]         ; TechnoType, transport with OpenTopped=yes\n"
 "Ammo.Shared=no        ; boolean\n"
@@ -6454,17 +6523,17 @@ msgstr ""
 "Ammo.Shared=no        ; boolean\n"
 "Ammo.Shared.Group=-1  ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1713
+#: ../../New-or-Enhanced-Logics.md:1734
 msgid "Sound entry on unit's creation"
 msgstr "单位创建时音效"
 
-#: ../../New-or-Enhanced-Logics.md:1715
+#: ../../New-or-Enhanced-Logics.md:1736
 msgid ""
 "When a unit is created, sound specified in `VoiceCreated` will be played "
 "for the unit owner."
 msgstr "当一个单位被创建时将为单位所有者播放 `VoiceCreated` 指定的音效。"
 
-#: ../../New-or-Enhanced-Logics.md:1716
+#: ../../New-or-Enhanced-Logics.md:1737
 msgid ""
 "If `IsVoiceCreatedGlobal` is set to true, `VoiceCreated` will be played "
 "globally instead of `EVA_UnitReady`."
@@ -6472,7 +6541,7 @@ msgstr ""
 "如果 `IsVoiceCreatedGlobal` 设为 true 则将全局播放 `VoiceCreated` 而不是 "
 "`EVA_UnitReady`。"
 
-#: ../../New-or-Enhanced-Logics.md:1719
+#: ../../New-or-Enhanced-Logics.md:1740
 msgid ""
 "[AudioVisual]\n"
 "IsVoiceCreatedGlobal=false   ; boolean\n"
@@ -6486,40 +6555,42 @@ msgstr ""
 "[SOMETECHNO]                 ; TechnoType\n"
 "VoiceCreated=                ; Sound entry\n"
 
-#: ../../New-or-Enhanced-Logics.md:1727
+#: ../../New-or-Enhanced-Logics.md:1748
 msgid "Targeting limitation for berzerk technos"
 msgstr "狂暴单位索敌限制"
 
-#: ../../New-or-Enhanced-Logics.md:1729
+#: ../../New-or-Enhanced-Logics.md:1750
 msgid "Now you can specify which houses berzerk's technos can target and fire."
 msgstr "现在你可以设定狂暴单位可以对哪些所属方的目标索敌和开火。"
 
-#: ../../New-or-Enhanced-Logics.md:1732
+#: ../../New-or-Enhanced-Logics.md:1753
 msgid ""
 "[General]\n"
-"BerzerkTargeting=all  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)\n"
+"BerzerkTargeting=all  ; Affected House Enumeration "
+"(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 msgstr ""
 "[General]\n"
-"BerzerkTargeting=all  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)\n"
+"BerzerkTargeting=all  ; Affected House Enumeration "
+"(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1737
+#: ../../New-or-Enhanced-Logics.md:1758
 msgid "Tiberium eater"
 msgstr "马夫逻辑"
 
-#: ../../New-or-Enhanced-Logics.md:1739
+#: ../../New-or-Enhanced-Logics.md:1760
 msgid ""
 "TechnoTypes can convert the ores underneath them into credits in real "
 "time, like GDI's MARV in Command & Conquer 3 Kane's Wrath."
 msgstr "可以让单位实时将自身脚下的矿石直接转化为资金，就像《凯恩之怒》中 GDI 的 MARV 那样。"
 
-#: ../../New-or-Enhanced-Logics.md:1740
+#: ../../New-or-Enhanced-Logics.md:1761
 msgid ""
 "`TiberiumEater.TransDelay` specifies the interval frames between two "
 "eating processes, 0 means eat in every frame. When it's below 0, the "
 "logic will be turned off for this TechnoType."
 msgstr "`TiberiumEater.TransDelay` 指定了两次吃矿之间间隔的帧数，0 代表逐帧。负值禁用。"
 
-#: ../../New-or-Enhanced-Logics.md:1741
+#: ../../New-or-Enhanced-Logics.md:1762
 msgid ""
 "`TiberiumEater.CellN` set a list of cells that'll process tiberium "
 "eating, where `N` is 0-based and the values are offset related to the "
@@ -6529,31 +6600,31 @@ msgstr ""
 "`TiberiumEater.CellN` 用于设定吃矿位置以单元格为单位的偏移列表，`N` 为 0 "
 "始序号，数值表示相对于单位所在单元格的偏移坐标。如果不设置则只吃脚下的。"
 
-#: ../../New-or-Enhanced-Logics.md:1742
+#: ../../New-or-Enhanced-Logics.md:1763
 msgid ""
 "`TiberiumEater.AmountPerCell` controls the amount of ores that can be "
 "eaten at each cell at once. No limit when it's below 0."
 msgstr "`TiberiumEater.AmountPerCell` 控制单次吃矿对与每个单元格而言可吃进去的矿石量上限。负值喂不饱。"
 
-#: ../../New-or-Enhanced-Logics.md:1743
+#: ../../New-or-Enhanced-Logics.md:1764
 msgid ""
 "By default, ores mined in this way worth the same as regular harvesting. "
 "This can be adjusted by `TiberiumEater.CashMultiplier`."
 msgstr "默认通过此方式采集的矿石价值与常规采矿相同。这可以通过 `TiberiumEater.CashMultiplier` 加以调整。"
 
-#: ../../New-or-Enhanced-Logics.md:1744
+#: ../../New-or-Enhanced-Logics.md:1765
 msgid ""
 "`TiberiumEater.Display`, if set to true, will create a flying text to "
 "display the total credits received in each eating process."
 msgstr "若 `TiberiumEater.Display` 设为 true 则每次吃矿时都会飘起一个代表所得总资金量的数字。"
 
-#: ../../New-or-Enhanced-Logics.md:1745
+#: ../../New-or-Enhanced-Logics.md:1766
 msgid ""
 "`TiberiumEater.Display.Houses` determines which houses can see the "
 "credits display."
 msgstr "`TiberiumEater.Display.Houses` 决定了哪些所属方能看见。"
 
-#: ../../New-or-Enhanced-Logics.md:1746
+#: ../../New-or-Enhanced-Logics.md:1767
 msgid ""
 "An animation will be played at each mined cell in an eating process. If "
 "`TiberiumEater.Anims` contains 8 entries, entry from position matching "
@@ -6561,7 +6632,7 @@ msgid ""
 "be chosen randomly."
 msgstr "每次吃矿时都会在被吃的单元格播放动画。若 `TiberiumEater.Anims` 包含 8 个条目则根据单位当前朝向选择动画，否则随机选取。"
 
-#: ../../New-or-Enhanced-Logics.md:1747
+#: ../../New-or-Enhanced-Logics.md:1768
 msgid ""
 "`TiberiumEater.Anims.TiberiumN`, if set, will override "
 "`TiberiumEater.Anims` when eating corresponding tiberium type."
@@ -6569,13 +6640,13 @@ msgstr ""
 "若设置了 `TiberiumEater.Anims.TiberiumN` 则在吃进去对应类型（`N` = `[0,3]`）的矿石时使用对应序列的 "
 "`TiberiumEater.Anims`。"
 
-#: ../../New-or-Enhanced-Logics.md:1748
+#: ../../New-or-Enhanced-Logics.md:1769
 msgid ""
 "If `TiberiumEater.AnimMove` set to true, the animations will move with "
 "the TechnoType."
 msgstr "若 `TiberiumEater.AnimMove` 设为 true 则动画会跟随单位移动。"
 
-#: ../../New-or-Enhanced-Logics.md:1751
+#: ../../New-or-Enhanced-Logics.md:1772
 msgid ""
 "[SOMETECHNO]                      ; InfantryType, VehicleType or "
 "AircraftType\n"
@@ -6584,7 +6655,8 @@ msgid ""
 "TiberiumEater.CashMultiplier=1.0  ; floating point value\n"
 "TiberiumEater.AmountPerCell=0     ; integer\n"
 "TiberiumEater.Display=true        ; boolean\n"
-"TiberiumEater.Display.Houses=all  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)\n"
+"TiberiumEater.Display.Houses=all  ; Affected House Enumeration "
+"(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "TiberiumEater.Anims=              ; List of AnimationTypes\n"
 "TiberiumEater.Anims.Tiberium0=    ; List of AnimationTypes\n"
 "TiberiumEater.Anims.Tiberium1=    ; List of AnimationTypes\n"
@@ -6599,7 +6671,8 @@ msgstr ""
 "TiberiumEater.CashMultiplier=1.0  ; floating point value\n"
 "TiberiumEater.AmountPerCell=0     ; integer\n"
 "TiberiumEater.Display=true        ; boolean\n"
-"TiberiumEater.Display.Houses=all  ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)\n"
+"TiberiumEater.Display.Houses=all  ; Affected House Enumeration "
+"(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "TiberiumEater.Anims=              ; List of AnimationTypes\n"
 "TiberiumEater.Anims.Tiberium0=    ; List of AnimationTypes\n"
 "TiberiumEater.Anims.Tiberium1=    ; List of AnimationTypes\n"
@@ -6607,18 +6680,18 @@ msgstr ""
 "TiberiumEater.Anims.Tiberium3=    ; List of AnimationTypes\n"
 "TiberiumEater.AnimMove=true       ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1767
+#: ../../New-or-Enhanced-Logics.md:1788
 msgid "Weapons fired on warping in / out"
 msgstr "武器在传送时开火"
 
-#: ../../New-or-Enhanced-Logics.md:1769
+#: ../../New-or-Enhanced-Logics.md:1790
 msgid ""
 "It is now possible to add weapons that are fired on a teleporting "
 "TechnoType when it warps in or out. They are at the same time as the "
 "appropriate animations (`WarpIn` / `WarpOut`) are displayed."
 msgstr "现在可以在科技类型传送来/去时发射武器。它们会与相应的 (`WarpIn`／`WarpOut`) 动画一起显示。"
 
-#: ../../New-or-Enhanced-Logics.md:1770
+#: ../../New-or-Enhanced-Logics.md:1791
 msgid ""
 "`WarpInMinRangeWeapon` is used instead of `WarpInWeapon` if the distance "
 "traveled (in leptons) was less than `ChronoRangeMinimum`. This works "
@@ -6629,7 +6702,7 @@ msgstr ""
 "时使用，无论是否设置了 `ChronoTrigger`。如果未设置 `WarpInMinRangeWeapon`，则默认为 "
 "`WarpInWeapon`。"
 
-#: ../../New-or-Enhanced-Logics.md:1771
+#: ../../New-or-Enhanced-Logics.md:1792
 msgid ""
 "If `WarpInWeapon.UseDistanceAsDamage` is set, `Damage` of "
 "`WarpIn(MinRange)Weapon` is overriden by the number of whole cells "
@@ -6638,7 +6711,7 @@ msgstr ""
 "如果设置了 `WarpInWeapon.UseDistanceAsDamage` 则 `WarpIn(MinRange)Weapon` 的 "
 "`Damage` 将被覆盖为传送所跨越的完整单元格数。"
 
-#: ../../New-or-Enhanced-Logics.md:1774
+#: ../../New-or-Enhanced-Logics.md:1795
 msgid ""
 "[SOMETECHNO]                            ; TechnoType\n"
 "WarpInWeapon=                           ; WeaponType\n"
@@ -6652,15 +6725,15 @@ msgstr ""
 "WarpInWeapon.UseDistanceAsDamage=false  ; boolean\n"
 "WarpOutWeapon=                          ; WeaponType\n"
 
-#: ../../New-or-Enhanced-Logics.md:1782
+#: ../../New-or-Enhanced-Logics.md:1803
 msgid "Reset MindControl after transformation"
 msgstr "变形后重置心控效果"
 
-#: ../../New-or-Enhanced-Logics.md:1784
+#: ../../New-or-Enhanced-Logics.md:1805
 msgid "After the unit conversion is completed, its mind control can be reset."
 msgstr "单位变形完毕后其心控效果可被重置。"
 
-#: ../../New-or-Enhanced-Logics.md:1785
+#: ../../New-or-Enhanced-Logics.md:1806
 msgid ""
 "If all warheads don't have `MindControl=yes`, then "
 "`Convert.ResetMindControl=yes` will release all controlled units."
@@ -6668,7 +6741,7 @@ msgstr ""
 "如果变形后的单位所有弹头都没有 `MindControl=yes`，那么 `Convert.ResetMindControl=yes` "
 "将释放所有被心控的单位。"
 
-#: ../../New-or-Enhanced-Logics.md:1786
+#: ../../New-or-Enhanced-Logics.md:1807
 msgid ""
 "If any warhead has `MindControl=yes`, then `Convert.ResetMindControl=yes`"
 " resets its maximum number of controls."
@@ -6676,7 +6749,7 @@ msgstr ""
 "如果变形后的单位任意弹头拥有 `MindControl=yes`，那么 `Convert.ResetMindControl=yes` "
 "将重置最大控制数量上限。"
 
-#: ../../New-or-Enhanced-Logics.md:1787
+#: ../../New-or-Enhanced-Logics.md:1808
 msgid ""
 "If all weapons don't have `InfiniteMindControl=yes`, then "
 "`Convert.ResetMindControl=yes` release controlled units that exceed the "
@@ -6685,7 +6758,7 @@ msgstr ""
 "如果变形后的单位所有武器都没有 `InfiniteMindControl=yes`，那么 "
 "`Convert.ResetMindControl=yes` 将释放超出上限的被心控单位。"
 
-#: ../../New-or-Enhanced-Logics.md:1790
+#: ../../New-or-Enhanced-Logics.md:1811
 msgid ""
 "[SOMETECHNO]                            ; TechnoType, before conversion\n"
 "Convert.ResetMindControl=false          ; boolean\n"
@@ -6693,21 +6766,21 @@ msgstr ""
 "[SOMETECHNO]                            ; TechnoType, before conversion\n"
 "Convert.ResetMindControl=false          ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1795
+#: ../../New-or-Enhanced-Logics.md:1816
 msgid "Terrain"
 msgstr "地形对象"
 
-#: ../../New-or-Enhanced-Logics.md:1797
+#: ../../New-or-Enhanced-Logics.md:1818
 msgid "Destroy animation & sound"
 msgstr "摧毁动画与音效"
 
-#: ../../New-or-Enhanced-Logics.md:1799
+#: ../../New-or-Enhanced-Logics.md:1820
 msgid ""
 "You can now specify a destroy animation and sound for a TerrainType that "
 "are played when it is destroyed."
 msgstr "现在你可以指定当地形对象被摧毁时播放播放的摧毁动画与音效。"
 
-#: ../../New-or-Enhanced-Logics.md:1802
+#: ../../New-or-Enhanced-Logics.md:1823
 msgid ""
 "[SOMETERRAINTYPE]  ; TerrainType\n"
 "DestroyAnim=       ; AnimationType\n"
@@ -6717,21 +6790,21 @@ msgstr ""
 "DestroyAnim=       ; AnimationType\n"
 "DestroySound=      ; Sound entry\n"
 
-#: ../../New-or-Enhanced-Logics.md:1808
+#: ../../New-or-Enhanced-Logics.md:1829
 msgid "Vehicles"
 msgstr "载具类型"
 
-#: ../../New-or-Enhanced-Logics.md:1810
+#: ../../New-or-Enhanced-Logics.md:1831
 msgid "Amphibious access vehicle"
 msgstr "两栖载具装载拓展"
 
-#: ../../New-or-Enhanced-Logics.md:1812
+#: ../../New-or-Enhanced-Logics.md:1833
 msgid ""
 "Now you can let amphibious infantry or vehicle passengers enter or leave "
 "amphibious transport vehicles on water surface."
 msgstr "现在两栖步兵或载具可以在水中进入或离开两栖运输工具。"
 
-#: ../../New-or-Enhanced-Logics.md:1815
+#: ../../New-or-Enhanced-Logics.md:1836
 msgid ""
 "[General]\n"
 "AmphibiousEnter=false    ; boolean\n"
@@ -6753,11 +6826,11 @@ msgstr ""
 "AmphibiousUnload=        ; boolean, default to [General] -> "
 "AmphibiousUnload\n"
 
-#: ../../New-or-Enhanced-Logics.md:1825
+#: ../../New-or-Enhanced-Logics.md:1846
 msgid "Damaged unit image changes"
 msgstr "单位伤残更换图像"
 
-#: ../../New-or-Enhanced-Logics.md:1827
+#: ../../New-or-Enhanced-Logics.md:1848
 msgid ""
 "When a unit is damaged (health points percentage is lower than "
 "`[AudioVisual] -> ConditionYellow` percentage), it now may use different "
@@ -6766,7 +6839,7 @@ msgstr ""
 "现在当单位伤残（生命值低于 `[AudioVisual] -> ConditionYellow` 的百分比）时可以通过 "
 "`Image.ConditionYellow` 为单位设置不同的图像。"
 
-#: ../../New-or-Enhanced-Logics.md:1828
+#: ../../New-or-Enhanced-Logics.md:1849
 msgid ""
 "Similar, `Image.ConditionRed` is used as image if unit health points "
 "percentage is lower than `[AudioVisual] -> ConditionRed` percentage."
@@ -6774,7 +6847,7 @@ msgstr ""
 "同样的如果单位生命值低于 `[AudioVisual] -> ConditionRed` 的百分比那么将会使用 "
 "`Image.ConditionRed` 作为图像。"
 
-#: ../../New-or-Enhanced-Logics.md:1829
+#: ../../New-or-Enhanced-Logics.md:1850
 msgid ""
 "It is also works on water by setting `WaterImage.ConditionYellow` and "
 "`WaterImage.ConditionRed` VehicleType, similar to Ares' `WaterImage`."
@@ -6782,7 +6855,7 @@ msgstr ""
 "类似于 Ares 的 `WaterImage`，可以通过设置 `WaterImage.ConditionYellow` 和 "
 "`WaterImage.ConditionRed` 的单位类型来在水上应用这一效果。"
 
-#: ../../New-or-Enhanced-Logics.md:1832
+#: ../../New-or-Enhanced-Logics.md:1853
 msgid ""
 "[SOMEVEHICLE]                         ; VehicleType\n"
 "Image.ConditionYellow=                ; VehicleType entry\n"
@@ -6796,23 +6869,23 @@ msgstr ""
 "WaterImage.ConditionYellow=           ; VehicleType entry\n"
 "WaterImage.ConditionRed=              ; VehicleType entry\n"
 
-#: ../../New-or-Enhanced-Logics.md:1841
+#: ../../New-or-Enhanced-Logics.md:1862
 msgid ""
 "Note that the VehicleTypes had to be defined under [VehicleTypes] and use"
 " same image type (SHP/VXL) for vanilla/damaged states."
 msgstr "注意这些被使用的单位必须在 `[VehicleTypes]` 下注册并且在常规／伤残状态下使用相同的图像类型（Shape／Voxel）。"
 
-#: ../../New-or-Enhanced-Logics.md:1844
+#: ../../New-or-Enhanced-Logics.md:1865
 msgid "Fast access vehicle"
 msgstr "快速上车"
 
-#: ../../New-or-Enhanced-Logics.md:1846
+#: ../../New-or-Enhanced-Logics.md:1867
 msgid ""
 "Now you can let infantry or vehicle passengers quickly enter or leave the"
 " transport vehicles without queuing."
 msgstr "现在你可以让步兵或载具类载员无需排队地快速进入或离开运输载具。"
 
-#: ../../New-or-Enhanced-Logics.md:1849
+#: ../../New-or-Enhanced-Logics.md:1870
 msgid ""
 "[General]\n"
 "NoQueueUpToEnter=false    ; boolean\n"
@@ -6834,11 +6907,11 @@ msgstr ""
 "NoQueueUpToUnload=        ; boolean, default to [General] -> "
 "NoQueueUpToUnload\n"
 
-#: ../../New-or-Enhanced-Logics.md:1859
+#: ../../New-or-Enhanced-Logics.md:1880
 msgid "Jumpjet Tilts While Moving"
 msgstr "Jumpjet 在移动时倾斜"
 
-#: ../../New-or-Enhanced-Logics.md:1861
+#: ../../New-or-Enhanced-Logics.md:1882
 msgid ""
 "![image](_static/images/jumpjet-tilt.gif) *Jumpjet Tilts in [Project Rush"
 " - Conquer](https://www.moddb.com/mods/project-rush-conquer)*"
@@ -6847,31 +6920,31 @@ msgstr ""
 "*[冲击计划：征服](https://www.moddb.com/mods/project-rush-conquer) 中的 Jumpjet "
 "前倾*"
 
-#: ../../New-or-Enhanced-Logics.md:1864
+#: ../../New-or-Enhanced-Logics.md:1885
 msgid ""
 "Now you can make jumpjets tilt forward when moving forward and sideways "
 "when turning by setting `JumpjetTilt` to true."
 msgstr "现在你可以通过将 `JumpjetTilt` 设为 true 来使 Jumpjet 单位在向前移动时前倾以及在转向时侧倾。"
 
-#: ../../New-or-Enhanced-Logics.md:1865
+#: ../../New-or-Enhanced-Logics.md:1886
 msgid "The maximum tilt angle will not exceed 90 degrees."
 msgstr "最大倾斜角度不会超过 90 度。"
 
-#: ../../New-or-Enhanced-Logics.md:1866
+#: ../../New-or-Enhanced-Logics.md:1887
 msgid ""
 "The magnitude of the forward tilt is related to the current speed and "
 "acceleration. They are additive and have two coefficients that can be "
 "adjusted for details."
 msgstr "向前倾斜的幅度与当前速度和加速度相关。它们会相加，这里给出两个用于细节调整的系数。"
 
-#: ../../New-or-Enhanced-Logics.md:1867
+#: ../../New-or-Enhanced-Logics.md:1888
 msgid ""
 "The magnitude of the sideways tilt is related to the current speed and "
 "rotation angle. They are multiplied and also have two coefficients that "
 "can be adjusted for details."
 msgstr "侧向倾斜的幅度与当前速度和旋转角度相关。它们会相乘，同样给出两个用于细节调整的系数。"
 
-#: ../../New-or-Enhanced-Logics.md:1870
+#: ../../New-or-Enhanced-Logics.md:1891
 msgid ""
 "[SOMEVEHICLE]                           ; VehicleType, with "
 "Locomotor=Jumpjet\n"
@@ -6889,15 +6962,15 @@ msgstr ""
 "JumpjetTilt.SidewaysRotationFactor=1.0  ; floating point value\n"
 "JumpjetTilt.SidewaysSpeedFactor=1.0     ; floating point value\n"
 
-#: ../../New-or-Enhanced-Logics.md:1879
+#: ../../New-or-Enhanced-Logics.md:1900
 msgid "Turretless Shape Vehicle FireUp"
 msgstr "无炮塔 Shape 载具开火前摇"
 
-#: ../../New-or-Enhanced-Logics.md:1881
+#: ../../New-or-Enhanced-Logics.md:1902
 msgid "`Voxel=no` turretless vehicles now support the use of `FireUp`."
 msgstr "现在 `Voxel=no` 的无炮塔载具现在已经支持 `FireUp`。"
 
-#: ../../New-or-Enhanced-Logics.md:1882
+#: ../../New-or-Enhanced-Logics.md:1903
 #, fuzzy
 msgid ""
 "`FireUp.ResetInRetarget` determines whether a vehicle's FireUp count is "
@@ -6905,7 +6978,7 @@ msgid ""
 "target."
 msgstr "`FireUp.ResetInRetarget` 决定当前载具目标改变时其前摇是否重置。当没有目标时该参数强制 `yes`。"
 
-#: ../../New-or-Enhanced-Logics.md:1885
+#: ../../New-or-Enhanced-Logics.md:1906
 msgid ""
 "[SOMEVEHICLE]                   ; VehicleType\n"
 "FireUp=                         ; integer\n"
@@ -6915,43 +6988,41 @@ msgstr ""
 "FireUp=                         ; integer\n"
 "FireUp.ResetInRetarget=true     ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1891
+#: ../../New-or-Enhanced-Logics.md:1912
 msgid "Warheads"
 msgstr "弹头"
 
-#: ../../New-or-Enhanced-Logics.md:1894
+#: ../../New-or-Enhanced-Logics.md:1915
 msgid "All new Warhead effects"
 msgstr "所有新增的弹头效果"
 
-#: ../../New-or-Enhanced-Logics.md:1895
+#: ../../New-or-Enhanced-Logics.md:1916
 msgid ""
 "Can be used with `CellSpread` and Ares' GenericWarhead superweapon where "
 "applicable."
 msgstr "可在适用的情况下与 `CellSpread` 和 Ares 的通用弹头超级武器一起使用。"
 
-#: ../../New-or-Enhanced-Logics.md:1896
+#: ../../New-or-Enhanced-Logics.md:1917
 msgid "Cannot be used with `MindControl.Permanent=yes` of Ares."
 msgstr "不能与 Ares 的 `MindControl.Permanent=yes` 共同使用。"
 
-#: ../../New-or-Enhanced-Logics.md:1897
+#: ../../New-or-Enhanced-Logics.md:1918
 msgid ""
 "Respect `Verses` where applicable unless `EffectsRequireVerses` is set to"
 " `false`."
-msgstr ""
-"在适用的情况下除非 `EffectsRequireVerses` 设为 `false` 否则尊重 "
-"`Verses`。"
+msgstr "在适用的情况下除非 `EffectsRequireVerses` 设为 `false` 否则尊重 `Verses`。"
 
+#: ../../New-or-Enhanced-Logics.md:1919
 msgid ""
-"If target has an active [shield](#shields), its armor type is used instead "
-"unless warhead can penetrate the shield."
-msgstr ""
-"如果目标拥有一个激活的 [护盾](#shields)，那么它的护甲类型将被使用，除非弹头可以穿透护盾。"
+"If target has an active [shield](#shields), its armor type is used "
+"instead unless warhead can penetrate the shield."
+msgstr "如果目标拥有一个激活的 [护盾](#shields)，那么它的护甲类型将被使用，除非弹头可以穿透护盾。"
 
-#: ../../New-or-Enhanced-Logics.md:1900
+#: ../../New-or-Enhanced-Logics.md:1922
 msgid "Break Mind Control on impact"
 msgstr "解除心控"
 
-#: ../../New-or-Enhanced-Logics.md:1902
+#: ../../New-or-Enhanced-Logics.md:1924
 msgid ""
 "![image](_static/images/remove-mc.gif) *Mind control break warhead being "
 "utilized in [RA2: Reboot](https://www.moddb.com/mods/reboot)*"
@@ -6959,13 +7030,13 @@ msgstr ""
 "![image](_static/images/remove-mc.gif) *[RA2: "
 "Reboot](https://www.moddb.com/mods/reboot) 中的心控解除弹头*"
 
-#: ../../New-or-Enhanced-Logics.md:1905
+#: ../../New-or-Enhanced-Logics.md:1927
 msgid ""
 "Warheads can now break mind control (doesn't apply to perma-MC-ed "
 "objects)."
 msgstr "弹头现在可以解除心灵控制（不适用于永久心控的对象）。"
 
-#: ../../New-or-Enhanced-Logics.md:1908
+#: ../../New-or-Enhanced-Logics.md:1930
 msgid ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "RemoveMindControl=false  ; boolean\n"
@@ -6973,17 +7044,17 @@ msgstr ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "RemoveMindControl=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1913
+#: ../../New-or-Enhanced-Logics.md:1935
 msgid "Warhead that can not kill"
 msgstr "弹头击杀限制"
 
-#: ../../New-or-Enhanced-Logics.md:1915
+#: ../../New-or-Enhanced-Logics.md:1937
 msgid ""
 "Warheads can now damage the enemy without killing them (minimum health "
 "will be 1)."
 msgstr "现在可以让一个弹头可以杀伤敌人但无法击杀它们（至少保留 1 滴血）。"
 
-#: ../../New-or-Enhanced-Logics.md:1918
+#: ../../New-or-Enhanced-Logics.md:1940
 msgid ""
 "[SOMEWARHEAD]  ; WarheadType\n"
 "CanKill=true   ; boolean\n"
@@ -6991,11 +7062,11 @@ msgstr ""
 "[SOMEWARHEAD]  ; WarheadType\n"
 "CanKill=true   ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1923
+#: ../../New-or-Enhanced-Logics.md:1945
 msgid "Chance-based extra damage or Warhead detonation / 'critical hits'"
 msgstr "暴击"
 
-#: ../../New-or-Enhanced-Logics.md:1925
+#: ../../New-or-Enhanced-Logics.md:1947
 msgid ""
 "Warheads can now apply additional chance-based damage or Warhead "
 "detonation ('critical hits') with the ability to customize chance, "
@@ -7003,7 +7074,7 @@ msgid ""
 "critical hit."
 msgstr "现在弹头可以基于概率额外造成暴击伤害或弹头爆炸，可以自定义暴击的概率、伤害、影响目标、受影响目标生命值阈值和暴击动画。"
 
-#: ../../New-or-Enhanced-Logics.md:1926
+#: ../../New-or-Enhanced-Logics.md:1948
 msgid ""
 "`Crit.Chance` determines chance for a critical hit to occur. By default "
 "this is checked once when the Warhead is detonated and every target that "
@@ -7014,7 +7085,7 @@ msgstr ""
 "`Crit.Chance` 决定暴击发生的概率。默认情况下这在弹头爆炸时检查一次，每个受影响的目标都可能受到暴击。如果设置了 "
 "`Crit.ApplyChancePerTarget`，那么每个目标是否成功进行暴击的概率将单独计算。"
 
-#: ../../New-or-Enhanced-Logics.md:1927
+#: ../../New-or-Enhanced-Logics.md:1949
 msgid ""
 "`Crit.ExtraDamage` determines the damage dealt by the critical hit. If "
 "`Crit.Warhead` is set, the damage is used to detonate the specified "
@@ -7024,20 +7095,20 @@ msgstr ""
 "`Crit.ExtraDamage` 决定暴击造成的额外伤害，如果设置了 "
 "`Crit.Warhead`，那么伤害将用于在每个受影响的目标上引爆指定的弹头，否则伤害将基于当前弹头的 `Verses` 设置直接造成伤害。"
 
-#: ../../New-or-Enhanced-Logics.md:1928
+#: ../../New-or-Enhanced-Logics.md:1950
 msgid ""
 "`Crit.ExtraDamage.ApplyFirepowerMult` determines whether or not the "
 "critical hit damage should multiply the TechnoType's firepower "
 "multipliers."
 msgstr "`Crit.ExtraDamage.ApplyFirepowerMult` 决定暴击造成的额外伤害是否受益于科技类型所拥有的火力加成。"
 
-#: ../../New-or-Enhanced-Logics.md:1929
+#: ../../New-or-Enhanced-Logics.md:1951
 msgid ""
 "`Crit.Warhead` can be used to set a Warhead to detonate instead of using "
 "current Warhead."
 msgstr "`Crit.Warhead` 可用于设置一个替代当前弹头引爆的弹头。"
 
-#: ../../New-or-Enhanced-Logics.md:1930
+#: ../../New-or-Enhanced-Logics.md:1952
 msgid ""
 "`Crit.Warhead.FullDetonation` controls whether or not the Warhead is "
 "detonated fully on the targets (as part of a dummy weapon) or simply "
@@ -7046,27 +7117,27 @@ msgstr ""
 "`Crit.Warhead.FullDetonation` 控制弹头是否在目标上完全引爆（作为虚拟武器的一部分）或者只能对所在区域造成杀伤并应用 "
 "Phobos 的弹头效果。"
 
-#: ../../New-or-Enhanced-Logics.md:1931
+#: ../../New-or-Enhanced-Logics.md:1953
 msgid ""
 "`Crit.Affects` can be used to customize types of targets that this "
 "Warhead can deal critical hits against. Critical hits cannot affect empty"
 " cells or cells containing only TerrainTypes, overlays etc."
 msgstr "`Crit.Affects` 可用于自定义此弹头可暴击的目标类型。暴击不能影响空置单元格或仅包含地形对象和覆盖物等的单元格。"
 
-#: ../../New-or-Enhanced-Logics.md:1932
+#: ../../New-or-Enhanced-Logics.md:1954
 msgid ""
 "`Crit.AffectsHouses` can be used to customize houses that this Warhead "
 "can deal critical hits against."
 msgstr "`Crit.AffectsHouses` 可用于自定义此弹头可暴击的目标所属。"
 
-#: ../../New-or-Enhanced-Logics.md:1933
+#: ../../New-or-Enhanced-Logics.md:1955
 msgid ""
 "`Crit.AffectBelowPercent` can be used to set minimum percentage of their "
 "maximum `Strength` that targets must have left to be affected by a "
 "critical hit."
 msgstr "`Crit.AffectBelowPercent` 可用于设置暴击允许的目标其剩余血量相对最大 `Strength` 的百分比下限。"
 
-#: ../../New-or-Enhanced-Logics.md:1934
+#: ../../New-or-Enhanced-Logics.md:1956
 msgid ""
 "`Crit.AnimList` can be used to set a list of animations used instead of "
 "Warhead's `AnimList` if Warhead deals a critical hit to even one target. "
@@ -7079,7 +7150,7 @@ msgstr ""
 "`Crit.AnimList.PickRandom`（默认为 `AnimList.PickRandom`），则从列表中随机选择一个动画。如果设置了"
 " `Crit.AnimList.CreateAll`（默认为 `AnimList.CreateAll`），则创建列表中的所有动画。"
 
-#: ../../New-or-Enhanced-Logics.md:1935
+#: ../../New-or-Enhanced-Logics.md:1957
 msgid ""
 "`Crit.AnimOnAffectedTargets`, if set, makes the animation(s) from "
 "`Crit.AnimList` play on each affected target *in addition* to animation "
@@ -7094,7 +7165,7 @@ msgstr ""
 "独立所以，`Crit.AnimList.PickRandom` 和 `Crit.AnimList.CreateAll` 将不会默认为 "
 "`AnimList` 对应项的值，需要手动设置。"
 
-#: ../../New-or-Enhanced-Logics.md:1936
+#: ../../New-or-Enhanced-Logics.md:1958
 msgid ""
 "`Crit.ActiveChanceAnims` can be used to set animation to be always "
 "displayed at the Warhead's detonation coordinates if the current Warhead "
@@ -7102,7 +7173,7 @@ msgid ""
 "random one is selected."
 msgstr "`Crit.ActiveChanceAnims` 可用于设置当前弹头有几率造成暴击时始终显示在弹头爆炸坐标处的动画。列出多个动画则随机选择其一。"
 
-#: ../../New-or-Enhanced-Logics.md:1937
+#: ../../New-or-Enhanced-Logics.md:1959
 msgid ""
 "`Crit.SuppressWhenIntercepted`, if set, prevents critical hits from "
 "occuring at all if the warhead was detonated from a [projectile that was "
@@ -7111,13 +7182,13 @@ msgstr ""
 "`Crit.SuppressWhenIntercepted` 如果设置则禁用弹头在被[抛射体拦截](#projectile-"
 "interception-logic)而引爆时造成暴击。"
 
-#: ../../New-or-Enhanced-Logics.md:1938
+#: ../../New-or-Enhanced-Logics.md:1960
 msgid ""
 "`ImmuneToCrit` can be set on TechnoTypes and ShieldTypes to make them "
 "immune to critical hits."
 msgstr "`ImmuneToCrit` 可以设置在科技类型和护盾类型上以使它们免疫暴击。"
 
-#: ../../New-or-Enhanced-Logics.md:1941
+#: ../../New-or-Enhanced-Logics.md:1963
 msgid ""
 "[SOMEWARHEAD]                               ; WarheadType\n"
 "Crit.Chance=0.0                             ; floating point value, "
@@ -7167,7 +7238,7 @@ msgstr ""
 "[SOMETECHNO]                                ; TechnoType\n"
 "ImmuneToCrit=false                          ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1964
+#: ../../New-or-Enhanced-Logics.md:1986
 msgid ""
 "If you set `Crit.Warhead` to the same Warhead it is defined on, or create"
 " a chain of Warheads with it that loops back to the first one there is a "
@@ -7175,17 +7246,17 @@ msgid ""
 "afterwards."
 msgstr "如果你将 `Crit.Warhead` 设为定义暴击的弹头或者创建一个最终回到第一个弹头的循环那么游戏可能会陷入循环并随后卡死或崩溃。"
 
-#: ../../New-or-Enhanced-Logics.md:1967
+#: ../../New-or-Enhanced-Logics.md:1989
 msgid "Convert TechnoType on impact"
 msgstr "单位转换弹头"
 
-#: ../../New-or-Enhanced-Logics.md:1975
+#: ../../New-or-Enhanced-Logics.md:1997
 msgid ""
 "In example, this warhead would convert all affected owned and friendly "
 "`SOLDIERA` and `SOLDIERB` to `NEWSOLDIER`:"
 msgstr "例如这个弹头可以将所有被影响的己方和友方 `SOLDIERA` 和 `SOLDIERB` 转换为 `NEWSOLDIER`："
 
-#: ../../New-or-Enhanced-Logics.md:1976
+#: ../../New-or-Enhanced-Logics.md:1998
 msgid ""
 "[ExampleWH]\n"
 "Convert.From=SOLDIERA,SOLDIERB\n"
@@ -7197,7 +7268,7 @@ msgstr ""
 "Convert.To=NEWSOLDIER\n"
 "Convert.AffectedHouses=team\n"
 
-#: ../../New-or-Enhanced-Logics.md:1984
+#: ../../New-or-Enhanced-Logics.md:2006
 msgid ""
 "[SOMEWARHEAD]                   ; WarheadType\n"
 "ConvertN.From=                  ; List of TechnoTypes\n"
@@ -7223,11 +7294,11 @@ msgstr ""
 "Convert.AffectedHouses=all      ; List of Affected House Enumeration "
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 
-#: ../../New-or-Enhanced-Logics.md:2004
+#: ../../New-or-Enhanced-Logics.md:2026
 msgid "Custom Mind Control Animation"
 msgstr "自定义心灵控制动画"
 
-#: ../../New-or-Enhanced-Logics.md:2005
+#: ../../New-or-Enhanced-Logics.md:2027
 msgid ""
 "Allows Warheads to play custom `MindControl.Anim` which defaults to "
 "`[CombatDamage] -> ControlledAnimationType`."
@@ -7235,7 +7306,7 @@ msgstr ""
 "允许弹头播放自定义的 `MindControl.Anim`，默认值取自 `[CombatDamage] -> "
 "ControlledAnimationType`。"
 
-#: ../../New-or-Enhanced-Logics.md:2008
+#: ../../New-or-Enhanced-Logics.md:2030
 msgid ""
 "[SOMEWARHEAD]                         ; WarheadType\n"
 "MindControl.Anim=                     ; Animation, defaults to "
@@ -7245,15 +7316,15 @@ msgstr ""
 "MindControl.Anim=                     ; Animation, defaults to "
 "[CombatDamage] -> ControlledAnimationType\n"
 
-#: ../../New-or-Enhanced-Logics.md:2013
+#: ../../New-or-Enhanced-Logics.md:2035
 msgid "Custom 'SplashList' on Warheads"
 msgstr "自定义弹头水花"
 
-#: ../../New-or-Enhanced-Logics.md:2015
+#: ../../New-or-Enhanced-Logics.md:2037
 msgid "![image](_static/images/splashlist-01.gif)"
 msgstr "![image](_static/images/splashlist-01.gif)"
 
-#: ../../New-or-Enhanced-Logics.md:2016
+#: ../../New-or-Enhanced-Logics.md:2038
 msgid ""
 "Allows Warheads to play custom water splash animations. See vanilla's "
 "[Conventional](https://www.modenc.renegadeprojects.com/Conventional) "
@@ -7264,7 +7335,7 @@ msgstr ""
 "[Conventional](https://www.modenc.renegadeprojects.com/Conventional) "
 "系统。`SplashList.PickRandom` 可设置为 `true` 以从列表中随机选择一个动画。"
 
-#: ../../New-or-Enhanced-Logics.md:2019
+#: ../../New-or-Enhanced-Logics.md:2041
 msgid ""
 "[SOMEWARHEAD]                ; WarheadType\n"
 "SplashList=<none>            ; List of AnimationTypes\n"
@@ -7274,11 +7345,11 @@ msgstr ""
 "SplashList=<none>            ; List of AnimationTypes\n"
 "SplashList.PickRandom=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2025
+#: ../../New-or-Enhanced-Logics.md:2047
 msgid "Damage multiplier for different houses"
 msgstr "对不同所属方的伤害修正比"
 
-#: ../../New-or-Enhanced-Logics.md:2027
+#: ../../New-or-Enhanced-Logics.md:2049
 msgid ""
 "Warheads are now able to define the extra damage multiplier for owner "
 "house, ally houses and enemy houses. If the warhead's own "
@@ -7294,7 +7365,7 @@ msgstr ""
 "1.0。注意：`DamageAlliesMultiplier` 不会像 `AffectsAllies` "
 "那样影响己方单位。此外这个功能不会影响无视防御的伤害，例如 `Suicide` 等。"
 
-#: ../../New-or-Enhanced-Logics.md:2030
+#: ../../New-or-Enhanced-Logics.md:2052
 msgid ""
 "[CombatDamage]\n"
 "DamageOwnerMultiplier=1.0     ; floating point value\n"
@@ -7316,11 +7387,11 @@ msgstr ""
 "DamageAlliesMultiplier=       ; floating point value\n"
 "DamageEnemiesMultiplier=      ; floating point value\n"
 
-#: ../../New-or-Enhanced-Logics.md:2042
+#: ../../New-or-Enhanced-Logics.md:2064
 msgid "Detonate Warhead on all objects on map"
 msgstr "全图弹头"
 
-#: ../../New-or-Enhanced-Logics.md:2044
+#: ../../New-or-Enhanced-Logics.md:2066
 msgid ""
 "Setting `DetonateOnAllMapObjects` to true allows a Warhead that is "
 "detonated by a projectile (for an example, this excludes things like "
@@ -7338,7 +7409,7 @@ msgstr ""
 "`AirburstWeapon/ShrapnelWeapon`，无论其实际目标如何，都可以对当前地图上所有存在且没死的对象进行引爆，并可以对目标进行筛选。注意，这是在弹头引爆之前的瞬间完成的，因此"
 " `PreImpactAnim`（Ares 功能）可以显示。"
 
-#: ../../New-or-Enhanced-Logics.md:2045
+#: ../../New-or-Enhanced-Logics.md:2067
 msgid ""
 "`DetonateOnAllMapObjects.Full` customizes whether or not the Warhead is "
 "detonated fully on the targets (as part of a dummy weapon) or simply "
@@ -7347,7 +7418,7 @@ msgstr ""
 "`DetonateOnAllMapObjects.Full` "
 "自定义弹头是否在目标上完全引爆（作为虚拟武器的一部分）或者只能对所在区域造成杀伤并应用 Phobos 的弹头效果。"
 
-#: ../../New-or-Enhanced-Logics.md:2046
+#: ../../New-or-Enhanced-Logics.md:2068
 msgid ""
 "`DetonateOnAllMapObjects.AffectTargets` is used to filter which types of "
 "targets (TechnoTypes) are considered valid and must be set to a valid "
@@ -7360,7 +7431,7 @@ msgstr ""
 "时筛选哪些类型的目标（科技类型）可被视为有效。仅 `none`、`all`、`aircraft`、`buildings`、`infantry` 和"
 " `units` 是有效值。默认为 `none`，因为包含所有对象类型可能会影响性能。"
 
-#: ../../New-or-Enhanced-Logics.md:2047
+#: ../../New-or-Enhanced-Logics.md:2069
 msgid ""
 "`DetonateOnAllMapObjects.AffectHouses` is used to filter which houses "
 "targets can belong to be considered valid and must be set to a valid "
@@ -7371,7 +7442,7 @@ msgstr ""
 "`DetonateOnAllMapObjects.AffectHouses` 用于在非 `none` "
 "时筛选哪些所属方的目标可以被视为有效。仅适用于发射弹头的所属方已知的情况。默认为 `none`，因为包含所有所属方可能会影响性能。"
 
-#: ../../New-or-Enhanced-Logics.md:2048
+#: ../../New-or-Enhanced-Logics.md:2070
 msgid ""
 "`DetonateOnAllMapObjects.AffectTypes` can be used to list specific "
 "TechnoTypes to be considered as valid targets. If any valid TechnoTypes "
@@ -7384,13 +7455,13 @@ msgstr ""
 "`DetonateOnAllMapObjects.AffectTargets` 和 "
 "`DetonateOnAllMapObjects.AffectHouses` 的优先级高于此设置。"
 
-#: ../../New-or-Enhanced-Logics.md:2049
+#: ../../New-or-Enhanced-Logics.md:2071
 msgid ""
 "`DetonateOnAllMapObjects.IgnoreTypes` can be used to list specific "
 "TechnoTypes to be never considered as valid targets."
 msgstr "`DetonateOnAllMapObjects.IgnoreTypes` 可用于列出特定的科技类型不得作为目标。"
 
-#: ../../New-or-Enhanced-Logics.md:2050
+#: ../../New-or-Enhanced-Logics.md:2072
 msgid ""
 "`DetonateOnAllMapObjects.RequireVerses`, if set to true, only considers "
 "targets whose armor type the warhead has non-zero `Verses` value against "
@@ -7402,7 +7473,7 @@ msgstr ""
 "`Verses` 值的目标为有效。对于具有激活状态护盾的目标除非弹头拥有 "
 "`Shield.Penetrate=true`，否则使用护盾的护甲类型。在所有上述筛选之后进行检查。"
 
-#: ../../New-or-Enhanced-Logics.md:2053
+#: ../../New-or-Enhanced-Logics.md:2075
 msgid ""
 "[SOMEWARHEAD]                                ; WarheadType\n"
 "DetonateOnAllMapObjects=false                ; boolean\n"
@@ -7426,7 +7497,7 @@ msgstr ""
 "DetonateOnAllMapObjects.IgnoreTypes=         ; List of TechnoTypes\n"
 "DetonateOnAllMapObjects.RequireVerses=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2065
+#: ../../New-or-Enhanced-Logics.md:2087
 msgid ""
 "While this feature can provide better performance than a large "
 "`CellSpread` value, it still has potential to slow down the game, "
@@ -7437,17 +7508,17 @@ msgstr ""
 "虽然此功能比巨大的 `CellSpread` 值性能上好得多但它仍然可能减慢游戏速度。特别是与动画、AlphaImage 等共同使用时。建议 "
 "modder 谨慎使用并通过筛选语句进行限制。"
 
-#: ../../New-or-Enhanced-Logics.md:2068
+#: ../../New-or-Enhanced-Logics.md:2090
 msgid "Fire weapon when Warhead kills something"
 msgstr "击杀武器"
 
-#: ../../New-or-Enhanced-Logics.md:2070
+#: ../../New-or-Enhanced-Logics.md:2092
 msgid ""
 "`KillWeapon` will be fired at the target TechnoType's location once it's "
 "killed by this Warhead."
 msgstr "被此弹头击杀时目标单位会爆出 `KillWeapon` 指定的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:2071
+#: ../../New-or-Enhanced-Logics.md:2093
 msgid ""
 "`KillWeapon.OnFirer` will be fired at the attacker's location once the "
 "target TechnoType is killed by this Warhead. If the source of this "
@@ -7455,7 +7526,7 @@ msgid ""
 "fired."
 msgstr "如果可以追溯到弹头来自哪个单位，那么 `KillWeapon.OnFirer` 可以让武器发射在开火者的位置。如果追溯不到来源那么将不会发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2072
+#: ../../New-or-Enhanced-Logics.md:2094
 msgid ""
 "`KillWeapon.AffectsHouses` / `KillWeapon.OnFirer.AffectsHouses` and "
 "`KillWeapon.Affects` / `KillWeapon.OnFirer.Affects` can be used to filter"
@@ -7466,13 +7537,13 @@ msgstr ""
 "`KillWeapon.OnFirer.AffectsHouses`／`KillWeapon.OnFirer.Affects` "
 "分别用于筛选哪些所属方和哪些类型的目标可以触发 `KillWeapon` 与 `KillWeapon.OnFirer`。"
 
-#: ../../New-or-Enhanced-Logics.md:2073
+#: ../../New-or-Enhanced-Logics.md:2095
 msgid ""
 "If the source of this Warhead is not another TechnoType, `KillWeapon` "
 "will be fired regardless of the target's house or type."
 msgstr "如果这个弹头的来源不是另一个单位，发射 `KillWeapon` 将不受目标所属方或类型的限制。"
 
-#: ../../New-or-Enhanced-Logics.md:2074
+#: ../../New-or-Enhanced-Logics.md:2096
 msgid ""
 "If a TechnoType has `SuppressKillWeapons` set to true, it will not "
 "trigger `KillWeapon` or `KillWeapon.OnFirer` upon being killed. "
@@ -7483,7 +7554,7 @@ msgstr ""
 "`KillWeapon.OnFirer`。`SuppressKillWeapons.Types` "
 "可用于列出受影响的武器类型，如果没有列出，则所有武器类型都受影响。"
 
-#: ../../New-or-Enhanced-Logics.md:2077
+#: ../../New-or-Enhanced-Logics.md:2099
 msgid ""
 "[SOMEWARHEAD]                         ; WarheadType\n"
 "KillWeapon=                           ; WeaponType\n"
@@ -7517,11 +7588,11 @@ msgstr ""
 "SuppressKillWeapons=false             ; boolean\n"
 "SuppressKillWeapons.Types=            ; List of WeaponTypes\n"
 
-#: ../../New-or-Enhanced-Logics.md:2091
+#: ../../New-or-Enhanced-Logics.md:2113
 msgid "Generate credits on impact"
 msgstr "撒币枪（弹）"
 
-#: ../../New-or-Enhanced-Logics.md:2093
+#: ../../New-or-Enhanced-Logics.md:2115
 msgid ""
 "![image](_static/images/hackerfinallyworks-01.gif) *`TransactMoney` used "
 "in [Rise of the East](https://www.moddb.com/mods/riseoftheeast)*"
@@ -7529,18 +7600,18 @@ msgstr ""
 "![image](_static/images/hackerfinallyworks-01.gif) "
 "*[东方崛起](https://www.moddb.com/mods/riseoftheeast) 中的 `TransactMoney` 应用*"
 
-#: ../../New-or-Enhanced-Logics.md:2096
+#: ../../New-or-Enhanced-Logics.md:2118
 msgid "Warheads can now give credits to its owner at impact."
 msgstr "现在弹头可以在爆炸时向其所有者撒币。"
 
-#: ../../New-or-Enhanced-Logics.md:2097
+#: ../../New-or-Enhanced-Logics.md:2119
 msgid ""
 "`TransactMoney.Display` can be set to display the amount of credits given"
 " or deducted. The number is displayed in green if given, red if deducted "
 "and will move upwards after appearing."
 msgstr "`TransactMoney.Display` 可以设置是否显示给予或扣除的资金金额。给予时数字显示为绿色，扣除时显示为红色，并在出现后向上飘起。"
 
-#: ../../New-or-Enhanced-Logics.md:2098
+#: ../../New-or-Enhanced-Logics.md:2120
 msgid ""
 "`TransactMoney.Display.AtFirer` if set, makes the credits display appear "
 "on firer instead of target. If set and firer is not known, it will "
@@ -7549,19 +7620,19 @@ msgstr ""
 "`TransactMoney.Display.AtFirer` "
 "如果设置则使资金出现在开火者处而非目标处。如果设置但开火者未知则无论如何都显示在目标处。"
 
-#: ../../New-or-Enhanced-Logics.md:2099
+#: ../../New-or-Enhanced-Logics.md:2121
 msgid ""
 "`TransactMoney.Display.Houses` determines which houses can see the "
 "credits display."
 msgstr "`TransactMoney.Display.Houses` 决定哪些所属方可以看到资金显示。"
 
-#: ../../New-or-Enhanced-Logics.md:2100
+#: ../../New-or-Enhanced-Logics.md:2122
 msgid ""
 "`TransactMoney.Display.Offset` is additional pixel offset for the center "
 "of the credits display, by default `0,0` at target's/firer's center."
 msgstr "`TransactMoney.Display.Offset` 是资金显示中心的额外像素偏移量，默认为 `0,0` 即目标／开火者的中心。"
 
-#: ../../New-or-Enhanced-Logics.md:2103
+#: ../../New-or-Enhanced-Logics.md:2125
 msgid ""
 "[SOMEWARHEAD]                        ; WarheadType\n"
 "TransactMoney=0                      ; integer - credits added or "
@@ -7581,11 +7652,11 @@ msgstr ""
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "TransactMoney.Display.Offset=0,0     ; X,Y, pixels relative to default\n"
 
-#: ../../New-or-Enhanced-Logics.md:2112
+#: ../../New-or-Enhanced-Logics.md:2134
 msgid "Iron Curtain & Force Shield damage penetration"
 msgstr "铁幕与力场护盾的伤害穿透"
 
-#: ../../New-or-Enhanced-Logics.md:2114
+#: ../../New-or-Enhanced-Logics.md:2136
 msgid ""
 "It is now possible to have Warhead be able to deal damage to Iron "
 "Curtained and/or Force Shielded objects. `PenetratesForceShield` defaults"
@@ -7594,7 +7665,7 @@ msgstr ""
 "现在可以让弹头对被铁幕和／或力场护盾保护的对象造成伤害。`PenetratesForceShield` 默认为 "
 "`PenetratesIronCurtain` 的值。"
 
-#: ../../New-or-Enhanced-Logics.md:2115
+#: ../../New-or-Enhanced-Logics.md:2137
 msgid ""
 "Note that this does not affect any Warhead effects other than those "
 "adjacent to damage (e.g `Psychedelic`) and things like debris generation "
@@ -7604,7 +7675,7 @@ msgstr ""
 "注意这不会影响关联伤害类效果（例如 `Psychedelic`）之外的弹头功能以及类似碎片生成和 `AirburstWeapon` "
 "的引爆这类通常在攻击被抵消时**本就**不发生的效果。"
 
-#: ../../New-or-Enhanced-Logics.md:2118
+#: ../../New-or-Enhanced-Logics.md:2140
 msgid ""
 "[SOMEWARHEAD]                ; WarheadType\n"
 "PenetratesIronCurtain=false  ; boolean\n"
@@ -7614,29 +7685,29 @@ msgstr ""
 "PenetratesIronCurtain=false  ; boolean\n"
 "PenetratesForceShield=       ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2124
+#: ../../New-or-Enhanced-Logics.md:2146
 msgid "Launch superweapons on impact"
 msgstr "发射超武"
 
-#: ../../New-or-Enhanced-Logics.md:2126
+#: ../../New-or-Enhanced-Logics.md:2148
 msgid "Superweapons can now be launched when a warhead is detonated."
 msgstr "现在弹头可以在引爆时发射超级武器"
 
-#: ../../New-or-Enhanced-Logics.md:2127
+#: ../../New-or-Enhanced-Logics.md:2149
 msgid ""
 "`LaunchSW` specifies the superweapons to launch when the warhead is "
 "detonated. If superweapon has negative `Money.Amount`, the firing house "
 "must have enough credits in order for it to be fired."
 msgstr "`LaunchSW` 指定当弹头引爆时要发射的超级武器。如果超级武器的 `Money.Amount` 为负则发射的所属方还需要拥有足够的资金。"
 
-#: ../../New-or-Enhanced-Logics.md:2128
+#: ../../New-or-Enhanced-Logics.md:2150
 msgid ""
 "`LaunchSW.RealLaunch` controls whether the owner who fired the warhead "
 "must own all listed superweapons. Otherwise they will be launched out of "
 "nowhere."
 msgstr "`LaunchSW.RealLaunch` 控制弹头的所有者是否需要拥有所有列出的超级武器。否则它们将无从发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2129
+#: ../../New-or-Enhanced-Logics.md:2151
 msgid ""
 "`LaunchSW.IgnoreInhibitors` ignores `SW.Inhibitors`/`SW.AnyInhibitor` of "
 "each superweapon, otherwise only non-inhibited superweapons are launched."
@@ -7644,7 +7715,7 @@ msgstr ""
 "`LaunchSW.IgnoreInhibitors` 设置是否忽略每个超级武器的 "
 "`SW.Inhibitors`／`SW.AnyInhibitor`，否则只有未被抑制的超级武器会被发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2130
+#: ../../New-or-Enhanced-Logics.md:2152
 msgid ""
 "`LaunchSW.IgnoreDesignators` ignores `SW.Designators` / "
 "`SW.AnyDesignator` respectively."
@@ -7652,7 +7723,7 @@ msgstr ""
 "`LaunchSW.IgnoreDesignators` 设置是否忽略每个超级武器的 "
 "`SW.Designators`／`SW.AnyDesignator`。"
 
-#: ../../New-or-Enhanced-Logics.md:2131
+#: ../../New-or-Enhanced-Logics.md:2153
 msgid ""
 "`LaunchSW.DisplayMoney` can be set to display the amount of credits given"
 " or deducted by the launched superweapon by `Money.Amount`. The number is"
@@ -7662,37 +7733,37 @@ msgstr ""
 "`LaunchSW.DisplayMoney` 可以设置是否显示所发射超武 `Money.Amount` "
 "而给予或扣除的资金金额。给予时数字显示为绿色，扣除时显示为红色，并在出现后向上飘起。"
 
-#: ../../New-or-Enhanced-Logics.md:2132
+#: ../../New-or-Enhanced-Logics.md:2154
 msgid ""
 "`LaunchSW.DisplayMoney.Houses` determines which houses can see the "
 "credits display."
 msgstr "`LaunchSW.DisplayMoney.Houses` 决定哪些所属方可以看到资金显示。"
 
-#: ../../New-or-Enhanced-Logics.md:2133
+#: ../../New-or-Enhanced-Logics.md:2155
 msgid ""
 "`LaunchSW.DisplayMoney.Offset` is additional pixel offset for the center "
 "of the credits display, by default `0,0` at superweapon's target cell."
 msgstr "`LaunchSW.DisplayMoney.Offset` 是资金显示中心的额外像素偏移量，默认为 `0,0` 即超级武器目标单元格处。"
 
-#: ../../New-or-Enhanced-Logics.md:2136
+#: ../../New-or-Enhanced-Logics.md:2158
 msgid ""
 "For animation warheads/weapons to take effect, `Damage.DealtByInvoker` "
 "must be set."
 msgstr "为使动画弹头／武器上的此逻辑生效必须设置 `Damage.DealtByInvoker`。"
 
-#: ../../New-or-Enhanced-Logics.md:2138
+#: ../../New-or-Enhanced-Logics.md:2160
 msgid ""
 "Due to the nature of some superweapon types, not all superweapons are "
 "suitable for launch. **Please use with caution!**"
 msgstr "由于某些超级武器类型的特性并非所有超级武器都适合发射。**请慎用！**"
 
-#: ../../New-or-Enhanced-Logics.md:2140
+#: ../../New-or-Enhanced-Logics.md:2162
 msgid ""
 "The superweapons are launched on the *cell* where the warhead is "
 "detonated, instead of being click-fired."
 msgstr "超级武器在弹头引爆的 **单元格** 上发射而不是通过点击发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2144
+#: ../../New-or-Enhanced-Logics.md:2166
 msgid ""
 "[SOMEWARHEAD]                     ; WarheadType\n"
 "LaunchSW=                         ; List of SuperWeaponTypes\n"
@@ -7714,11 +7785,11 @@ msgstr ""
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "LaunchSW.DisplayMoney.Offset=0,0  ; X,Y, pixels relative to default\n"
 
-#: ../../New-or-Enhanced-Logics.md:2155
+#: ../../New-or-Enhanced-Logics.md:2177
 msgid "Parasite removal"
 msgstr "移除寄生"
 
-#: ../../New-or-Enhanced-Logics.md:2157
+#: ../../New-or-Enhanced-Logics.md:2179
 msgid ""
 "By default if unit takes negative damage from a Warhead (before `Verses` "
 "are calculated), any parasites infecting it are removed and deleted. This"
@@ -7728,7 +7799,7 @@ msgstr ""
 "默认情况下如果单位从弹头收到负伤害（在 `Verses` "
 "前计算）任何寄生单位都会被移除和删除。现在可以自定义此行为以禁用负伤害的移除效果或为任意弹头启用它。"
 
-#: ../../New-or-Enhanced-Logics.md:2160
+#: ../../New-or-Enhanced-Logics.md:2182
 msgid ""
 "[SOMEWARHEAD]     ; WarheadType\n"
 "RemoveParasite=   ; boolean\n"
@@ -7736,18 +7807,18 @@ msgstr ""
 "[SOMEWARHEAD]     ; WarheadType\n"
 "RemoveParasite=   ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2165
+#: ../../New-or-Enhanced-Logics.md:2187
 msgid "Remove disguise on impact"
 msgstr "移除伪装"
 
-#: ../../New-or-Enhanced-Logics.md:2167
+#: ../../New-or-Enhanced-Logics.md:2189
 msgid ""
 "Warheads can now remove disguise from disguised spies or mirage tanks. "
 "This will work even if the disguised was acquired by default through "
 "`PermaDisguise`."
 msgstr "弹头现在可以移除间谍或幻影坦克的伪装。即使伪装是通过 `PermaDisguise` 默认获得来的。"
 
-#: ../../New-or-Enhanced-Logics.md:2170
+#: ../../New-or-Enhanced-Logics.md:2192
 msgid ""
 "[SOMEWARHEAD]         ; WarheadType\n"
 "RemoveDisguise=false  ; boolean\n"
@@ -7755,19 +7826,19 @@ msgstr ""
 "[SOMEWARHEAD]         ; WarheadType\n"
 "RemoveDisguise=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2175
+#: ../../New-or-Enhanced-Logics.md:2197
 msgid "Reveal map for owner on impact"
 msgstr "揭示弹"
 
-#: ../../New-or-Enhanced-Logics.md:2177
+#: ../../New-or-Enhanced-Logics.md:2199
 msgid "Warheads can now reveal an area or the entire map on impact."
 msgstr "现在弹头可以在引爆时揭示部分区域或整个地图的黑幕。"
 
-#: ../../New-or-Enhanced-Logics.md:2178
+#: ../../New-or-Enhanced-Logics.md:2200
 msgid "Reveal only applies to the owner of the warhead."
 msgstr "仅适用于弹头所有者。"
 
-#: ../../New-or-Enhanced-Logics.md:2181
+#: ../../New-or-Enhanced-Logics.md:2203
 msgid ""
 "[SOMEWARHEAD]  ; WarheadType\n"
 "Reveal=0       ; integer - cell radius, negative values mean reveal the "
@@ -7777,29 +7848,29 @@ msgstr ""
 "Reveal=0       ; integer - cell radius, negative values mean reveal the "
 "entire map\n"
 
-#: ../../New-or-Enhanced-Logics.md:2186
+#: ../../New-or-Enhanced-Logics.md:2208
 msgid "Sell or undeploy building on impact"
 msgstr "将建筑出售或反部署"
 
-#: ../../New-or-Enhanced-Logics.md:2188
+#: ../../New-or-Enhanced-Logics.md:2210
 msgid ""
 "Warheads with `BuildingSell` can now sell buildings with build up image. "
 "It has a higher priority than `BuildingUndeploy`."
 msgstr "现在拥有 `BuildingSell` 的弹头可以出售拥有拔起动画的建筑。它的优先级高于 `BuildingUndeploy`。"
 
-#: ../../New-or-Enhanced-Logics.md:2189
+#: ../../New-or-Enhanced-Logics.md:2211
 msgid ""
 "`BuildingSell.IgnoreUnsellable` controls whether to ignore all possible "
 "situations where sales may be disabled except for build up image."
 msgstr "`BuildingSell.IgnoreUnsellable` 控制是否忽略除了缺失拔起动画之外所有可能禁止建筑出售的情况。"
 
-#: ../../New-or-Enhanced-Logics.md:2190
+#: ../../New-or-Enhanced-Logics.md:2212
 msgid ""
 "Warheads with `BuildingUndeploy` can now undeploy buildings with "
 "`UndeploysInto`."
 msgstr "现在拥有 `BuildingUndeploy` 的弹头可以令目标建筑反部署为 `UndeploysInto` 的对象。"
 
-#: ../../New-or-Enhanced-Logics.md:2191
+#: ../../New-or-Enhanced-Logics.md:2213
 msgid ""
 "`BuildingUndeploy.Leave` controls whether need to let them move to low "
 "threat locations nearby. The threat degree here is calculated using the "
@@ -7809,7 +7880,7 @@ msgstr ""
 "`BuildingUndeploy.Leave` "
 "控制是否需要让它们移动到附近较低威胁的位置。这里的威胁程度使用科技类型的价格计算。如果附近的科技类型没有主武器或属于友方所属，那么不被计入。"
 
-#: ../../New-or-Enhanced-Logics.md:2194
+#: ../../New-or-Enhanced-Logics.md:2216
 msgid ""
 "[SOMEWARHEAD]                        ; WarheadType\n"
 "BuildingSell=false                   ; boolean\n"
@@ -7823,19 +7894,19 @@ msgstr ""
 "BuildingUndeploy=false               ; boolean\n"
 "BuildingUndeploy.Leave=false         ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2202
+#: ../../New-or-Enhanced-Logics.md:2224
 msgid "Shroud map for enemies on impact"
 msgstr "黑幕弹"
 
-#: ../../New-or-Enhanced-Logics.md:2204
+#: ../../New-or-Enhanced-Logics.md:2226
 msgid "Warheads can now shroud an area or the entire map on impact."
 msgstr "现在弹头可以在引爆时填充部分区域或整个地图的黑幕"
 
-#: ../../New-or-Enhanced-Logics.md:2205
+#: ../../New-or-Enhanced-Logics.md:2227
 msgid "Shroud only applies to enemies of the warhead owner."
 msgstr "仅适用于敌对所属方。"
 
-#: ../../New-or-Enhanced-Logics.md:2208
+#: ../../New-or-Enhanced-Logics.md:2230
 msgid ""
 "[SOMEWARHEAD]  ; WarheadType\n"
 "CreateGap=0    ; integer - cell radius, negative values mean shroud the "
@@ -7845,11 +7916,11 @@ msgstr ""
 "CreateGap=0    ; integer - cell radius, negative values mean shroud the "
 "entire map\n"
 
-#: ../../New-or-Enhanced-Logics.md:2213
+#: ../../New-or-Enhanced-Logics.md:2235
 msgid "Spawn powerup crate"
 msgstr "生成工具箱"
 
-#: ../../New-or-Enhanced-Logics.md:2215
+#: ../../New-or-Enhanced-Logics.md:2237
 msgid ""
 "Warheads can now spawn powerup crates of specified type(s) on their "
 "impact cells (if free, or nearby cells if occupied something other than a"
@@ -7858,13 +7929,13 @@ msgstr ""
 "现在弹头可以在其引爆的单元格上创建指定类型的升级工具箱（如果空置，若被非工具箱的对象占据则生成到附近的单元格）类似于地图触发动作 `108 "
 "创建工具箱...`。"
 
-#: ../../New-or-Enhanced-Logics.md:2216
+#: ../../New-or-Enhanced-Logics.md:2238
 msgid ""
 "`SpawnsCrateN` where N is a number starting from 0, parsed until no key "
 "is found can be used to define the type of crate spawned."
 msgstr "`SpawnsCrateN` 中的 N 是从 0 开始的数字，游戏会解析到最后一个为止。用于定义每个生成的升级工具箱类型。"
 
-#: ../../New-or-Enhanced-Logics.md:2217
+#: ../../New-or-Enhanced-Logics.md:2239
 msgid ""
 "`SpawnsCrateN.Weight` is a number that determines relative weighting of "
 "spawning corresponding crate type vs. other listed ones (0 is no chance, "
@@ -7873,13 +7944,13 @@ msgstr ""
 "`SpawnsCrateN.Weight` 是一个用于确定生成对应升级工具箱类型与其他列出的类型相比的相对权重（0 "
 "表示没门，越高代表概率越高）如果未定义则默认为 1。"
 
-#: ../../New-or-Enhanced-Logics.md:2218
+#: ../../New-or-Enhanced-Logics.md:2240
 msgid ""
 "`SpawnsCrate.Type/Weight` is an alias for `SpawnsCrate0.Type/Weight` if "
 "latter is not set."
 msgstr "如果未设置 `SpawnsCrate0.Type/Weight` 则 `SpawnsCrate.Type/Weight` 是其别名。"
 
-#: ../../New-or-Enhanced-Logics.md:2221
+#: ../../New-or-Enhanced-Logics.md:2243
 msgid ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "SpawnsCrate(N).Type=     ; Powerup crate type enum "
@@ -7893,18 +7964,18 @@ msgstr ""
 "\n"
 "SpawnsCrate(N).Weight=1  ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:2227
+#: ../../New-or-Enhanced-Logics.md:2249
 msgid "Trigger specific NotHuman infantry Death anim sequence"
 msgstr "指定非人步兵死亡序列"
 
-#: ../../New-or-Enhanced-Logics.md:2229
+#: ../../New-or-Enhanced-Logics.md:2251
 msgid ""
 "Warheads are now able to trigger specific `NotHuman=yes` infantry `Death`"
 " anim sequence using the corresponding tag. It's value represents "
 "sequences from `Die1` to `Die5`."
 msgstr "现在弹头可以使用相应的标签触发特定的 `NotHuman=yes` 步兵 `Death` 动画序列。其值代表从 `Die1` 到 `Die5`。"
 
-#: ../../New-or-Enhanced-Logics.md:2232
+#: ../../New-or-Enhanced-Logics.md:2254
 msgid ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "NotHuman.DeathSequence=  ; integer (1 to 5)\n"
@@ -7912,15 +7983,15 @@ msgstr ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "NotHuman.DeathSequence=  ; integer (1 to 5)\n"
 
-#: ../../New-or-Enhanced-Logics.md:2237
+#: ../../New-or-Enhanced-Logics.md:2259
 msgid "Weapons"
 msgstr "武器"
 
-#: ../../New-or-Enhanced-Logics.md:2239
+#: ../../New-or-Enhanced-Logics.md:2261
 msgid "AreaFire target customization"
 msgstr "自定义 `AreaFire` 目标"
 
-#: ../../New-or-Enhanced-Logics.md:2241
+#: ../../New-or-Enhanced-Logics.md:2263
 msgid ""
 "You can now specify how AreaFire weapon picks its target. By default it "
 "targets the base cell the firer is currently on, but this can now be "
@@ -7931,13 +8002,13 @@ msgstr ""
 "现在你可以指定 AreaFire 武器如何选择目标。默认情况下它会瞄准开火者当前所处的单元格，现在可以通过将 `AreaFire.Target` "
 "设为 `self` 或 `random` 分别改为瞄准发开火者自身或武器 `Range` 范围内的随机单元格。"
 
-#: ../../New-or-Enhanced-Logics.md:2242
+#: ../../New-or-Enhanced-Logics.md:2264
 msgid ""
 "`AreaFire.Target=self` respects normal targeting rules (Warhead `Verses` "
 "etc.) against the firer itself."
 msgstr "`AreaFire.Target=self` 遵守对开火者自身的正常目标筛选规则（弹头 `Verses` 等）。"
 
-#: ../../New-or-Enhanced-Logics.md:2243
+#: ../../New-or-Enhanced-Logics.md:2265
 msgid ""
 "`AreaFire.Target=random` ignores cells that are ineligible or contain "
 "ineligible objects based on listed values in weapon's `CanTarget` & "
@@ -7946,7 +8017,7 @@ msgstr ""
 "`AreaFire.Target=random` 会忽略由武器 `CanTarget` 和 `CanTargetHouses` "
 "值设为不可作为目标的单元格或存在不可作为目标的对象的单元格。"
 
-#: ../../New-or-Enhanced-Logics.md:2246
+#: ../../New-or-Enhanced-Logics.md:2268
 msgid ""
 "[SOMEWEAPON]         ; WeaponType\n"
 "AreaFire.Target=base ; AreaFire Target Enumeration (base|self|random)\n"
@@ -7954,11 +8025,11 @@ msgstr ""
 "[SOMEWEAPON]         ; WeaponType\n"
 "AreaFire.Target=base ; AreaFire Target Enumeration (base|self|random)\n"
 
-#: ../../New-or-Enhanced-Logics.md:2251
+#: ../../New-or-Enhanced-Logics.md:2273
 msgid "Burst delay customizations"
 msgstr "自定义 BurstDelay"
 
-#: ../../New-or-Enhanced-Logics.md:2253
+#: ../../New-or-Enhanced-Logics.md:2275
 msgid ""
 "`Burst.Delays` allows specifying weapon-specific burst shot delays. Takes"
 " precedence over the old `BurstDelayX` logic available on VehicleTypes, "
@@ -7971,7 +8042,7 @@ msgstr ""
 "逻辑，且适用于步兵和建筑类型的武器（由于战机类型武器的发射系统完全不同因此暂不支持），并允许独立设置每一发 `Burst` 之间的间隔而不仅限于第"
 " 1 发到第 4 发。"
 
-#: ../../New-or-Enhanced-Logics.md:2254
+#: ../../New-or-Enhanced-Logics.md:2276
 msgid ""
 "If no delay is defined for a shot, it falls back to last delay value "
 "defined (f.ex `Burst=3` and `Burst.Delays=10` would use 10 as delay for "
@@ -7980,14 +8051,14 @@ msgstr ""
 "如果未未某一发设定间隔那么它会使用上一发所定义的间隔（例如 `Burst=3` 和 `Burst.Delays=10` 将使用 10 "
 "作为所有连发的间隔）。"
 
-#: ../../New-or-Enhanced-Logics.md:2255
+#: ../../New-or-Enhanced-Logics.md:2277
 msgid ""
 "Using `-1` as delay reverts back to old logic (`BurstDelay0-3` for "
 "VehicleTypes if available or random value between 3-5 otherwise) for that"
 " shot."
 msgstr "使用 `-1` 作为间隔会使该发使用旧逻辑（如果有则使用载具类型的 `BurstDelay0-3` 否则使用 3-5 之间的随机值）。"
 
-#: ../../New-or-Enhanced-Logics.md:2256
+#: ../../New-or-Enhanced-Logics.md:2278
 msgid ""
 "`Burst.FireWithinSequence` is only used if the weapon is fired by "
 "InfantryType or `Voxel=no` turretless VehicleType, and setting it to true"
@@ -7997,13 +8068,13 @@ msgstr ""
 "`Burst.FireWithinSequence` 仅在步兵或 `Voxel=no` 的无炮塔载具发射武器时使用，将其设为 true "
 "以允许步兵/载具在同一射击序列内射出多发 `Burst`。"
 
-#: ../../New-or-Enhanced-Logics.md:2257
+#: ../../New-or-Enhanced-Logics.md:2279
 msgid ""
 "First shot is always fired at sequence frame determined by firing frame "
 "controls on InfantryType image (`FireUp` et al)."
 msgstr "第一发始终在由步兵类型图像的射击帧（如 `FireUp` 等）确定的帧序列决定。"
 
-#: ../../New-or-Enhanced-Logics.md:2258
+#: ../../New-or-Enhanced-Logics.md:2280
 msgid ""
 "Following shots come at intervals determined by `Burst.Delays` (with "
 "minimum delay of 1 frame) or random delay between 3 to 5 frames if not "
@@ -8014,7 +8085,7 @@ msgstr ""
 "后续的连发发射间隔由 `Burst.Delays` 决定（最小间隔为 1 帧）或未定义情况下使用随机 3 到 5 "
 "帧。注意如果下一发的发射帧超出了射击序列长度则连发计数器将被重置且武器会重新开始装填。"
 
-#: ../../New-or-Enhanced-Logics.md:2259
+#: ../../New-or-Enhanced-Logics.md:2281
 msgid ""
 "Burst shot counter is not immediately reset if firing is ceased mid-"
 "sequence after at least one shot, but the frame at which each burst shot "
@@ -8024,7 +8095,7 @@ msgid ""
 "burst shot should be fired is hit)."
 msgstr "如果在至少一发后停止射击则连发计数器不会立即重置，但每个连发的发射帧不会受此影响（换而言之，如果之后重新开始射击而武器没有重新装填，那么射击序列会重新开始，但不会发射任何直到下一发应该被发射的帧）。"
 
-#: ../../New-or-Enhanced-Logics.md:2262
+#: ../../New-or-Enhanced-Logics.md:2284
 msgid ""
 "[SOMEWEAPON]                    ; WeaponType\n"
 "Burst.Delays=-1                 ; integer - burst delays (comma-"
@@ -8036,11 +8107,11 @@ msgstr ""
 "separated) for shots in order from first to last.\n"
 "Burst.FireWithinSequence=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2268
+#: ../../New-or-Enhanced-Logics.md:2290
 msgid "Extra warhead detonations"
 msgstr "额外弹头"
 
-#: ../../New-or-Enhanced-Logics.md:2270
+#: ../../New-or-Enhanced-Logics.md:2292
 msgid ""
 "It is now possible to have same weapon detonate multiple Warheads on "
 "impact by listing `ExtraWarheads`. The warheads are detonated at same "
@@ -8053,7 +8124,7 @@ msgstr ""
 "来让同一武器在命中时引爆多个弹头。这些弹头会在主弹头爆炸后按列出的顺序在同一位置引爆。这仅适用于由武器发射且引爆时仍保留其信息的抛射体（由于目前存在的技术限制，这不包括"
 " `AirburstWeapon`）。"
 
-#: ../../New-or-Enhanced-Logics.md:2271
+#: ../../New-or-Enhanced-Logics.md:2293
 msgid ""
 "`ExtraWarheads.DamageOverrides` can be used to override the weapon's "
 "`Damage` for the extra Warhead detonations. Value from position matching "
@@ -8063,7 +8134,7 @@ msgstr ""
 "`ExtraWarheads.DamageOverrides` 可用于额外弹头引爆时覆盖武器的 `Damage` 属性。如果找到 "
 "`ExtraWarheads` 中与之对应的值则使用，否则使用最后列出的值。如果列表为空则使用武器的 `Damage` 属性。"
 
-#: ../../New-or-Enhanced-Logics.md:2272
+#: ../../New-or-Enhanced-Logics.md:2294
 msgid ""
 "`ExtraWarheads.DetonationChances` can be used to customize the chance of "
 "each extra Warhead detonation occuring. Value from position matching the "
@@ -8074,7 +8145,7 @@ msgstr ""
 "`ExtraWarheads.DetonationChances` 可用于自定义每个额外弹头爆炸的概率。如果找到 `ExtraWarheads` "
 "中与之对应的值则使用，否则使用最后列出的值。如果列表为空则每个额外弹头都必然引爆。"
 
-#: ../../New-or-Enhanced-Logics.md:2273
+#: ../../New-or-Enhanced-Logics.md:2295
 msgid ""
 "`ExtraWarheads.FullDetonation` can be used to customize whether or not "
 "each individual Warhead is detonated fully (as part of a dummy weapon) or"
@@ -8086,13 +8157,13 @@ msgstr ""
 "可用于设置每个额外弹头是否在目标上完全引爆（作为虚拟武器的一部分）或者只能对所在区域造成杀伤并应用 Phobos 的弹头效果。如果找到 "
 "`ExtraWarheads` 中与之对应的值则使用，否则使用最后列出的值。如果列表为空则默认为 true。"
 
-#: ../../New-or-Enhanced-Logics.md:2274
+#: ../../New-or-Enhanced-Logics.md:2296
 msgid ""
 "Note that the listed Warheads must be listed in `[Warheads]` for them to "
 "work."
 msgstr "注意列出的弹头必须在 `[Warheads]` 中列出才能生效。"
 
-#: ../../New-or-Enhanced-Logics.md:2277
+#: ../../New-or-Enhanced-Logics.md:2299
 msgid ""
 "[SOMEWEAPON]                      ; WeaponType\n"
 "ExtraWarheads=                    ; List of WarheadTypes\n"
@@ -8108,11 +8179,11 @@ msgstr ""
 "(percentage or absolute)\n"
 "ExtraWarheads.FullDetonation=     ; List of booleans\n"
 
-#: ../../New-or-Enhanced-Logics.md:2285
+#: ../../New-or-Enhanced-Logics.md:2307
 msgid "Feedback weapon"
 msgstr "反馈武器"
 
-#: ../../New-or-Enhanced-Logics.md:2287
+#: ../../New-or-Enhanced-Logics.md:2309
 msgid ""
 "![image](_static/images/feedbackweapon.gif) *`FeedbackWeapon` used to "
 "apply healing aura upon firing a weapon in [Project "
@@ -8122,13 +8193,13 @@ msgstr ""
 "*[幽灵计划](https://www.moddb.com/mods/project-phantom) "
 "中使用反馈武器在发射武器时对目标施加治疗光环*"
 
-#: ../../New-or-Enhanced-Logics.md:2290
+#: ../../New-or-Enhanced-Logics.md:2312
 msgid ""
 "You can now specify an auxiliary weapon to be fired on the firer itself "
 "when a weapon is fired."
 msgstr "现在你可以指定一个辅助武器在发射武器时对开火者自身发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2291
+#: ../../New-or-Enhanced-Logics.md:2313
 msgid ""
 "`FireInTransport` setting of the feedback weapon is respected to "
 "determine if it can be fired when the original weapon is fired from "
@@ -8139,7 +8210,7 @@ msgstr ""
 "当原始武器于运输工具内的载员使用时反馈武器会根据自身的 `FireInTransport` "
 "决定能否发射。如果反馈武器被发射那么它将命中运输工具。注：`OpenToppedDamageMultiplier` 不适用于反馈武器。"
 
-#: ../../New-or-Enhanced-Logics.md:2294
+#: ../../New-or-Enhanced-Logics.md:2316
 msgid ""
 "[SOMEWEAPON]     ; WeaponType\n"
 "FeedbackWeapon=  ; WeaponType\n"
@@ -8147,17 +8218,17 @@ msgstr ""
 "[SOMEWEAPON]     ; WeaponType\n"
 "FeedbackWeapon=  ; WeaponType\n"
 
-#: ../../New-or-Enhanced-Logics.md:2299
+#: ../../New-or-Enhanced-Logics.md:2321
 msgid "Keep Range After Firing"
 msgstr "开火后保持距离"
 
-#: ../../New-or-Enhanced-Logics.md:2301
+#: ../../New-or-Enhanced-Logics.md:2323
 msgid ""
 "Technos can maintain a suitable distance after firing if `KeepRange` is "
 "not set to 0."
 msgstr "如果 `KeepRange` 没有设为 0 那么科技类型可以在开火后与目标保持适当的距离。"
 
-#: ../../New-or-Enhanced-Logics.md:2302
+#: ../../New-or-Enhanced-Logics.md:2324
 msgid ""
 "`KeepRange` controls how long the distance to maintain when the techno's "
 "ROF timer is ticking. What is actually read is its absolute value. If it "
@@ -8172,19 +8243,19 @@ msgstr ""
 "`MinimumRange`。对于负值则科技类型会尽可能保持在该距离附近，就像它有一个开火后的特殊 "
 "`Range`。此外如果有效射程区间太小单位将被视为无法开火。最好有一个 1.0 长度的有效射程，对步兵而言为 2.0。"
 
-#: ../../New-or-Enhanced-Logics.md:2303
+#: ../../New-or-Enhanced-Logics.md:2325
 msgid ""
 "`KeepRange.AllowAI` controls whether this function is effective for "
 "computer."
 msgstr "`KeepRange.AllowAI` 控制此功能是否对 AI 玩家生效。"
 
-#: ../../New-or-Enhanced-Logics.md:2304
+#: ../../New-or-Enhanced-Logics.md:2326
 msgid ""
 "`KeepRange.AllowPlayer` controls whether this function is effective for "
 "human."
 msgstr "`KeepRange.AllowPlayer` 控制此功能是否对人类玩家生效。"
 
-#: ../../New-or-Enhanced-Logics.md:2307
+#: ../../New-or-Enhanced-Logics.md:2329
 msgid ""
 "[SOMEWEAPON]                 ; WeaponType\n"
 "KeepRange=0                  ; floating point value\n"
@@ -8196,23 +8267,23 @@ msgstr ""
 "KeepRange.AllowAI=false      ; boolean\n"
 "KeepRange.AllowPlayer=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2314
+#: ../../New-or-Enhanced-Logics.md:2336
 msgid "Make units try turning to target when firing with `OmniFire=yes`"
 msgstr "`OmniFire=yes` 下转向"
 
-#: ../../New-or-Enhanced-Logics.md:2316
+#: ../../New-or-Enhanced-Logics.md:2338
 msgid ""
 "The unit will try to turn the body to target even firing with "
 "`OmniFire=yes`."
 msgstr "即便使用 `OmniFire=yes` 的武器开火单位也会尝试将车体转向目标。"
 
-#: ../../New-or-Enhanced-Logics.md:2317
+#: ../../New-or-Enhanced-Logics.md:2339
 msgid ""
 "Jumpjets are recommended to have the same value of body `ROT` and "
 "`JumpjetTurnRate`."
 msgstr "建议 Jumpjet 的 `ROT` 和 `JumpjetTurnRate` 相同。"
 
-#: ../../New-or-Enhanced-Logics.md:2320
+#: ../../New-or-Enhanced-Logics.md:2342
 msgid ""
 "[SOMEWEAPON]              ; WeaponType\n"
 "OmniFire=yes\n"
@@ -8222,11 +8293,11 @@ msgstr ""
 "OmniFire=yes\n"
 "OmniFire.TurnToTarget=no  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2326
+#: ../../New-or-Enhanced-Logics.md:2348
 msgid "Radiation enhancements"
 msgstr "辐射增强"
 
-#: ../../New-or-Enhanced-Logics.md:2328
+#: ../../New-or-Enhanced-Logics.md:2350
 msgid ""
 "In addition to allowing custom radiation types, several enhancements are "
 "also available to the default radiation type defined in `[Radiation]`, "
@@ -8236,11 +8307,11 @@ msgstr ""
 "除了允许自定义辐射类型外还有对于默认辐射类型 `[Radiation]` 的增强，例如可以设置所有者与开火者或对建筑造成伤害。详见[自定义辐射类型"
 "](#custom-radiation-types)。"
 
-#: ../../New-or-Enhanced-Logics.md:2330
+#: ../../New-or-Enhanced-Logics.md:2352
 msgid "Strafing aircraft weapon customization"
 msgstr "自定义战机扫射"
 
-#: ../../New-or-Enhanced-Logics.md:2332
+#: ../../New-or-Enhanced-Logics.md:2354
 msgid ""
 "![image](_static/images/strafing-01.gif) *Strafing aircraft weapon "
 "customization in [Project Phantom](https://www.moddb.com/mods/project-"
@@ -8249,11 +8320,11 @@ msgstr ""
 "![image](_static/images/strafing-01.gif) "
 "*[幽灵计划](https://www.moddb.com/mods/project-phantom) 中的自定义战机扫射武器*"
 
-#: ../../New-or-Enhanced-Logics.md:2335
+#: ../../New-or-Enhanced-Logics.md:2357
 msgid "Some of the behavior of strafing aircraft weapons can now be customized."
 msgstr "现在可以自定义战机扫射武器的一些行为。"
 
-#: ../../New-or-Enhanced-Logics.md:2336
+#: ../../New-or-Enhanced-Logics.md:2358
 msgid ""
 "`Strafing` controls if the aircraft can strafe when firing at the target."
 " Default to `true` if the projectile's `ROT` < 2 and `Inviso=false` "
@@ -8262,7 +8333,7 @@ msgstr ""
 "`Strafing` 控制战机在目标射击时是否可以扫射。如果抛射体 `ROT` < 2 且 `Inviso=false` 并且没有 "
 "`Trajectory` 则默认为 `true` 其他情况为 `false`。"
 
-#: ../../New-or-Enhanced-Logics.md:2337
+#: ../../New-or-Enhanced-Logics.md:2359
 msgid ""
 "`Strafing.Shots` controls the number of times the weapon is fired during "
 "a single strafe run, defaults to 5 if not set. `Ammo` is only deducted at"
@@ -8271,7 +8342,7 @@ msgstr ""
 "`Strafing.Shots` 控制在单词扫射过程中武器发射的次数，如果未设置则默认为 5。`Ammo` "
 "只会在扫射结束后扣除一次，无论实际多少次。"
 
-#: ../../New-or-Enhanced-Logics.md:2338
+#: ../../New-or-Enhanced-Logics.md:2360
 msgid ""
 "`Strafing.SimulateBurst` controls whether or not the shots fired during "
 "strafing simulate behavior of `Burst`, allowing for alternating firing "
@@ -8280,14 +8351,14 @@ msgstr ""
 "`Strafing.SimulateBurst` 控制在扫射过程中发射的武器是否模拟 `Burst` 的行为，即允许交替开火坐标。仅当武器 "
 "`Burst` 设置为 1 或未定义时才有效。"
 
-#: ../../New-or-Enhanced-Logics.md:2339
+#: ../../New-or-Enhanced-Logics.md:2361
 msgid ""
 "`Strafing.UseAmmoPerShot`, if set to `true` overrides the usual behaviour"
 " of only deducting ammo after a strafing run and instead doing it after "
 "each individual shot."
 msgstr "`Strafing.UseAmmoPerShot` 如果设为 `true` 将在每次开火后都扣除弹药而不是通常的仅在扫射结束后才扣除弹药。"
 
-#: ../../New-or-Enhanced-Logics.md:2340
+#: ../../New-or-Enhanced-Logics.md:2362
 msgid ""
 "`Strafing.EndDelay` can be used to override the delay after firing last "
 "shot in strafing run before aircraft resumes another strafing run or "
@@ -8302,7 +8373,7 @@ msgstr ""
 "Speed`。注意对于弹药量足够进行多次扫射的战机而言过短的间隔可能导致并不理想的行为例如四处游走或朝向怪异的方向，具体取决于 "
 "`[WeaponType] -> ROF` 和／或 `[AircraftType] -> Speed` 等其他因素。"
 
-#: ../../New-or-Enhanced-Logics.md:2341
+#: ../../New-or-Enhanced-Logics.md:2363
 msgid ""
 "There is a special case for aircraft spawned by `Type=SpyPlane` "
 "superweapons on `SpyPlane Approach` or `SpyPlane Overfly` mission where "
@@ -8313,7 +8384,7 @@ msgstr ""
 "对于 `Type=SpyPlane` 超级武器生成的战机在 `SpyPlane Approach` 或 `SpyPlane Overfly` "
 "任务中的情况 `Strafing.Shots` 只有在其主武器上手动设置才会生效并决定地图揭示效果的最大次数而无视其他因素。"
 
-#: ../../New-or-Enhanced-Logics.md:2344
+#: ../../New-or-Enhanced-Logics.md:2366
 msgid ""
 "[SOMEWEAPON]                   ; WeaponType\n"
 "Strafing=                      ; boolean\n"
@@ -8329,11 +8400,11 @@ msgstr ""
 "Strafing.UseAmmoPerShot=false  ; boolean\n"
 "Strafing.EndDelay=             ; integer, game frames\n"
 
-#: ../../New-or-Enhanced-Logics.md:2353
+#: ../../New-or-Enhanced-Logics.md:2375
 msgid "Visual effect scatter"
 msgstr "视觉效果散布"
 
-#: ../../New-or-Enhanced-Logics.md:2355
+#: ../../New-or-Enhanced-Logics.md:2377
 msgid ""
 "You can now add a random offset to visual effect's (`IsLaser=true`, "
 "`IsElectricBolt=true` or `IsRadBeam=true`) target location if set "
@@ -8342,7 +8413,7 @@ msgstr ""
 "现在你可以在 `VisualScatter` 设为 true "
 "时为视觉效果（`IsLaser=true`、`IsElectricBolt=true` 或 `IsRadBeam=true`）添加一个随机偏移。"
 
-#: ../../New-or-Enhanced-Logics.md:2358
+#: ../../New-or-Enhanced-Logics.md:2380
 msgid ""
 "[AudioVisual]\n"
 "VisualScatter.Min=0.03  ; floating point value, distance in cells\n"
@@ -8358,7 +8429,7 @@ msgstr ""
 "[SOMEWEAPON]            ; WeaponType\n"
 "VisualScatter=false     ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2368
+#: ../../New-or-Enhanced-Logics.md:2390
 msgid ""
 "This function is only used as an additional scattering visual display, "
 "which is different from `BallisticScatter.(Min/Max)` and can be used "
@@ -8368,11 +8439,11 @@ msgstr ""
 "此功能仅叠加到**视觉效果**原本的散布上，也就是说它独立于 `BallisticScatter.(Min/Max)` "
 "且可共同使用，不会影响抛射体实际爆点的散布。"
 
-#: ../../New-or-Enhanced-Logics.md:2371
+#: ../../New-or-Enhanced-Logics.md:2393
 msgid "Weapon targeting filter"
 msgstr "武器瞄准筛选"
 
-#: ../../New-or-Enhanced-Logics.md:2373
+#: ../../New-or-Enhanced-Logics.md:2395
 msgid ""
 "![image](_static/images/weaponfilter.gif) *`Weapon target filter - "
 "different weapon used against enemies & allies as well as units & "
@@ -8383,21 +8454,21 @@ msgstr ""
 "*[幽灵计划](https://www.moddb.com/mods/project-phantom) 中的武器瞄准筛选 - "
 "就像分别对单位和建筑使用那样对敌军和友军使用不同武器*"
 
-#: ../../New-or-Enhanced-Logics.md:2376
+#: ../../New-or-Enhanced-Logics.md:2398
 msgid ""
 "You can now specify which targets or houses a weapon can fire at. This "
 "also affects weapon selection, other than certain special cases where the"
 " selection is fixed."
 msgstr "现在你可以指定武器可以开火的目标或所属方。这还会影响武器选择，除了某些特殊情况下的固定选择。"
 
-#: ../../New-or-Enhanced-Logics.md:2377
+#: ../../New-or-Enhanced-Logics.md:2399
 msgid ""
 "Note that `CanTarget` explicitly requires either `all` or `empty` to be "
 "listed for the weapon to be able to fire at cells containing no "
 "TechnoTypes."
 msgstr "注意 `CanTarget` 要求明确列出 `all` 或 `empty` 才能对不包含任何科技类型的单元格开火。"
 
-#: ../../New-or-Enhanced-Logics.md:2380
+#: ../../New-or-Enhanced-Logics.md:2402
 msgid ""
 "[SOMEWEAPON]              ; WeaponType\n"
 "CanTarget=all             ; List of Affected Target Enumeration "

--- a/docs/locale/zh_CN/LC_MESSAGES/User-Interface.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/User-Interface.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Phobos \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-15 21:26+0800\n"
+"POT-Creation-Date: 2025-06-19 22:32+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -106,18 +106,18 @@ msgstr "音频"
 msgid "You can now specify which soundtrack themes would play on win or lose."
 msgstr "现在你可以指定在胜利或失败时播放哪些音轨的主题曲。"
 
-#: ../../User-Interface.md:23 ../../User-Interface.md:62
-#: ../../User-Interface.md:122 ../../User-Interface.md:141
-#: ../../User-Interface.md:154 ../../User-Interface.md:177
-#: ../../User-Interface.md:202 ../../User-Interface.md:258
-#: ../../User-Interface.md:296 ../../User-Interface.md:315
-#: ../../User-Interface.md:325 ../../User-Interface.md:348
-#: ../../User-Interface.md:444 ../../User-Interface.md:459
-#: ../../User-Interface.md:479 ../../User-Interface.md:507
-#: ../../User-Interface.md:552 ../../User-Interface.md:587
-#: ../../User-Interface.md:597 ../../User-Interface.md:616
-#: ../../User-Interface.md:675 ../../User-Interface.md:733
-#: ../../User-Interface.md:753
+#: ../../User-Interface.md:23 ../../User-Interface.md:83
+#: ../../User-Interface.md:158 ../../User-Interface.md:177
+#: ../../User-Interface.md:190 ../../User-Interface.md:213
+#: ../../User-Interface.md:238 ../../User-Interface.md:294
+#: ../../User-Interface.md:332 ../../User-Interface.md:351
+#: ../../User-Interface.md:361 ../../User-Interface.md:384
+#: ../../User-Interface.md:480 ../../User-Interface.md:495
+#: ../../User-Interface.md:515 ../../User-Interface.md:543
+#: ../../User-Interface.md:588 ../../User-Interface.md:623
+#: ../../User-Interface.md:633 ../../User-Interface.md:652
+#: ../../User-Interface.md:711 ../../User-Interface.md:769
+#: ../../User-Interface.md:789
 msgid "In `rulesmd.ini`:"
 msgstr "在 `rulesmd.ini`："
 
@@ -147,10 +147,10 @@ msgstr ""
 "补充仓库](https://github.com/Phobos-developers/PhobosSupplementaries) 示例 "
 "Shape 文件的默认配置。*"
 
-#: ../../User-Interface.md:34 ../../User-Interface.md:136
-#: ../../User-Interface.md:487 ../../User-Interface.md:532
-#: ../../User-Interface.md:575 ../../User-Interface.md:635
-#: ../../User-Interface.md:709
+#: ../../User-Interface.md:34 ../../User-Interface.md:144
+#: ../../User-Interface.md:172 ../../User-Interface.md:523
+#: ../../User-Interface.md:568 ../../User-Interface.md:611
+#: ../../User-Interface.md:671 ../../User-Interface.md:745
 msgid "image"
 msgstr "图像"
 
@@ -169,116 +169,90 @@ msgid "`InfoIndex` defines the specific `InfoType`."
 msgstr "`InfoIndex` 定义了具体的 `InfoType`。"
 
 #: ../../User-Interface.md:39
-msgid ""
-"In `InfoType=Spawns`,"
-msgstr ""
-"在 `InfoType=Spawns` 中，"
-
-msgid ""
-"0 - alive spawns,"
-msgstr ""
-"0 - 存活的子机，"
-
-msgid ""
-"1 - docked spawns,"
-msgstr ""
-"1 - 返航的子机，"
-
-msgid ""
-"2 - launching spawns. <br><br>"
-msgstr ""
-"2 - 发射中的子机。<br><br>"
+msgid "In `InfoType=Spawns`,"
+msgstr "在 `InfoType=Spawns` 中，"
 
 #: ../../User-Interface.md:40
-msgid ""
-"In `InfoType=Tiberium`,"
-msgstr ""
-"在 `InfoType=Tiberium` 中，"
-
-msgid ""
-"0 - all,"
-msgstr ""
-"0 - 所有类型，"
-
-msgid ""
-"1 - the first tiberium,"
-msgstr ""
-"1 - 第一类矿石，"
-
-msgid ""
-"2 - the second tiberium, <br>..."
-msgstr ""
-"2 - 第二类矿石，<br>..."
+msgid "0 - alive spawns,"
+msgstr "0 - 存活的子机，"
 
 #: ../../User-Interface.md:41
-msgid ""
-"In `InfoType=SpawnTimer`,"
-msgstr ""
-"在 `InfoType=SpawnTimer` 中，"
-
-msgid ""
-"0 - the fastest spawnee,"
-msgstr ""
-"0 - 最快的子机，"
-
-msgid ""
-"1 - the first spawnee,"
-msgstr ""
-"1 - 第一个子机，"
-
-msgid ""
-"2 - the second spawnee, <br>..."
-msgstr ""
-"2 - 第二个子机，<br>..."
+msgid "1 - docked spawns,"
+msgstr "1 - 返航的子机，"
 
 #: ../../User-Interface.md:42
-msgid ""
-"In `InfoType=SuperWeapon`,"
-msgstr ""
-"在 `InfoType=SuperWeapon` 中，"
-
-msgid ""
-"0 - the first SW of all,"
-msgstr ""
-"0 - 所有超武中的第一个，"
-
-msgid ""
-"1 - `[BuildingType] -> SuperWeapon`,"
-msgstr ""
-"1 - `[BuildingType] -> SuperWeapon`，"
-
-msgid ""
-"2 - `[BuildingType] -> SuperWeapon2`,"
-msgstr ""
-"2 - `[BuildingType] -> SuperWeapon2`，"
-
-msgid ""
-"3 - the first SW in `[BuildingType] -> SuperWeapons`, <br>..."
-msgstr ""
-"3 - `[BuildingType] -> SuperWeapons` 中的第一个，<br>..."
-
-#: ../../User-Interface.md:43
-msgid ""
-"In `InfoType=FactoryProcess`,"
-msgstr ""
-"在 `InfoType=FactoryProcess` 中，"
-
-msgid ""
-"0 - the first factory in production,"
-msgstr ""
-"0 - 正在生产的首个产线，"
-
-msgid ""
-"1 - primary factory,"
-msgstr ""
-"1 - 主／科技建筑生产线，"
-
-msgid ""
-"2 - secondary factory. <br><br>"
-msgstr ""
-"2 - 副／防御建筑生产线。<br><br>"
+msgid "2 - launching spawns. <br><br>"
+msgstr "2 - 发射中的子机。<br><br>"
 
 #: ../../User-Interface.md:44
+msgid "In `InfoType=Tiberium`,"
+msgstr "在 `InfoType=Tiberium` 中，"
+
+#: ../../User-Interface.md:45
+msgid "0 - all,"
+msgstr "0 - 所有类型，"
+
+#: ../../User-Interface.md:46
+msgid "1 - the first tiberium,"
+msgstr "1 - 第一类矿石，"
+
+#: ../../User-Interface.md:47
+msgid "2 - the second tiberium, <br>..."
+msgstr "2 - 第二类矿石，<br>..."
+
+#: ../../User-Interface.md:49
+msgid "In `InfoType=SpawnTimer`,"
+msgstr "在 `InfoType=SpawnTimer` 中，"
+
+#: ../../User-Interface.md:50
+msgid "0 - the fastest spawnee,"
+msgstr "0 - 最快的子机，"
+
+#: ../../User-Interface.md:51
+msgid "1 - the first spawnee,"
+msgstr "1 - 第一个子机，"
+
+#: ../../User-Interface.md:52
+msgid "2 - the second spawnee, <br>..."
+msgstr "2 - 第二个子机，<br>..."
+
+#: ../../User-Interface.md:54
+msgid "In `InfoType=SuperWeapon`,"
+msgstr "在 `InfoType=SuperWeapon` 中，"
+
+#: ../../User-Interface.md:55
+msgid "0 - the first SW of all,"
+msgstr "0 - 所有超武中的第一个，"
+
+#: ../../User-Interface.md:56
+msgid "1 - `[BuildingType] -> SuperWeapon`,"
+msgstr "1 - `[BuildingType] -> SuperWeapon`，"
+
+#: ../../User-Interface.md:57
+msgid "2 - `[BuildingType] -> SuperWeapon2`,"
+msgstr "2 - `[BuildingType] -> SuperWeapon2`，"
+
+#: ../../User-Interface.md:58
+msgid "3 - the first SW in `[BuildingType] -> SuperWeapons`, <br>..."
+msgstr "3 - `[BuildingType] -> SuperWeapons` 中的第一个，<br>..."
+
+#: ../../User-Interface.md:60
+msgid "In `InfoType=FactoryProcess`,"
+msgstr "在 `InfoType=FactoryProcess` 中，"
+
+#: ../../User-Interface.md:61
+msgid "0 - the first factory in production,"
+msgstr "0 - 正在生产的首个产线，"
+
+#: ../../User-Interface.md:62
+msgid "1 - primary factory,"
+msgstr "1 - 主／科技建筑生产线，"
+
+#: ../../User-Interface.md:63
+msgid "2 - secondary factory. <br><br>"
+msgstr "2 - 副／防御建筑生产线。<br><br>"
+
+#: ../../User-Interface.md:65
 msgid ""
 "`Anchor.Horizontal` and `Anchor.Vertical` set the anchor point from which"
 " the display is drawn (depending on `Align`) relative to unit's "
@@ -287,55 +261,53 @@ msgstr ""
 "`Anchor.Horizontal` 和 `Anchor.Vertical` 设置显示位置相对于单位中心／选择框的锚点（取决于 "
 "`Align`）。建筑使用 `Anchor.Building`。"
 
-#: ../../User-Interface.md:45
+#: ../../User-Interface.md:66
 msgid ""
 "`Offset` and `Offset.ShieldDelta` (the latter applied when a shield is "
 "active) can be used to further modify the position."
 msgstr "`Offset` 和 `Offset.ShieldDelta`（后者在护盾激活时使用）可用于进一步修改位置。"
 
-#: ../../User-Interface.md:46
+#: ../../User-Interface.md:67
 msgid ""
 "By default, values are displayed in `current/maximum` format (i.e. "
 "`20/40`)."
 msgstr "默认情况下，值以 `当前值/最大值` 的格式显示（例如 `20/40`）。"
 
-#: ../../User-Interface.md:47
+#: ../../User-Interface.md:68
 msgid ""
 "`HideMaxValue=yes` will make the counter show only the current value "
 "(i.e. `20`), default to whether the techno is infantry or not."
 msgstr "`HideMaxValue=yes` 将使计数器仅显示当前值（例如 `20`），默认值取决于科技类型是否为步兵。"
 
-#: ../../User-Interface.md:48
+#: ../../User-Interface.md:69
 msgid "`Percentage=yes` changes the format to `percent%` (i.e. `50%`)."
 msgstr "`Percentage=yes` 将格式更改为 `百分比 %`（例如 `50%`）。"
 
-#: ../../User-Interface.md:49
+#: ../../User-Interface.md:70
 msgid ""
 "`ValueAsTimer` controls whether the value will be displayed in the form "
 "of a timer (i.e. `0:30`, `5:00` or `1:00:00`)."
-msgstr ""
-"`ValueAsTimer` 控制数值是否以计时器格式显示（例如 `0:30`，`5:00` 或 `1:00:00`）。"
+msgstr "`ValueAsTimer` 控制数值是否以计时器格式显示（例如 `0:30`，`5:00` 或 `1:00:00`）。"
 
-#: ../../User-Interface.md:50 ../../User-Interface.md:255
+#: ../../User-Interface.md:71 ../../User-Interface.md:291
 msgid ""
 "`VisibleToHouses` and `VisibleToHouses.Observer` can limit visibility to "
 "specific players."
 msgstr "`VisibleToHouses` 和 `VisibleToHouses.Observer` 可以限定特定玩家可见。"
 
-#: ../../User-Interface.md:51
+#: ../../User-Interface.md:72
 msgid ""
 "`VisibleInSpecialState` controls whether this display type will show when"
 " the owner is in ironcurtain or is attacked by a temporal weapon."
-msgstr ""
-"`VisibleInSpecialState` 控制当拥有者处于铁幕或被超时空武器冻结时是否仍显示此类信息。"
+msgstr "`VisibleInSpecialState` 控制当拥有者处于铁幕或被超时空武器冻结时是否仍显示此类信息。"
 
-#: ../../User-Interface.md:52
+#: ../../User-Interface.md:73
 msgid ""
 "The digits can be either a custom shape (.shp) or text drawn using the "
 "game font. This depends on whether `Shape` is set."
 msgstr "数字可以是自定义的 Shape（.shp） 或使用游戏字体绘制的文本。这取决于是否设置了 `Shape`。"
 
-#: ../../User-Interface.md:53
+#: ../../User-Interface.md:74
 msgid ""
 "`Text.Color`, `Text.Color.ConditionYellow` and `Text.Color.ConditionRed` "
 "allow customization of the font color. `Text.Background=yes` will "
@@ -344,53 +316,57 @@ msgstr ""
 "`Text.Color`、`Text.Color.ConditionYellow` 和 `Text.Color.ConditionRed` "
 "允许自定义颜色。`Text.Background=yes` 将绘制黑色矩形背景。"
 
-#: ../../User-Interface.md:54
+#: ../../User-Interface.md:75
 msgid ""
 "When using shapes, a custom palette can be specified with `Palette`. "
 "`Shape.Spacing` controls pixel buffer between characters. If "
 "`Shape.PercentageFrame` set to true, it will only draw one frame that "
 "corresponds to total frames by percentage."
-msgstr "当使用 Shape时，可以通过 `Palette` 指定自定义色盘。`Shape.Spacing` 控制字符之间以像素为单位的间隔。"
-"若 `Shape.PercentageFrame` 设为 true，则仅绘制与总进度百分比相对应的单个帧。"
+msgstr ""
+"当使用 Shape时，可以通过 `Palette` 指定自定义色盘。`Shape.Spacing` 控制字符之间以像素为单位的间隔。若 "
+"`Shape.PercentageFrame` 设为 true，则仅绘制与总进度百分比相对应的单个帧。"
 
-#: ../../User-Interface.md:55
+#: ../../User-Interface.md:76
 msgid ""
 "Frames 0-9 will be used as digits when the owner's health bar is green, "
 "10-19 when yellow, 20-29 when red. For `/` and `%` (or `:` if set "
 "`ValueAsTimer` to true) characters, frame numbers are 30-31, 32-33, "
 "34-35, respectively."
 msgstr ""
-"当所有者的血量为健康状态时使用 0-9 帧的数字，黄血时使用 10-19 帧，红血时使用 20-29 帧。对于 `/` 和 `%` "
-"（或当 `ValueAsTimer=true` 时的 `:`）符号，帧序号索引分别为 30-31、32-33、34-35。"
+"当所有者的血量为健康状态时使用 0-9 帧的数字，黄血时使用 10-19 帧，红血时使用 20-29 帧。对于 `/` 和 `%` （或当 "
+"`ValueAsTimer=true` 时的 `:`）符号，帧序号索引分别为 30-31、32-33、34-35。"
 
-#: ../../User-Interface.md:56
+#: ../../User-Interface.md:77
 msgid ""
 "Default `Offset.ShieldDelta` for `InfoType=Shield` is `0,-10`, `0,0` for "
 "others."
 msgstr "对于 `InfoType=Shield` 其默认为 `Offset.ShieldDelta` 为 `0,-10`，其他为 `0,0`。"
 
-#: ../../User-Interface.md:57
+#: ../../User-Interface.md:78
 msgid "Default `Shape.Spacing` for buildings is `4,-2`, `4,0` for others."
 msgstr "建筑的 `Shape.Spacing` 默认为 `4,-2`，其他为 `4,0`。"
 
-#: ../../User-Interface.md:58
+#: ../../User-Interface.md:79
 msgid ""
 "`ValueScaleDivisor` can be used to adjust scale of displayed values. Both"
 " the current & maximum value will be divided by the integer number given,"
 " if higher than 1. Default to 1 (or 15 when set `ValueAsTimer` to true)."
-msgstr "`ValueScaleDivisor` 可用于调整显示值的缩放比例。如果给定的整数大于 1 那么当前值和最大值都将除以该整数。"
-"默认为 1（或当 `ValueAsTimer=true` 时为 15）。"
+msgstr ""
+"`ValueScaleDivisor` 可用于调整显示值的缩放比例。如果给定的整数大于 1 那么当前值和最大值都将除以该整数。默认为 1（或当 "
+"`ValueAsTimer=true` 时为 15）。"
 
-#: ../../User-Interface.md:60
+#: ../../User-Interface.md:81
 msgid ""
 "`DigitalDisplay.Health.FakeAtDisguise`, if set to true on an InfantryType"
 " with Disguise, will use the disguised TechnoType's `Strength` value as "
 "the maximum value of health display. The current value will be displayed "
 "as the percentage of its current health multiplies the new maximum value."
 msgstr ""
-"若 `DigitalDisplay.Health.FakeAtDisguise` 在一个使用伪装的步兵上设为 true，那么它将用被伪装单位的 `Strength` 来显示最大值。当前值将由该单位当前生命值所占的百分比乘新的最大值计算得出。"
+"若 `DigitalDisplay.Health.FakeAtDisguise` 在一个使用伪装的步兵上设为 true，那么它将用被伪装单位的 "
+"`Strength` 来显示最大值。当前值将由该单位当前生命值所占的百分比乘新的最大值计算得出。"
 
-#: ../../User-Interface.md:63
+#: ../../User-Interface.md:84
+#, fuzzy
 msgid ""
 "[DigitalDisplayTypes]\n"
 "0=SOMEDIGITALDISPLAYTYPE\n"
@@ -426,8 +402,8 @@ msgid ""
 "enumeration (top|lefttop|leftbottom|bottom|rightbottom|righttop)\n"
 "Percentage=false                               ; boolean\n"
 "HideMaxValue=false                             ; boolean\n"
-"VisibleToHouses=owner                          ; Affected house "
-"enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)\n"
+"VisibleToHouses=owner                          ; Affected House "
+"Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "VisibleToHouses.Observer=true                  ; boolean\n"
 "VisibleInSpecialState=true                     ; boolean\n"
 "ValueScaleDivisor=                             ; integer\n"
@@ -518,18 +494,18 @@ msgstr ""
 "DigitalDisplayTypes\n"
 "DigitalDisplay.Health.FakeAtDisguise=true      ; boolean\n"
 
-#: ../../User-Interface.md:107 ../../User-Interface.md:128
-#: ../../User-Interface.md:164 ../../User-Interface.md:185
-#: ../../User-Interface.md:227 ../../User-Interface.md:242
-#: ../../User-Interface.md:283 ../../User-Interface.md:305
-#: ../../User-Interface.md:428 ../../User-Interface.md:518
-#: ../../User-Interface.md:563 ../../User-Interface.md:623
-#: ../../User-Interface.md:697 ../../User-Interface.md:741
-#: ../../User-Interface.md:765
+#: ../../User-Interface.md:128 ../../User-Interface.md:164
+#: ../../User-Interface.md:200 ../../User-Interface.md:221
+#: ../../User-Interface.md:263 ../../User-Interface.md:278
+#: ../../User-Interface.md:319 ../../User-Interface.md:341
+#: ../../User-Interface.md:464 ../../User-Interface.md:554
+#: ../../User-Interface.md:599 ../../User-Interface.md:659
+#: ../../User-Interface.md:733 ../../User-Interface.md:777
+#: ../../User-Interface.md:801
 msgid "In `RA2MD.INI`:"
 msgstr "在 `RA2MD.INI`："
 
-#: ../../User-Interface.md:108
+#: ../../User-Interface.md:129
 msgid ""
 "[Phobos]\n"
 "DigitalDisplay.Enable=false                    ; boolean\n"
@@ -537,7 +513,7 @@ msgstr ""
 "[Phobos]\n"
 "DigitalDisplay.Enable=false                    ; boolean\n"
 
-#: ../../User-Interface.md:114
+#: ../../User-Interface.md:135
 msgid ""
 "An example shape file for digits can be found on [Phobos supplementaries "
 "repo](https://github.com/Phobos-developers/PhobosSupplementaries)."
@@ -545,38 +521,66 @@ msgstr ""
 "可以在 [Phobos 补充仓库](https://github.com/Phobos-"
 "developers/PhobosSupplementaries) 找到数字化显示的示例 Shape 文件。"
 
-msgid "`Shape.PercentageFrame` effectively provides the ultimate solution for all static data display effects: it allows mapping the current value to a specific static frame index in a shape file sequence by calculating its proportional ratio to the total value, where the concrete image on this frame is entirely user-defined."
-msgstr "`Shape.PercentageFrame` 实际上提供了一切静态化数据显示效果的终极解决方案：它允许将当前值通过计算其相对总值的比例来到一个 Shape 文件序列中的特定静态帧的序号，而这一帧上的具体图像是完全由用户自由定义的。"
+#: ../../User-Interface.md:139
+msgid ""
+"`Shape.PercentageFrame` effectively provides the ultimate solution for "
+"all static data display effects: it allows mapping the current value to a"
+" specific static frame index in a shape file sequence by calculating its "
+"proportional ratio to the total value, where the concrete image on this "
+"frame is entirely user-defined."
+msgstr ""
+"`Shape.PercentageFrame` 实际上提供了一切静态化数据显示效果的终极解决方案：它允许将当前值通过计算其相对总值的比例来到一个 "
+"Shape 文件序列中的特定静态帧的序号，而这一帧上的具体图像是完全由用户自由定义的。"
 
-msgid "You can create a circular health bar for technos, where the different frames of this ring Shape file correspond to the state of the circular health bar at varying degrees of damage."
+#: ../../User-Interface.md:142
+msgid ""
+"You can create a circular health bar for technos, where the different "
+"frames of this ring Shape file correspond to the state of the circular "
+"health bar at varying degrees of damage."
 msgstr "例如：你可以为单位制作一个圆环形状的血条，这个圆环 Shape 文件的不同帧对应环状血条不同程度的受损状态。"
 
-msgid "![image](_static/images/ring-health-bar.gif) *Example of a ring-shaped health bar*"
+#: ../../User-Interface.md:144
+msgid ""
+"![image](_static/images/ring-health-bar.gif) *Example of a ring-shaped "
+"health bar*"
 msgstr "![image](_static/images/ring-health-bar.gif) *圆环形状的血条样例*"
 
-msgid "The arrangement of static images on the plane is entirely up to you to draw freely, without being constrained by pre-established frameworks (e.g., the original rule for health bars was to start at a fixed coordinate, fetch a pip from a fixed frame of a fixed file at fixed intervals, and then arrange them horizontally), choosing from inherently limited options."
-msgstr "静态图像在平面上的排布方式完全由您自由绘制，而不必受制于既定的框架下（例如对于血条来说原先的规则就是固定坐标处开始按固定间隔从固定文件的固定帧获取一个 pip 格点然后横向排布），在本就有限的选项中进行选择。"
+#: ../../User-Interface.md:147
+msgid ""
+"The arrangement of static images on the plane is entirely up to you to "
+"draw freely, without being constrained by pre-established frameworks "
+"(e.g., the original rule for health bars was to start at a fixed "
+"coordinate, fetch a pip from a fixed frame of a fixed file at fixed "
+"intervals, and then arrange them horizontally), choosing from inherently "
+"limited options."
+msgstr ""
+"静态图像在平面上的排布方式完全由您自由绘制，而不必受制于既定的框架下（例如对于血条来说原先的规则就是固定坐标处开始按固定间隔从固定文件的固定帧获取一个"
+" pip 格点然后横向排布），在本就有限的选项中进行选择。"
 
-msgid "Of course, this is just the implementation method. To balance freedom with efficiency—that is, how to efficiently draw the patterns you need—you still need to independently explore a workflow that suits you."
+#: ../../User-Interface.md:150
+msgid ""
+"Of course, this is just the implementation method. To balance freedom "
+"with efficiency—that is, how to efficiently draw the patterns you "
+"need—you still need to independently explore a workflow that suits you."
 msgstr "当然，这只是实现方式，对于在可行的同时兼顾效率，即如何高效绘制您所需要的图样，您仍需自主探索属于您的工作流。"
 
-#: ../../User-Interface.md:117
+#: ../../User-Interface.md:153
 msgid "Flashing Technos on selecting"
 msgstr "闪烁选中的科技类型"
 
-#: ../../User-Interface.md:119
+#: ../../User-Interface.md:155
 msgid ""
 "Selecting technos, controlled by player, now may show a flash effect by "
 "setting `SelectionFlashDuration` parameter higher than 0."
 msgstr "现在可以通过设置一个大于 0 的 `SelectionFlashDuration` 来让由玩家控制的单位在被选中时可以出现闪烁效果。"
 
-#: ../../User-Interface.md:120
+#: ../../User-Interface.md:156
 msgid ""
 "The feature can be toggled on/off by user if enabled in mod via "
 "`ShowFlashOnSelecting` setting in `RA2MD.INI`."
 msgstr "此功能可以在 mod 中于 `RA2MD.INI` 设置 `ShowFlashOnSelecting` 来由用户自行开关。"
 
-#: ../../User-Interface.md:123
+#: ../../User-Interface.md:159
 msgid ""
 "[AudioVisual]\n"
 "SelectionFlashDuration=0    ; integer, number of frames\n"
@@ -584,7 +588,7 @@ msgstr ""
 "[AudioVisual]\n"
 "SelectionFlashDuration=0    ; integer, number of frames\n"
 
-#: ../../User-Interface.md:129
+#: ../../User-Interface.md:165
 msgid ""
 "[Phobos]\n"
 "ShowFlashOnSelecting=false  ; boolean\n"
@@ -592,11 +596,11 @@ msgstr ""
 "[Phobos]\n"
 "ShowFlashOnSelecting=false  ; boolean\n"
 
-#: ../../User-Interface.md:134
+#: ../../User-Interface.md:170
 msgid "Hide health bars"
 msgstr "隐藏血条"
 
-#: ../../User-Interface.md:136
+#: ../../User-Interface.md:172
 msgid ""
 "![image](_static/images/healthbar.hide-01.png) *Health bars hidden in "
 "[CnC: Final War](https://www.moddb.com/mods/cncfinalwar)*"
@@ -604,35 +608,35 @@ msgstr ""
 "![image](_static/images/healthbar.hide-01.png) *[CnC: Final "
 "War](https://www.moddb.com/mods/cncfinalwar) 中的隐藏血条使用实例*"
 
-#: ../../User-Interface.md:139
+#: ../../User-Interface.md:175
 msgid ""
 "Health bar display can now be turned off as needed, hiding both the "
 "health bar box and health pips."
 msgstr "现在可以根据需要关闭血条显示，这会隐藏血条框和生命值点数。"
 
-#: ../../User-Interface.md:142
+#: ../../User-Interface.md:178
 msgid ""
 "[SOMENAME]            ; TechnoType\n"
 "HealthBar.Hide=false  ; boolean\n"
 msgstr ""
 
-#: ../../User-Interface.md:147
+#: ../../User-Interface.md:183
 msgid "Light flash effect toggling"
 msgstr "闪光效果切换"
 
-#: ../../User-Interface.md:149
+#: ../../User-Interface.md:185
 msgid ""
 "It is possible to toggle certain light flash effects off. These light "
 "flash effects include:"
 msgstr "可以关闭某些闪光效果。这些闪光效果包括："
 
-#: ../../User-Interface.md:150
+#: ../../User-Interface.md:186
 msgid ""
 "Combat light effects (`Bright=true`) and everything that uses same "
 "functionality e.g Iron Curtain / Force Field impact flashes."
 msgstr "战斗闪光效果（`Bright=true`）以及使用相同逻辑的所有效果，例如铁幕／力场护盾受击闪光。"
 
-#: ../../User-Interface.md:151
+#: ../../User-Interface.md:187
 msgid ""
 "Alpha images attached to ParticleSystems or Particles that are generated "
 "through a Warhead's `Particle` if `[AudioVisual] -> "
@@ -644,7 +648,7 @@ msgstr ""
 "`Particle.AlphaImageIsLightFlash` 设为 true，那么计入那些附加在由弹头 `Particle` "
 "生成的粒子系统或粒子上的 AlphaImage 光效。"
 
-#: ../../User-Interface.md:152
+#: ../../User-Interface.md:188
 msgid ""
 "Additionally these alpha images are not created if `[AudioVisual] -> "
 "LightFlashAlphaImageDetailLevel` is higher than current detail level, "
@@ -653,7 +657,7 @@ msgstr ""
 "此外如果 `[AudioVisual] -> LightFlashAlphaImageDetailLevel` 高于当前画质级别，那么无论 "
 "`HideLightFlashEffects` 设置如何，这些 AlphaImage 都不会被创建。"
 
-#: ../../User-Interface.md:155
+#: ../../User-Interface.md:191
 msgid ""
 "[AudioVisual]\n"
 "WarheadParticleAlphaImageIsLightFlash=false  ; boolean\n"
@@ -669,7 +673,7 @@ msgstr ""
 "[SOMEWARHEAD]                                ; WarheadType\n"
 "Particle.AlphaImageIsLightFlash=             ; boolean\n"
 
-#: ../../User-Interface.md:165
+#: ../../User-Interface.md:201
 msgid ""
 "[Phobos]\n"
 "HideLightFlashEffects=false  ; boolean\n"
@@ -677,11 +681,11 @@ msgstr ""
 "[Phobos]\n"
 "HideLightFlashEffects=false  ; boolean\n"
 
-#: ../../User-Interface.md:170
+#: ../../User-Interface.md:206
 msgid "Low priority for box selection"
 msgstr "低优先级框选"
 
-#: ../../User-Interface.md:172
+#: ../../User-Interface.md:208
 msgid ""
 "![smartvesters](_static/images/lowpriority-01.gif) *Harvesters not "
 "selected together with battle units in [Rise of the "
@@ -690,11 +694,11 @@ msgstr ""
 "![智能矿车](_static/images/lowpriority-01.gif) "
 "*[东方崛起](https://www.moddb.com/mods/riseoftheeast) 中的矿车不会与作战单位一同被选中*"
 
-#: ../../User-Interface.md:172
+#: ../../User-Interface.md:208
 msgid "smartvesters"
 msgstr "智能矿车"
 
-#: ../../User-Interface.md:175
+#: ../../User-Interface.md:211
 msgid ""
 "You can now set lower priority for an ingame object (currently has effect"
 " on units mostly), which means it will be excluded from box selection if "
@@ -707,7 +711,7 @@ msgstr ""
 "现在你可以为游戏中的对象设置较低的优先级（目前主要影响单位），这意味着如果框选区域内至少有一个正常优先级的单位，则该对象将被排除在框选结果之外。否则它会被正常地选中。适用于带类型选择框选（类型选择快捷键"
 " + 拖动）和普通框选。如果要添加的单位中不存在正常优先级的单位那么 Shift 框选时正常将低优先级单位添加到选中的组中。"
 
-#: ../../User-Interface.md:178
+#: ../../User-Interface.md:214
 msgid ""
 "[SOMETECHNO]                ; TechnoType\n"
 "LowSelectionPriority=false  ; boolean\n"
@@ -715,14 +719,14 @@ msgstr ""
 "[SOMETECHNO]                ; TechnoType\n"
 "LowSelectionPriority=false  ; boolean\n"
 
-#: ../../User-Interface.md:183 ../../User-Interface.md:225
-#: ../../User-Interface.md:240
+#: ../../User-Interface.md:219 ../../User-Interface.md:261
+#: ../../User-Interface.md:276
 msgid ""
 "This behavior is designed to be toggleable by users. For now you can only"
 " do that externally via client or manually."
 msgstr "此行为设计为可由用户切换。目前你只能通过客户端或进行手动设置。"
 
-#: ../../User-Interface.md:186
+#: ../../User-Interface.md:222
 msgid ""
 "[Phobos]\n"
 "PrioritySelectionFiltering=true  ; boolean\n"
@@ -730,11 +734,11 @@ msgstr ""
 "[Phobos]\n"
 "PrioritySelectionFiltering=true  ; boolean\n"
 
-#: ../../User-Interface.md:191
+#: ../../User-Interface.md:227
 msgid "Placement preview"
 msgstr "放置预览"
 
-#: ../../User-Interface.md:193
+#: ../../User-Interface.md:229
 msgid ""
 "![placepreview](_static/images/placepreview.png) *Building placement "
 "preview using 50% translucency in [Rise of the "
@@ -743,11 +747,11 @@ msgstr ""
 "![放置预览](_static/images/placepreview.png) "
 "*[东方崛起](https://www.moddb.com/mods/riseoftheeast) 中使用 50% 透明度的建筑放置预览*"
 
-#: ../../User-Interface.md:193
+#: ../../User-Interface.md:229
 msgid "placepreview"
 msgstr "放置预览"
 
-#: ../../User-Interface.md:196
+#: ../../User-Interface.md:232
 msgid ""
 "Building previews can now be enabled when placing a building for "
 "construction. This can be enabled on a global basis with `[AudioVisual] "
@@ -757,7 +761,7 @@ msgstr ""
 "现在放置建筑进行建造时可以启用建筑预览。这可以通过在全局设置 `[AudioVisual] -> PlacementPreview` "
 "和每个建筑上设置 `[BuildingType] -> PlacementPreview` 来进一步自定义开启。"
 
-#: ../../User-Interface.md:197
+#: ../../User-Interface.md:233
 msgid ""
 "The building placement grid (`place.shp`) translucency setting can be "
 "adjusted via `PlacementGrid.Translucency` if `PlacementPreview` is "
@@ -767,7 +771,7 @@ msgstr ""
 "可以调整建筑放置网格（`place.shp`）的透明度，如果 `PlacementPreview` 被启用，那么由 "
 "`PlacementGrid.TranslucencyWithPreview` 来进行调整。"
 
-#: ../../User-Interface.md:198
+#: ../../User-Interface.md:234
 msgid ""
 "If using the building's appropriate `Buildup` is not desired, "
 "customizations allow for you to choose the exact SHP and frame you'd "
@@ -778,14 +782,14 @@ msgstr ""
 "`PlacementPreview.Shape`、`PlacementPreview.ShapeFrame` 和 "
 "`PlacementPreview.Palette` 来选择你希望显示的确切 Shape 文件和帧。"
 
-#: ../../User-Interface.md:199
+#: ../../User-Interface.md:235
 msgid ""
 "You can specify theater-specific palettes and shapes by putting three `~`"
 " marks to the theater specific part of the filename. `~~~` is replaced "
 "with the theater’s three-letter extension."
 msgstr "你可以通过在文件名的特定部分添加三个 `~` 标记来指定特定气候的色盘和 Shape 文件。`~~~` 将被替换为气候的三字母扩展名。"
 
-#: ../../User-Interface.md:200
+#: ../../User-Interface.md:236
 msgid ""
 "`PlacementPreview.ShapeFrame` tag defaults to building's artmd.ini "
 "`Buildup` entry's last non-shadow frame. If there is no 'Buildup' "
@@ -795,7 +799,7 @@ msgstr ""
 "`PlacementPreview.ShapeFrame` 标签默认为建筑 `artmd.ini` 中 `Buildup` "
 "条目的最后一个非阴影帧。如果没有指定 `Buildup` 那么它会尝试使用建筑本体的第一帧（动画帧和 Bib 不包括在此预览效果中）作为默认值。"
 
-#: ../../User-Interface.md:203
+#: ../../User-Interface.md:239
 msgid ""
 "[AudioVisual]\n"
 "PlacementGrid.Translucency=0            ; translucency level (0/25/50/75)"
@@ -847,7 +851,7 @@ msgstr ""
 "PlacementPreview.Translucency=       ; translucency level (0/25/50/75), "
 "defaults to [AudioVisual] -> PlacementPreview.Translucency\n"
 
-#: ../../User-Interface.md:222
+#: ../../User-Interface.md:258
 msgid ""
 "The `PlacementPreview.Palette` option is not used when "
 "`PlacementPreview.Remap` is set to yes. This may change in future."
@@ -855,7 +859,7 @@ msgstr ""
 "当 `PlacementPreview.Remap` 设为 yes 时 `PlacementPreview.Palette` "
 "不会被使用。这在未来可能进行更改。"
 
-#: ../../User-Interface.md:228
+#: ../../User-Interface.md:264
 msgid ""
 "[Phobos]\n"
 "ShowPlacementPreview=yes   ; boolean\n"
@@ -863,17 +867,17 @@ msgstr ""
 "[Phobos]\n"
 "ShowPlacementPreview=yes   ; boolean\n"
 
-#: ../../User-Interface.md:233
+#: ../../User-Interface.md:269
 msgid "Real time timers"
 msgstr "实时计时器"
 
-#: ../../User-Interface.md:235
+#: ../../User-Interface.md:271
 msgid ""
 "Timers can now display values in real time, taking game speed into "
 "account. This can be enabled with `RealTimeTimers=true`."
 msgstr "计时器现在可以实时显示值，同时考虑游戏速度。这可以通过 `RealTimeTimers=true` 来启用。"
 
-#: ../../User-Interface.md:236
+#: ../../User-Interface.md:272
 msgid ""
 "By default, time is calculated relative to desired framerate. Enabling "
 "`RealTimeTimers.Adaptive` (always true for unlimited FPS and custom "
@@ -883,17 +887,17 @@ msgstr ""
 "默认情况下，时间是根据期望的帧率计算的。当启用 `RealTimeTimers.Adaptive`（对于无限制 FPS 和自定义速度始终为 "
 "true）时，时间将根据 **当前** FPS 计算，同时考虑延迟。"
 
-#: ../../User-Interface.md:237
+#: ../../User-Interface.md:273
 msgid ""
 "When playing with unlimited FPS (or custom speed above 60 FPS), the "
 "timers might constantly change value because of the unstable nature."
 msgstr "在使用无限制 FPS（或自定义速度高于 60 FPS）时，计时器可能会因为不稳定而不断改变数值。"
 
-#: ../../User-Interface.md:238
+#: ../../User-Interface.md:274
 msgid "This option respects custom game speeds."
 msgstr "此选项尊重自定义游戏速度。"
 
-#: ../../User-Interface.md:243
+#: ../../User-Interface.md:279
 msgid ""
 "[Phobos]\n"
 "RealTimeTimers=false            ; boolean\n"
@@ -903,18 +907,18 @@ msgstr ""
 "RealTimeTimers=false            ; boolean\n"
 "RealTimeTimers.Adaptive=false   ; boolean\n"
 
-#: ../../User-Interface.md:249
+#: ../../User-Interface.md:285
 msgid "Select Box"
 msgstr "自定义选择框"
 
-#: ../../User-Interface.md:251
+#: ../../User-Interface.md:287
 msgid ""
 "Now you can use and customize select box for infantry, vehicle and "
 "aircraft. No select box for buildings in default case, but you still can "
 "specific for some building if you want."
 msgstr "现在你可以为每个单位自定义选择框。默认建筑没有选择框但你可以为其开启。"
 
-#: ../../User-Interface.md:252
+#: ../../User-Interface.md:288
 msgid ""
 "`Frames` can be used to list frames of `Shape` file that'll be drawn as a"
 " select box when the TechnoType's health is at or below full health/the "
@@ -924,17 +928,17 @@ msgstr ""
 "`Frames` 可用于列举 `Shape` 文件中用于绘制选择框的帧，对应单位生命值处于满血／低于 `[AudioVisual] -> "
 "ConditionYellow/ConditionRed` 的百分比时的不同状态。"
 
-#: ../../User-Interface.md:253
+#: ../../User-Interface.md:289
 msgid ""
 "If `Grounded` set to true, the select box will be drawn on the ground "
 "below the TechnoType."
 msgstr "如果 `Grounded` 设为 true 那么选择框将绘制在单位正下方的地面上。"
 
-#: ../../User-Interface.md:254
+#: ../../User-Interface.md:290
 msgid "Select box's translucency setting can be adjusted via `Translucency`."
 msgstr "选择框的半透明效果可以通过 `Translucency` 来进行调整。"
 
-#: ../../User-Interface.md:256
+#: ../../User-Interface.md:292
 msgid ""
 "`DrawAboveTechno` specific whether the select box will be drawn before "
 "drawing the TechnoType. If set to false, the select box can be obscured "
@@ -944,7 +948,7 @@ msgstr ""
 "`DrawAboveTechno` 决定选择框是否在相对于单位本体更高的图层绘制。若为 false 则选择框可以被单位本体遮挡，且绘制位置将忽略 "
 "`PixelSelectionBracketDelta`。"
 
-#: ../../User-Interface.md:259
+#: ../../User-Interface.md:295
 msgid ""
 "[SelectBoxTypes]\n"
 "0=SOMESELECTBOXTYPE\n"
@@ -1000,7 +1004,7 @@ msgstr ""
 "SelectBox=                              ; Select box\n"
 "HideSelectBox=false                     ; boolean\n"
 
-#: ../../User-Interface.md:284
+#: ../../User-Interface.md:320
 msgid ""
 "[Phobos]\n"
 "EnableSelectBox=false                   ; boolean\n"
@@ -1008,11 +1012,11 @@ msgstr ""
 "[Phobos]\n"
 "EnableSelectBox=false                   ; boolean\n"
 
-#: ../../User-Interface.md:289
+#: ../../User-Interface.md:325
 msgid "Show designator & inhibitor range"
 msgstr "显示指示者和抑制者范围"
 
-#: ../../User-Interface.md:291
+#: ../../User-Interface.md:327
 msgid ""
 "It is now possible to display range of designator and inhibitor units "
 "when in super weapon targeting mode. Each instance of player owned techno"
@@ -1022,7 +1026,7 @@ msgstr ""
 "现在可以在超级武器瞄准模式下显示指示者和抑制者单位的范围。每个玩家拥有的、列在 `[SuperWeapon] -> SW.Designators`"
 " 中的科技类型将显示一个半径由 `[TechnoType] -> DesignatorRange` 或 `Sight` 设置的圆。"
 
-#: ../../User-Interface.md:292
+#: ../../User-Interface.md:328
 msgid ""
 "In a similar manner, each instance of enemy owned techno types listed in "
 "`[SuperWeapon] -> SW.Inhibitors` will display a circle with radius set in"
@@ -1031,7 +1035,7 @@ msgstr ""
 "类似的，每个敌方拥有的、列在 `[SuperWeapon] -> SW.Inhibitors` 中的科技类型将显示一个半径由 "
 "`[TechnoType] -> InhibitorRange` 或 `Sight` 设置的圆。"
 
-#: ../../User-Interface.md:293
+#: ../../User-Interface.md:329
 msgid ""
 "This feature can be disabled globally with `[AudioVisual] -> "
 "ShowDesignatorRange=false` or per SuperWeaponType with `[SuperWeapon] -> "
@@ -1040,7 +1044,7 @@ msgstr ""
 "可以通过全局的 `[AudioVisual] -> ShowDesignatorRange=false` 或超级武器类型上的 "
 "`[SuperWeapon] -> ShowDesignatorRange=false` 来禁用此功能。"
 
-#: ../../User-Interface.md:294
+#: ../../User-Interface.md:330
 msgid ""
 "This feature can be toggled *by the player* (if enabled in the mod) with "
 "`ShowDesignatorRange` in `RA2MD.INI` or with [\"Toggle Designator Range\""
@@ -1049,7 +1053,7 @@ msgstr ""
 "此功能可以 **由玩家** 通过在 `RA2MD.INI` 中设置 `ShowDesignatorRange` 或 “界面” 类别中的 "
 "[“开启指示者范围显示” 快捷键](#toggle-designator-range)来切换（如果在 mod 中启用）。"
 
-#: ../../User-Interface.md:297
+#: ../../User-Interface.md:333
 msgid ""
 "[AudioVisual]\n"
 "ShowDesignatorRange=true    ; boolean\n"
@@ -1063,7 +1067,7 @@ msgstr ""
 "[SOMESW]                    ; SuperWeaponType\n"
 "ShowDesignatorRange=true    ; boolean\n"
 
-#: ../../User-Interface.md:306
+#: ../../User-Interface.md:342
 msgid ""
 "[Phobos]\n"
 "ShowDesignatorRange=false             ; boolean\n"
@@ -1071,17 +1075,17 @@ msgstr ""
 "[Phobos]\n"
 "ShowDesignatorRange=false             ; boolean\n"
 
-#: ../../User-Interface.md:311
+#: ../../User-Interface.md:347
 msgid "SuperWeapon ShowTimer sorting"
 msgstr "超级武器计时器优先级"
 
-#: ../../User-Interface.md:313
+#: ../../User-Interface.md:349
 msgid ""
 "You can now sort the timers of superweapons in ascending order from top "
 "to bottom according to a given priority value."
 msgstr "现在你可以根据给定的优先级数值将超级武器的计时器从上到下按升序排列。"
 
-#: ../../User-Interface.md:316
+#: ../../User-Interface.md:352
 msgid ""
 "[SOMESW]              ; SuperWeaponType\n"
 "ShowTimer=yes\n"
@@ -1091,11 +1095,11 @@ msgstr ""
 "ShowTimer=yes\n"
 "ShowTimer.Priority=0  ; integer\n"
 
-#: ../../User-Interface.md:322
+#: ../../User-Interface.md:358
 msgid "Type select for buildings"
 msgstr "建筑同类选择"
 
-#: ../../User-Interface.md:323
+#: ../../User-Interface.md:359
 msgid ""
 "In vanilla game, type select can almost only be used on 1x1 buildings "
 "with `UndeploysInto`. Now it's possible to use it on all buildings if "
@@ -1104,7 +1108,7 @@ msgstr ""
 "在原本的游戏中，类型选择几乎只能用于拥有 `UndeploysInto` 的 1x1 建筑。现在如果将 "
 "`BuildingTypeSelectable` 设为 true，那么也可以对所有建筑使用类型选择。"
 
-#: ../../User-Interface.md:326
+#: ../../User-Interface.md:362
 msgid ""
 "[General]\n"
 "BuildingTypeSelectable=false  ; boolean\n"
@@ -1112,7 +1116,7 @@ msgstr ""
 "[General]\n"
 "BuildingTypeSelectable=false  ; boolean\n"
 
-#: ../../User-Interface.md:332
+#: ../../User-Interface.md:368
 msgid ""
 "In Vanilla, you can type select a building by holding down the T key in "
 "advance and then clicking on the building. However, other type selection "
@@ -1123,36 +1127,36 @@ msgstr ""
 "在原版中，你可以通过提前按住 `T` 键然后点击建筑来进行类型选择。然而，其他类型选择方法（例如先选择建筑再按 `T` "
 "键，或者先选择建筑再按底边栏的类型选择按钮）对建筑无效。"
 
-#: ../../User-Interface.md:336
+#: ../../User-Interface.md:372
 msgid ""
 "Due to technical limitations, this feature is forcibly disabled without "
 "Ares."
 msgstr "由于技术限制，没有 Ares 的情况此功能将被强制禁用。"
 
-#: ../../User-Interface.md:339
+#: ../../User-Interface.md:375
 msgid "Visual indication of income from grinders and refineries"
 msgstr "从回收站和矿场获得收入的视觉提示"
 
-#: ../../User-Interface.md:341
+#: ../../User-Interface.md:377
 msgid ""
 "`DisplayIncome` can be set to display the amount of credits acquired when"
 " a building is grinding units / receiving ore dump from harvesters or "
 "slaves."
 msgstr "`DisplayIncome` 可以设置为显示建筑在回收单位或从矿车或奴隶接受矿石时获得的资金点数。"
 
-#: ../../User-Interface.md:342
+#: ../../User-Interface.md:378
 msgid ""
 "Multiple income within less than one in-game second have their amounts "
 "coalesced into single display."
 msgstr "在游戏内不到一秒的时间内多次收入的金额将会合并成一个来显示。"
 
-#: ../../User-Interface.md:343
+#: ../../User-Interface.md:379
 msgid ""
 "`DisplayIncome.Houses` determines which houses can see the credits "
 "display."
 msgstr "`DisplayIncome.Houses` 决定哪些所属方可以看到资金点数显示。"
 
-#: ../../User-Interface.md:344
+#: ../../User-Interface.md:380
 msgid ""
 "If you don't want players to see how AI cheats with `VirtualPurifiers` "
 "for example, `DisplayIncome.AllowAI` can be set to false to disable the "
@@ -1161,19 +1165,19 @@ msgstr ""
 "例如如果你不希望玩家看到 AI 如何通过 `VirtualPurifiers` 作弊，可以将 `DisplayIncome.AllowAI` 设为"
 " false 以禁用。覆盖上一条选项。"
 
-#: ../../User-Interface.md:345
+#: ../../User-Interface.md:381
 msgid ""
 "`DisplayIncome.Offset` is additional pixel offset for the center of the "
 "credits display, by default `0,0` at building's center."
 msgstr "`DisplayIncome.Offset` 是资金点数显示中心以像素为单位的额外偏移，默认为 `0,0` 即建筑的中心。"
 
-#: ../../User-Interface.md:346
+#: ../../User-Interface.md:382
 msgid ""
 "`[AudioVisual] -> DisplayIncome` also allows to display the amount of "
 "credits when selling a unit on a repair bay."
 msgstr "`[AudioVisual] -> DisplayIncome` 还允许在维修厂出售单位时显示资金点数。"
 
-#: ../../User-Interface.md:349
+#: ../../User-Interface.md:385
 msgid ""
 "[AudioVisual]\n"
 "DisplayIncome=false       ; boolean\n"
@@ -1201,37 +1205,37 @@ msgstr ""
 "[AudioVisual] -> DisplayIncome.Houses\n"
 "DisplayIncome.Offset=0,0  ; X,Y, pixels relative to default\n"
 
-#: ../../User-Interface.md:361
+#: ../../User-Interface.md:397
 msgid "Hotkey Commands"
 msgstr "快捷键命令"
 
-#: ../../User-Interface.md:363
+#: ../../User-Interface.md:399
 msgid "`[ ]` Display Damage Numbers"
 msgstr "`[ ]` 显示伤害数字"
 
-#: ../../User-Interface.md:365
+#: ../../User-Interface.md:401
 msgid ""
 "Switches on/off floating numbers when dealing damage. See "
 "[this](Miscellanous.md#display-damage-numbers) for details."
 msgstr "切换在造成杀伤时显示／隐藏浮动数字。详见 [此处](Miscellanous.md#display-damage-numbers) 以了解。"
 
-#: ../../User-Interface.md:366
+#: ../../User-Interface.md:402
 msgid ""
 "For localization add `TXT_DISPLAY_DAMAGE` and `TXT_DISPLAY_DAMAGE_DESC` "
 "into your `.csf` file."
 msgstr "为了本地化请将 `TXT_DISPLAY_DAMAGE` 和 `TXT_DISPLAY_DAMAGE_DESC` 添加到你的 `.csf` 文件。"
 
-#: ../../User-Interface.md:368
+#: ../../User-Interface.md:404
 msgid "`[ ]` Dump Object Info"
 msgstr "`[ ]` 输出对象信息"
 
-#: ../../User-Interface.md:370
+#: ../../User-Interface.md:406
 msgid ""
 "Writes currently hovered or last selected object info in log and shows a "
 "message. See [this](Miscellanous.md#dump-object-info) for details."
 msgstr "将当前悬停或最后选中的对象的信息写入日志并显示消息。详见 [此处](Miscellanous.md#dump-object-info) 以了解。"
 
-#: ../../User-Interface.md:371
+#: ../../User-Interface.md:407
 msgid ""
 "For localization add `TXT_DUMP_OBJECT_INFO` and "
 "`TXT_DUMP_OBJECT_INFO_DESC` into your `.csf` file."
@@ -1239,15 +1243,15 @@ msgstr ""
 "为了本地化请将 `TXT_DUMP_OBJECT_INFO` 和 `TXT_DUMP_OBJECT_INFO_DESC` 添加到你的 `.csf`"
 " 文件。"
 
-#: ../../User-Interface.md:373
+#: ../../User-Interface.md:409
 msgid "`[ ]` Toggle Frame By Frame Mode"
 msgstr "`[ ]` 开关逐帧模式"
 
-#: ../../User-Interface.md:375
+#: ../../User-Interface.md:411
 msgid "Switches on/off [frame by frame mode](Miscellanous.md#frame-step-in)."
 msgstr "开关[逐帧模式](Miscellanous.md#frame-step-in)。"
 
-#: ../../User-Interface.md:376
+#: ../../User-Interface.md:412
 msgid ""
 "For localization add `TXT_FRAME_BY_FRAME` and `TXT_FRAME_BY_FRAME_DESC` "
 "into your `.csf` file."
@@ -1255,11 +1259,11 @@ msgstr ""
 "为了本地化，请将 `TXT_FRAME_BY_FRAME` 和 `TXT_FRAME_BY_FRAME_DESC` 添加到你的 `.csf` "
 "文件中。"
 
-#: ../../User-Interface.md:378
+#: ../../User-Interface.md:414
 msgid "`[ ]` Save Variables"
 msgstr "`[ ]` 保存变量"
 
-#: ../../User-Interface.md:380
+#: ../../User-Interface.md:416
 msgid ""
 "Save local & global variables to an INI file. See [this](Miscellanous.md"
 "#save-variables-to-file) for details."
@@ -1267,7 +1271,7 @@ msgstr ""
 "将局部变量和全局变量保存到一个 INI 文件。参见 [此处](Miscellanous.md#save-variables-to-file) "
 "以了解。"
 
-#: ../../User-Interface.md:381
+#: ../../User-Interface.md:417
 msgid ""
 "For localization add `TXT_SAVE_VARIABLES` and `TXT_SAVE_VARIABLES_DESC` "
 "into your `.csf` file."
@@ -1275,17 +1279,17 @@ msgstr ""
 "为了本地化，请将 `TXT_SAVE_VARIABLES` 和 `TXT_SAVE_VARIABLES_DESC` 添加到你的 `.csf` "
 "文件中。"
 
-#: ../../User-Interface.md:383
+#: ../../User-Interface.md:419
 msgid "`[ ]` Toggle Designator Range"
 msgstr "`[ ]` 切换指示范围"
 
-#: ../../User-Interface.md:385
+#: ../../User-Interface.md:421
 msgid ""
 "Switches on/off super weapon designator range indicator. See [this"
 "](#show-designator--inhibitor-range) for details."
 msgstr "切换超级武器指示者范围指示器开关。参见 [此处](#show-designator--inhibitor-range) 以了解。"
 
-#: ../../User-Interface.md:386
+#: ../../User-Interface.md:422
 msgid ""
 "For localization add `TXT_DESIGNATOR_RANGE` and "
 "`TXT_DESIGNATOR_RANGE_DESC` into your `.csf` file."
@@ -1293,15 +1297,15 @@ msgstr ""
 "为了本地化，请将 `TXT_DESIGNATOR_RANGE` 和 `TXT_DESIGNATOR_RANGE_DESC` 添加到你的 "
 "`.csf` 文件中。"
 
-#: ../../User-Interface.md:388
+#: ../../User-Interface.md:424
 msgid "`[ ]` Toggle Digital Display"
 msgstr "`[ ]` 开关数字化显示"
 
-#: ../../User-Interface.md:390
+#: ../../User-Interface.md:426
 msgid "Switches on/off [digital display types](#digital-display)."
 msgstr "开关[数字化显示类型](#digital-display)。"
 
-#: ../../User-Interface.md:391
+#: ../../User-Interface.md:427
 msgid ""
 "For localization add `TXT_DIGITAL_DISPLAY` and `TXT_DIGITAL_DISPLAY_DESC`"
 " into your `.csf` file."
@@ -1309,17 +1313,17 @@ msgstr ""
 "为了本地化，请将 `TXT_DIGITAL_DISPLAY` 和 `TXT_DIGITAL_DISPLAY_DESC` 添加到你的 `.csf` "
 "文件中。"
 
-#: ../../User-Interface.md:393
+#: ../../User-Interface.md:429
 msgid "`[ ]` Next Idle Harvester"
 msgstr "`[ ]` 下一个空闲矿车"
 
-#: ../../User-Interface.md:395
+#: ../../User-Interface.md:431
 msgid ""
 "Selects and centers the camera on the next TechnoType that is counted via"
 " the [harvester counter](#harvester-counter) and is currently idle."
 msgstr "选择并将镜头中心转移到下一个被 [矿车计数器](#harvester-counter) 计入且处于空闲状态的科技类型。"
 
-#: ../../User-Interface.md:396
+#: ../../User-Interface.md:432
 msgid ""
 "For localization add `TXT_NEXT_IDLE_HARVESTER` and "
 "`TXT_NEXT_IDLE_HARVESTER_DESC` into your `.csf` file."
@@ -1327,15 +1331,15 @@ msgstr ""
 "为了本地化请将 `TXT_NEXT_IDLE_HARVESTER` 和 `TXT_NEXT_IDLE_HARVESTER_DESC` 添加到你的 "
 "`.csf` 文件。"
 
-#: ../../User-Interface.md:398
+#: ../../User-Interface.md:434
 msgid "`[ ]` Quicksave"
 msgstr "`[ ]` 快速保存"
 
-#: ../../User-Interface.md:400
+#: ../../User-Interface.md:436
 msgid "Save the current singleplayer game."
 msgstr "保存当前的单人游戏"
 
-#: ../../User-Interface.md:401
+#: ../../User-Interface.md:437
 msgid ""
 "For localization, add `TXT_QUICKSAVE`, `TXT_QUICKSAVE_DESC`, "
 "`TXT_QUICKSAVE_SUFFIX` and `MSG:NotAvailableInMultiplayer` into your "
@@ -1344,7 +1348,7 @@ msgstr ""
 "为了本地化，请将 `TXT_QUICKSAVE`、`TXT_QUICKSAVE_DESC`、`TXT_QUICKSAVE_SUFFIX` 和 "
 "`MSG:NotAvailableInMultiplayer` 添加到你的 `.csf` 文件中。"
 
-#: ../../User-Interface.md:402
+#: ../../User-Interface.md:438
 msgid ""
 "These vanilla CSF entries will be used: `TXT_SAVING_GAME`, "
 "`TXT_GAME_WAS_SAVED` and `TXT_ERROR_SAVING_GAME`."
@@ -1352,43 +1356,43 @@ msgstr ""
 "这些原有 CSF 条目将会被使用：`TXT_SAVING_GAME`、`TXT_GAME_WAS_SAVED` 和 "
 "`TXT_ERROR_SAVING_GAME`。"
 
-#: ../../User-Interface.md:403
+#: ../../User-Interface.md:439
 msgid ""
 "The save should be looks like `Allied Mission 25: Esther's Money - "
 "QuickSaved`."
 msgstr "保存的文件名应当类似于 `Allied Mission 25: Esther's Money - QuickSaved`。"
 
-#: ../../User-Interface.md:405
+#: ../../User-Interface.md:441
 msgid "Loading screen"
 msgstr "载入图"
 
-#: ../../User-Interface.md:407
+#: ../../User-Interface.md:443
 msgid "PCX files can now be used as loadscreen images."
 msgstr "现在可以使用 PCX 文件作为载入图图像。"
 
-#: ../../User-Interface.md:408
+#: ../../User-Interface.md:444
 msgid "You can specify custom loadscreen with Ares tag `File.LoadScreen`."
 msgstr "你可以使用 Ares 标签 `File.LoadScreen` 指定自定义载入图。"
 
-#: ../../User-Interface.md:409
+#: ../../User-Interface.md:445
 msgid ""
 "Campaign loading screen (`missionmd.ini -> [LS800BkgdName]`) can also use"
 " PCX image."
 msgstr "战役载入图（`missionmd.ini -> [LS800BkgdName]`) 也可以使用 PCX 图像。"
 
-#: ../../User-Interface.md:410
+#: ../../User-Interface.md:446
 msgid ""
 "Observer loading screen can use `ls800obs.pcx` *(or `ls640obs.pcx` when "
 "screen width is 640)* for this feature."
 msgstr "观察者载入图可以使用 `ls800obs.pcx`（当屏幕宽度为 640 时使用 `ls640obs.pcx`）。"
 
-#: ../../User-Interface.md:411
+#: ../../User-Interface.md:447
 msgid ""
 "The loadscreen size can now be different from the default `800x600` one; "
 "if the image is bigger than the screen it's centered and cropped."
 msgstr "载入图的大小现在可以与默认的 `800x600` 不同；如果图像比屏幕大，它将被居中并裁剪。"
 
-#: ../../User-Interface.md:412
+#: ../../User-Interface.md:448
 msgid ""
 "This feature works in conjunction with CnCNet5 spawner DLL which resizes "
 "loadscreen window to actual monitor size and places the image in center. "
@@ -1398,27 +1402,27 @@ msgstr ""
 "此功能与 CnCNet5 Spawner DLL 相结合，它将把载入界面固定为当前游戏分辨率大小并把载入图置于中间。如果没有 CnCNet5 "
 "Spanwer，那么载入分辨率将被锁定为 `800x600`。"
 
-#: ../../User-Interface.md:413
+#: ../../User-Interface.md:449
 msgid ""
 "Same applies to campaign loading screen (`missionmd.ini -> "
 "[LS800BkgdName]`)."
 msgstr "同样适用于战役载入图（`missionmd.ini -> [LS800BkgdName]`)。"
 
-#: ../../User-Interface.md:414
+#: ../../User-Interface.md:450
 msgid ""
 "You can now disable hardcoded black dots that YR engine shows over empty "
 "spawn locations, which allows to use prettier and more correctly placed "
 "markers that are produced by Map Renderer instead."
 msgstr "现在你可以禁用 YR 引擎在空置出生点显示的黑点，这允许使用由地图渲染器生成的更没关且位置正确的标记。"
 
-#: ../../User-Interface.md:416 ../../User-Interface.md:469
-#: ../../User-Interface.md:498 ../../User-Interface.md:544
-#: ../../User-Interface.md:581 ../../User-Interface.md:610
-#: ../../User-Interface.md:663 ../../User-Interface.md:721
+#: ../../User-Interface.md:452 ../../User-Interface.md:505
+#: ../../User-Interface.md:534 ../../User-Interface.md:580
+#: ../../User-Interface.md:617 ../../User-Interface.md:646
+#: ../../User-Interface.md:699 ../../User-Interface.md:757
 msgid "In `uimd.ini`:"
 msgstr "在 `uimd.ini`："
 
-#: ../../User-Interface.md:417
+#: ../../User-Interface.md:453
 msgid ""
 "[LoadingScreen]\n"
 "DisableEmptySpawnPositions=false  ; boolean\n"
@@ -1426,21 +1430,21 @@ msgstr ""
 "[LoadingScreen]\n"
 "DisableEmptySpawnPositions=false  ; boolean\n"
 
-#: ../../User-Interface.md:422
+#: ../../User-Interface.md:458
 msgid "Miscellanous"
 msgstr "杂项"
 
-#: ../../User-Interface.md:424
+#: ../../User-Interface.md:460
 msgid "Skip saving game on starting a new campaign"
 msgstr "开始新战役时跳过保存游戏"
 
-#: ../../User-Interface.md:426
+#: ../../User-Interface.md:462
 msgid ""
 "When starting a new campaign, the game automatically saves the game. Now "
 "you can decide whether you want that to happen or not."
 msgstr "在开始新战役时游戏会自动保存游戏。现在你可以自行决定是否要进行保存。"
 
-#: ../../User-Interface.md:429
+#: ../../User-Interface.md:465
 msgid ""
 "[Phobos]\n"
 "SaveGameOnScenarioStart=true ; boolean\n"
@@ -1448,27 +1452,27 @@ msgstr ""
 "[Phobos]\n"
 "SaveGameOnScenarioStart=true ; boolean\n"
 
-#: ../../User-Interface.md:434
+#: ../../User-Interface.md:470
 msgid "Sidebar / Battle UI"
 msgstr "侧边栏／战斗界面 UI"
 
-#: ../../User-Interface.md:437 ../../User-Interface.md:439
+#: ../../User-Interface.md:473 ../../User-Interface.md:475
 msgid "Building Production Queue"
 msgstr "建筑生产队列"
 
-#: ../../User-Interface.md:439
+#: ../../User-Interface.md:475
 msgid ""
 "![Building Production Queue](_static/images/buildingQueue.png) *Queueing "
 "multiple buildings*"
 msgstr "![Building Production Queue](_static/images/buildingQueue.png) *列队多个建筑*"
 
-#: ../../User-Interface.md:442
+#: ../../User-Interface.md:478
 msgid ""
 "Buildings can now be queued for construction like other units if "
 "`BuildingProductionQueue` is set to true."
 msgstr "现在如果 `BuildingProductionQueue` 设置为 true 那么建筑可以像其他单位一样列队建造。"
 
-#: ../../User-Interface.md:445
+#: ../../User-Interface.md:481
 msgid ""
 "[General]\n"
 "BuildingProductionQueue=false  ; boolean\n"
@@ -1476,40 +1480,40 @@ msgstr ""
 "[General]\n"
 "BuildingProductionQueue=false  ; boolean\n"
 
-#: ../../User-Interface.md:451
+#: ../../User-Interface.md:487
 msgid ""
 "When the building becomes ready to be placed, the next building's "
 "construction will not begin until the player places the current building."
 msgstr "只有等玩家摆下当前建筑以后序列中的下一个建筑才会开始生产。"
 
-#: ../../User-Interface.md:454
+#: ../../User-Interface.md:490
 msgid "Cameo Sorting"
 msgstr "图标排序"
 
-#: ../../User-Interface.md:456
+#: ../../User-Interface.md:492
 msgid ""
 "You can now specify Cameo Priority for any TechnoType/SuperWeaponType. "
 "Vanilla sorting rules are "
 "[here](https://modenc.renegadeprojects.com/Cameo_Sorting)."
 msgstr "现在你可以为任何科技类型／超级武器类型指定图标优先级。原版排序规则可见[此处](https://modenc.renegadeprojects.com/Cameo_Sorting)。"
 
-#: ../../User-Interface.md:457
+#: ../../User-Interface.md:493
 msgid ""
 "The Cameo Priority is checked just before evevything vanilla. Greater "
 "`CameoPriority` wins."
 msgstr "图标优先级在原版所有内容之前检查。更高的 `CameoPriority` 具有更高优先级。"
 
-#: ../../User-Interface.md:460
+#: ../../User-Interface.md:496
 msgid ""
 "[SOMENAME]             ; TechnoType / SuperWeaponType\n"
 "CameoPriority=0        ; integer\n"
 msgstr ""
 
-#: ../../User-Interface.md:465
+#: ../../User-Interface.md:501
 msgid "Center pause menu background"
 msgstr "暂停菜单背景居中"
 
-#: ../../User-Interface.md:467
+#: ../../User-Interface.md:503
 msgid ""
 "Pause menu background (`bkgdXX(y).shp`) can now optionally be centered on"
 " the center of the available space instead of top-left corner. This "
@@ -1517,7 +1521,7 @@ msgid ""
 " `1024x768` in mind."
 msgstr "现在可以选择将暂停菜单背景（`bkgdXX(y).shp`) 居中而不是丢在左上角。这允许背景在分辨率大于 `1024x768` 的时候更好地设计。"
 
-#: ../../User-Interface.md:470
+#: ../../User-Interface.md:506
 msgid ""
 "[Sidebar]\n"
 "CenterPauseMenuBackground=false  ; boolean\n"
@@ -1525,15 +1529,15 @@ msgstr ""
 "[Sidebar]\n"
 "CenterPauseMenuBackground=false  ; boolean\n"
 
-#: ../../User-Interface.md:475
+#: ../../User-Interface.md:511
 msgid "Custom Missing Cameo (`XXICON.SHP`)"
 msgstr "自定义缺省图标（`XXICON.SHP`）"
 
-#: ../../User-Interface.md:477
+#: ../../User-Interface.md:513
 msgid "You can now specify any SHP/PCX file as `XXICON.SHP` for missing cameo."
 msgstr "现在你可以指定任何 SHP／PCX 文件作为缺省图标使用的 `XXICON.SHP` 。"
 
-#: ../../User-Interface.md:480
+#: ../../User-Interface.md:516
 msgid ""
 "[AudioVisual]\n"
 "MissingCameo=XXICON.SHP  ; filename - including the .shp/.pcx extension\n"
@@ -1541,11 +1545,11 @@ msgstr ""
 "[AudioVisual]\n"
 "MissingCameo=XXICON.SHP  ; filename - including the .shp/.pcx extension\n"
 
-#: ../../User-Interface.md:485
+#: ../../User-Interface.md:521
 msgid "Harvester counter"
 msgstr "矿车计数器"
 
-#: ../../User-Interface.md:487
+#: ../../User-Interface.md:523
 msgid ""
 "![image](_static/images/harvestercounter-01.gif) *Harvester Counter in "
 "[Fantasy ADVENTURE](https://www.moddb.com/mods/fantasy-adventure)*"
@@ -1553,13 +1557,13 @@ msgstr ""
 "![image](_static/images/harvestercounter-01.gif) "
 "*[幻想奇遇](https://www.moddb.com/mods/fantasy-adventure) 中的矿车计数器*"
 
-#: ../../User-Interface.md:490
+#: ../../User-Interface.md:526
 msgid ""
 "An additional counter for your active / total harvesters can be added "
 "near the credits indicator."
 msgstr "可以在资金示数器附近添加一个额外的计数器用于显示你的活动（工作中）矿车的数量／总矿车数量。"
 
-#: ../../User-Interface.md:491
+#: ../../User-Interface.md:527
 msgid ""
 "You can specify which TechnoType should be counted as a Harvester with "
 "`Harvester.Counted`. If not set, the techno with `Harvester=yes` or "
@@ -1568,25 +1572,25 @@ msgstr ""
 "你可以使用 `Harvester.Counted` 指定哪些科技类型被视为矿车。若未设置，带有 `Harvester=yes` 或 "
 "`Enslaves=SOMESLAVE` 的单位将被计入。"
 
-#: ../../User-Interface.md:492
+#: ../../User-Interface.md:528
 msgid ""
 "Can be set to true on buildings with `ProduceCashAmount` to count them as"
 " active 'harvesters' while generating credits."
 msgstr "可以在使用 `ProduceCashAmount` 的建筑上设置为 true 以便在其生成资金时计为工作中的 “矿车”。"
 
-#: ../../User-Interface.md:493
+#: ../../User-Interface.md:529
 msgid ""
 "The counter is displayed with the format of `Label(Active "
 "Harvesters)/(Total Harvesters)`. The label is `⛏ U+26CF` by default."
 msgstr "计数器以 `标签(活动矿车数/总矿车数)` 的格式显示，标签默认为 `⛏ U+26CF`。"
 
-#: ../../User-Interface.md:494
+#: ../../User-Interface.md:530
 msgid ""
 "You can adjust counter position by `Sidebar.HarvesterCounter.Offset`, "
 "negative means left/up, positive means right/down."
 msgstr "你可以通过 `Sidebar.HarvesterCounter.Offset` 调整计数器位置，负数表示左／上，正数表示右／下。"
 
-#: ../../User-Interface.md:495
+#: ../../User-Interface.md:531
 msgid ""
 "By setting `HarvesterCounter.ConditionYellow` and "
 "`HarvesterCounter.ConditionRed`, the game will warn player by changing "
@@ -1598,13 +1602,13 @@ msgstr ""
 "`HarvesterCounter.ConditionRed`，当矿车活动百分比小于或等于它们时，游戏将通过改变计数器颜色来警告玩家，就像 HP "
 "达到 `ConditionYellow` 和 `ConditionRed` 改变颜色一样。"
 
-#: ../../User-Interface.md:496
+#: ../../User-Interface.md:532
 msgid ""
 "The feature can be toggled on/off by user if enabled in mod via "
 "`ShowHarvesterCounter` setting in `RA2MD.INI`."
 msgstr "此逻辑可以在 mod 中于 `RA2MD.INI` 设置 `ShowHarvesterCounter` 来由用户自行开关。"
 
-#: ../../User-Interface.md:499
+#: ../../User-Interface.md:535
 msgid ""
 "[Sidebar]\n"
 "HarvesterCounter.Show=false           ; boolean\n"
@@ -1618,7 +1622,7 @@ msgstr ""
 "HarvesterCounter.ConditionYellow=99%  ; floating point value, percents\n"
 "HarvesterCounter.ConditionRed=50%     ; floating point value, percents\n"
 
-#: ../../User-Interface.md:508
+#: ../../User-Interface.md:544
 msgid ""
 "[SOMETECHNO]                                    ; TechnoType\n"
 "Harvester.Counted=                              ; boolean\n"
@@ -1638,7 +1642,7 @@ msgstr ""
 "Sidebar.HarvesterCounter.ColorYellow=255,255,0  ; integer - R,G,B\n"
 "Sidebar.HarvesterCounter.ColorRed=255,0,0       ; integer - R,G,B\n"
 
-#: ../../User-Interface.md:519
+#: ../../User-Interface.md:555
 msgid ""
 "[Phobos]\n"
 "ShowHarvesterCounter=true  ; boolean\n"
@@ -1646,7 +1650,7 @@ msgstr ""
 "[Phobos]\n"
 "ShowHarvesterCounter=true  ; boolean\n"
 
-#: ../../User-Interface.md:525 ../../User-Interface.md:570
+#: ../../User-Interface.md:561 ../../User-Interface.md:606
 msgid ""
 "If you use the vanilla font in your mod, you can use the improved font "
 "(v4 and higher; can be found on [Phobos supplementaries "
@@ -1662,17 +1666,17 @@ msgstr ""
 ".arsaneus-design.com/project_stuff/2016/WWFontEditor/release/?C=M;O=D) "
 "绘制它们。"
 
-#: ../../User-Interface.md:527
+#: ../../User-Interface.md:563
 msgid ""
 "Additionally, default position for harvester counter overlaps with [weeds"
 " counter](#weeds-counter)."
 msgstr "此外，默认的矿车计数器位置与[废矿计数器](#weeds-counter)重叠。"
 
-#: ../../User-Interface.md:530
+#: ../../User-Interface.md:566
 msgid "Power delta counter"
 msgstr "电力差值计数器"
 
-#: ../../User-Interface.md:532
+#: ../../User-Interface.md:568
 msgid ""
 "![image](_static/images/powerdelta-01.gif) *Power delta Counter in "
 "[Assault Amerika](https://www.moddb.com/mods/assault-amerika)*"
@@ -1680,19 +1684,19 @@ msgstr ""
 "![image](_static/images/powerdelta-01.gif) *[Assault "
 "Amerika](https://www.moddb.com/mods/assault-amerika) 中的电力差值计数器*"
 
-#: ../../User-Interface.md:535
+#: ../../User-Interface.md:571
 msgid ""
 "An additional counter for your power delta (surplus) can be added near "
 "the credits indicator."
 msgstr "可以在资金示数器旁边追加一个电力差值计数器以显示你的电力差值（盈余）。"
 
-#: ../../User-Interface.md:536
+#: ../../User-Interface.md:572
 msgid ""
 "The counter is displayed with the format of `Label(sign)(Power Delta)`. "
 "The label is `PowerLabel` used in `ToolTips` (by default `⚡ U+26A1`)."
 msgstr "计数器以 `Label(sign)(电力差值)` 的格式显示，标签默认为 `PowerLabel`（在 `ToolTips` 中使用）。"
 
-#: ../../User-Interface.md:537
+#: ../../User-Interface.md:573
 msgid ""
 "When the power of the player is blacked-out by a spy or force-shield, "
 "`PowerBlackoutLabel` in `ToolTips` is displayed instead (by default ⚡❌ "
@@ -1701,13 +1705,13 @@ msgstr ""
 "当玩家的电力被间谍或力场护盾中断时，在 `ToolTips` 中显示的会换成 `PowerBlackoutLabel` （默认为 `⚡❌ "
 "U+26A1 U+274C`），文本颜色为 `Sidebar.PowerDelta.ColorGrey`。"
 
-#: ../../User-Interface.md:538
+#: ../../User-Interface.md:574
 msgid ""
 "You can adjust counter position by `Sidebar.PowerDelta.Offset`, negative "
 "means left/up, positive means right/down."
 msgstr "你可以通过 `Sidebar.PowerDelta.Offset` 调整计数器位置，负数表示左／上，正数表示右／下。"
 
-#: ../../User-Interface.md:539
+#: ../../User-Interface.md:575
 msgid ""
 "You can adjust counter text alignment by `Sidebar.PowerDelta.Align`, "
 "acceptable values are left, right, center/centre."
@@ -1715,7 +1719,7 @@ msgstr ""
 "你可以通过 `Sidebar.PowerDelta.Align` "
 "调整计数器对齐方式，可接受的值为左对齐（`left`）、右对齐（`right`）或居中对齐（`center`／`centre`）。"
 
-#: ../../User-Interface.md:540
+#: ../../User-Interface.md:576
 msgid ""
 "By setting `PowerDelta.ConditionYellow` and `PowerDelta.ConditionRed`, "
 "the game will warn player by changing the color of counter whenever the "
@@ -1726,19 +1730,19 @@ msgstr ""
 "`PowerDelta.ConditionRed`，当电力使用率超过指定值时，游戏将通过改变计数器颜色来警告玩家（例如，当负载与输出功率之比大于 "
 "100% 时，计数器会变为红色）。"
 
-#: ../../User-Interface.md:541
+#: ../../User-Interface.md:577
 msgid ""
 "The exception for this rule is when both power output and drain are 0 - "
 "in this case the counter will default to yellow."
 msgstr "此规则的例外情况是当负载和输出功率均为 0 时 - 这种情况下计数器将默认为黄色。"
 
-#: ../../User-Interface.md:542
+#: ../../User-Interface.md:578
 msgid ""
 "The feature can be toggled on/off by user if enabled in mod via "
 "`ShowPowerDelta` setting in `RA2MD.INI`."
 msgstr "此逻辑可以在 mod 中于 `RA2MD.INI` 设置 `ShowPowerDelta` 来由用户自行开关。"
 
-#: ../../User-Interface.md:545
+#: ../../User-Interface.md:581
 msgid ""
 "[Sidebar]\n"
 "PowerDelta.Show=false           ; boolean\n"
@@ -1750,7 +1754,7 @@ msgstr ""
 "PowerDelta.ConditionYellow=75%  ; floating point value, percents\n"
 "PowerDelta.ConditionRed=100%    ; floating point value, percents\n"
 
-#: ../../User-Interface.md:553
+#: ../../User-Interface.md:589
 msgid ""
 "[SOMESIDE]                                ; Side\n"
 "Sidebar.PowerDelta.Offset=0,0             ; X,Y, pixels relative to "
@@ -1772,7 +1776,7 @@ msgstr ""
 "Sidebar.PowerDelta.Align=left             ; Alignment enumeration - left "
 "| center/centre | right\n"
 
-#: ../../User-Interface.md:564
+#: ../../User-Interface.md:600
 msgid ""
 "[Phobos]\n"
 "ShowPowerDelta=true  ; boolean\n"
@@ -1780,11 +1784,11 @@ msgstr ""
 "[Phobos]\n"
 "ShowPowerDelta=true  ; boolean\n"
 
-#: ../../User-Interface.md:573
+#: ../../User-Interface.md:609
 msgid "Producing Progress"
 msgstr "生产进度"
 
-#: ../../User-Interface.md:575
+#: ../../User-Interface.md:611
 msgid ""
 "![image](_static/images/producing-progress-01.gif) *Producing Progress "
 "bars in [Fantasy ADVENTURE](https://www.moddb.com/mods/fantasy-"
@@ -1793,17 +1797,17 @@ msgstr ""
 "![image](_static/images/producing-progress-01.gif) "
 "*[幻想奇遇](https://www.moddb.com/mods/fantasy-adventure) 中的生产进度条*"
 
-#: ../../User-Interface.md:578
+#: ../../User-Interface.md:614
 msgid "You can now know your factories' status via sidebar!"
 msgstr "现在你可以通过侧边栏了解到你的工厂的状态了！"
 
-#: ../../User-Interface.md:579
+#: ../../User-Interface.md:615
 msgid ""
 "You need to draw your own assets (`tab0xpp.shp`, x is replaced by 0-3) "
 "and put them into `sidec0x.mix`."
 msgstr "你需要自己绘制资源（`tab0xpp.shp`，x 替换为 0-3）并将它们放入 `sidec0x.mix` 中。"
 
-#: ../../User-Interface.md:582
+#: ../../User-Interface.md:618
 msgid ""
 "[Sidebar]\n"
 "ProducingProgress.Show=false  ; boolean\n"
@@ -1811,17 +1815,17 @@ msgstr ""
 "[Sidebar]\n"
 "ProducingProgress.Show=false  ; boolean\n"
 
-#: ../../User-Interface.md:588
+#: ../../User-Interface.md:624
 msgid ""
 "[SOMESIDE]                            ; Side\n"
 "Sidebar.ProducingProgress.Offset=0,0  ; X,Y, pixels relative to default\n"
 msgstr ""
 
-#: ../../User-Interface.md:593
+#: ../../User-Interface.md:629
 msgid "Specify Sidebar style"
 msgstr "指定侧边栏样式"
 
-#: ../../User-Interface.md:595
+#: ../../User-Interface.md:631
 msgid ""
 "It's now possible to switch hardcoded sidebar button coords to use GDI "
 "sidebar coords by setting `Sidebar.GDIPosition`. Defaults to true for "
@@ -1830,17 +1834,17 @@ msgstr ""
 "现在可以通过设置 `Sidebar.GDIPosition` 来切换硬编码的侧边栏按钮坐标为 GDI "
 "阵营（原版盟军）侧边栏坐标。默认情况下，第一个阵营为 true，其他阵营为 false。"
 
-#: ../../User-Interface.md:598
+#: ../../User-Interface.md:634
 msgid ""
 "[SOMESIDE]             ; Side\n"
 "Sidebar.GDIPositions=  ; boolean\n"
 msgstr ""
 
-#: ../../User-Interface.md:603
+#: ../../User-Interface.md:639
 msgid "Weeds counter"
 msgstr "废矿计数器"
 
-#: ../../User-Interface.md:605
+#: ../../User-Interface.md:641
 msgid ""
 "Counter for amount of [weeds in storage](Fixed-or-Improved-"
 "Logics.md#weeds--weed-eaters) can be added near the credits indicator."
@@ -1848,25 +1852,25 @@ msgstr ""
 "你可以在资金示数器附近添加一个额外的计数器用于显示[存储的泰伯利亚废矿](Fixed-or-Improved-Logics.md#weeds"
 "--weed-eaters)的数量。"
 
-#: ../../User-Interface.md:606
+#: ../../User-Interface.md:642
 msgid ""
 "You can adjust counter position by `Sidebar.WeedsCounter.Offset` (per-"
 "side setting), negative means left/up, positive means right/down."
 msgstr "你可以通过 `Sidebar.WeedsCounter.Offset`（每个阵营的设置）调整计数器位置，负数表示左／上，正数表示右／下。"
 
-#: ../../User-Interface.md:607
+#: ../../User-Interface.md:643
 msgid ""
 "Counter is by default displayed in side's tooltip color, which can be "
 "overridden per side by setting `Sidebar.WeedsCounter.Color`."
 msgstr "计数器默认为每个阵营拓展工具条的颜色，可以通过设置 `Sidebar.WeedsCounter.Color` 来为每个阵营独立覆盖设置。"
 
-#: ../../User-Interface.md:608
+#: ../../User-Interface.md:644
 msgid ""
 "The feature can be toggled on/off by user if enabled in mod via "
 "`ShowWeedsCounter` setting in `RA2MD.INI`."
 msgstr "此逻辑可以在 mod 中于 `RA2MD.INI` 设置 `ShowWeedsCounter` 来由用户自行开关。"
 
-#: ../../User-Interface.md:611
+#: ../../User-Interface.md:647
 msgid ""
 "[Sidebar]\n"
 "WeedsCounter.Show=false          ; boolean\n"
@@ -1874,7 +1878,7 @@ msgstr ""
 "[Sidebar]\n"
 "WeedsCounter.Show=false          ; boolean\n"
 
-#: ../../User-Interface.md:617
+#: ../../User-Interface.md:653
 msgid ""
 "[SOMESIDE]                       ; Side\n"
 "Sidebar.WeedsCounter.Offset=0,0  ; X,Y, pixels relative to default\n"
@@ -1884,7 +1888,7 @@ msgstr ""
 "Sidebar.WeedsCounter.Offset=0,0  ; X,Y, pixels relative to default\n"
 "Sidebar.WeedsCounter.Color=      ; integer - R,G,B\n"
 
-#: ../../User-Interface.md:624
+#: ../../User-Interface.md:660
 msgid ""
 "[Phobos]\n"
 "ShowWeedsCounter=true  ; boolean\n"
@@ -1892,17 +1896,17 @@ msgstr ""
 "[Phobos]\n"
 "ShowWeedsCounter=true  ; boolean\n"
 
-#: ../../User-Interface.md:630
+#: ../../User-Interface.md:666
 msgid ""
 "Default position for weeds counter overlaps with [harvester counter"
 "](#harvester-counter)."
 msgstr "默认的废矿计数器位置与[矿车计数器](#harvester-counter)重叠。"
 
-#: ../../User-Interface.md:633
+#: ../../User-Interface.md:669
 msgid "SuperWeapon Sidebar"
 msgstr "超武侧边栏"
 
-#: ../../User-Interface.md:635
+#: ../../User-Interface.md:671
 msgid ""
 "![image](_static/images/sw_sidebar.png) *SuperWeapon Sidebar used with "
 "vanilla-like assets for from [Phobos supplementaries](https://github.com"
@@ -1912,23 +1916,23 @@ msgstr ""
 "补充仓库](https://github.com/Phobos-developers/PhobosSupplementaries) 中类原版 UI"
 " 资产的超武侧边栏*"
 
-#: ../../User-Interface.md:638
+#: ../../User-Interface.md:674
 msgid ""
 "It is possible to put superweapon cameos on the left of screen like C&C3 "
 "when `SuperWeaponSidebar` is true."
 msgstr "当 `SuperWeaponSidebar` 为 true 时可以把超级武器的图标像 C&C3 那样放置在屏幕左侧。"
 
-#: ../../User-Interface.md:639
+#: ../../User-Interface.md:675
 msgid "Superweapon Sidebar is compatible with Ares superweapons."
 msgstr "超武侧边栏兼容 Ares 新增的超武类别。"
 
-#: ../../User-Interface.md:640
+#: ../../User-Interface.md:676
 msgid ""
 "`SuperWeaponSidebar.Pyramid` controls whether cameos are arranged in a "
 "pyramid or rectangle."
 msgstr "`SuperWeaponSidebar.Pyramid` 决定图标以金字塔形而不是矩形排列。"
 
-#: ../../User-Interface.md:641
+#: ../../User-Interface.md:677
 msgid ""
 "`SuperWeaponSidebar.Interval` controls the distance between two column "
 "cameos (excluding the background). When you need to make a background, "
@@ -1938,7 +1942,7 @@ msgstr ""
 "`SuperWeaponSidebar.Interval` 控制两列图标之间的间距（不包括背景）。如果你需要制作背景那么背景图像的宽度应当为 "
 "`SuperWeaponSidebar.Interval` + 60（图标固定宽度）。"
 
-#: ../../User-Interface.md:642
+#: ../../User-Interface.md:678
 msgid ""
 "`SuperWeaponSidebar.LeftOffset` controls the distance between the left "
 "side of cameo and the left side of its column (background). This should "
@@ -1947,7 +1951,7 @@ msgstr ""
 "`SuperWeaponSidebar.LeftOffset` 控制图标左侧与其所在列（背景）左侧的距离，该值不应大于 "
 "`SuperWeaponSidebar.Interval`。"
 
-#: ../../User-Interface.md:643
+#: ../../User-Interface.md:679
 msgid ""
 "`SuperWeaponSidebar.CameoHeight` controls the distance from the top of "
 "the previous cameo to the top of the next cameo. That is, the space "
@@ -1959,17 +1963,17 @@ msgstr ""
 "`SuperWeaponSidebar.CameoHeight` - 48（图标固定高度）。该值不应小于 "
 "48。如果你需要制作背景那么此值即为背景图像的高度。"
 
-#: ../../User-Interface.md:644
+#: ../../User-Interface.md:680
 msgid ""
 "`SuperWeaponSidebar.Max` controls the maximum number of cameos on the "
 "leftmost column, which also depends on the current game resolution."
 msgstr "`SuperWeaponSidebar.Max` 控制左侧每列最多显示的图标数量，这也取决于游戏分辨率。"
 
-#: ../../User-Interface.md:645
+#: ../../User-Interface.md:681
 msgid "`SuperWeaponSidebar.MaxColumns` controls that maximum count of columns."
 msgstr "`SuperWeaponSidebar.MaxColumns` 控制最多有多少列。"
 
-#: ../../User-Interface.md:646
+#: ../../User-Interface.md:682
 msgid ""
 "`SuperWeaponSidebar.Significance` is needed for user to control which "
 "superweapons appear on the sidebar. Only superweapons with "
@@ -1981,7 +1985,7 @@ msgstr ""
 "`SuperWeaponSidebar.Significance` 不低于用户定义的 "
 "`SuperWeaponSidebar.RequiredSignificance` 时才会出现。"
 
-#: ../../User-Interface.md:649
+#: ../../User-Interface.md:685
 msgid ""
 "While a mod maker can \"ban\" certain superweapons from appearing on a "
 "sidebar completely using `SuperWeaponSidebar.Allow=false` and "
@@ -2003,37 +2007,37 @@ msgstr ""
 "来控制哪些超武出现在侧边栏上。这样一来具有不同偏好和不同显示分辨率的用户就可以通过客户端设置来控制他们希望在侧边栏上看到多少超武而无需编辑 Mod"
 " 文件，并且你可以通过默认的 Significance 值来精确指定你的预期效果。"
 
-#: ../../User-Interface.md:652
+#: ../../User-Interface.md:688
 msgid ""
 "There is a hotkey to toggle the sidebar on/off, which can be bound to a "
 "key in the hotkey settings."
 msgstr "快捷键设置中新增了一个快捷键条目以用于开关超武侧边栏。"
 
-#: ../../User-Interface.md:653
+#: ../../User-Interface.md:689
 msgid ""
 "`TXT_TOGGLE_SW_SIDEBAR` and `TXT_TOGGLE_SW_SIDEBAR_DESC` are used for "
 "localization of the hotkey."
 msgstr "`TXT_TOGGLE_SW_SIDEBAR` 与 `TXT_TOGGLE_SW_SIDEBAR_DESC` 用于该快捷键的本地化。"
 
-#: ../../User-Interface.md:654
+#: ../../User-Interface.md:690
 msgid ""
 "`SuperWeaponSidebarKeysEnabled` enables users to use hotkeys for "
 "superweapons displayed on the sidebar."
 msgstr "`SuperWeaponSidebarKeysEnabled` 允许用户使用快捷键拉起侧边栏上显示的超武。"
 
-#: ../../User-Interface.md:655
+#: ../../User-Interface.md:691
 msgid ""
 "The hotkeys are positional and are only provided for the first 10 "
 "superweapons."
 msgstr "这些快捷键的位置是定死仅对应前 10 个超武的。"
 
-#: ../../User-Interface.md:656
+#: ../../User-Interface.md:692
 msgid ""
 "If assigned, a hotkey will be displayed on a superweapon instead of the "
 "`Ready` (or its alternative) text."
 msgstr "如果已分配快捷键，则对应的按键会替代 `就绪` 等文本显示在超武图标上。"
 
-#: ../../User-Interface.md:657
+#: ../../User-Interface.md:693
 msgid ""
 "For localization of those hotkeys, add `TXT_FIRE_TACTICAL_SW_XX` and "
 "`TXT_FIRE_TACTICAL_SW_XX_DESC` into your `.csf` file."
@@ -2041,7 +2045,7 @@ msgstr ""
 "为了本地化，请将 `TXT_FIRE_TACTICAL_SW_XX` 和 `TXT_FIRE_TACTICAL_SW_XX_DESC` 添加到你的"
 " `.csf` 文件中。"
 
-#: ../../User-Interface.md:660
+#: ../../User-Interface.md:696
 msgid ""
 "Positional superweapon hotkeys are an experimental feature and currently "
 "the user experience may be not polished enough, due to superweapon "
@@ -2049,8 +2053,18 @@ msgid ""
 " default."
 msgstr "超武快捷键属于实验性功能并且由于超武在侧边栏上的位置并不固定所以当前用户体验可能不够完善，因此该功默认处于禁用状态。"
 
-#: ../../User-Interface.md:664
+#: ../../User-Interface.md:700
+#, fuzzy
 msgid ""
+"[Sidebar]\n"
+"SuperWeaponSidebar=false                    ; boolean\n"
+"SuperWeaponSidebar.Pyramid=true             ; boolean\n"
+"SuperWeaponSidebar.Interval=0               ; integer, pixels\n"
+"SuperWeaponSidebar.LeftOffset=0             ; integer, pixels\n"
+"SuperWeaponSidebar.CameoHeight=48           ; integer, pixels\n"
+"SuperWeaponSidebar.Max=0                    ; integer\n"
+"SuperWeaponSidebar.MaxColumns=              ; integer\n"
+msgstr ""
 "[Sidebar]\n"
 "SuperWeaponSidebar=false              ; boolean\n"
 "SuperWeaponSidebar.Pyramid=true      ; boolean\n"
@@ -2059,67 +2073,58 @@ msgid ""
 "SuperWeaponSidebar.CameoHeight=48     ; integer, pixels\n"
 "SuperWeaponSidebar.Max=0              ; integer\n"
 "SuperWeaponSidebar.MaxColumns=        ; integer\n"
-msgstr ""
-"[Sidebar]\n"
-"SuperWeaponSidebar=false              ; boolean\n"
-"SuperWeaponSidebar.Pyramid=true      ; boolean\n"
-"SuperWeaponSidebar.Interval=0         ; integer, pixels\n"
-"SuperWeaponSidebar.LeftOffset=0       ; integer, pixels\n"
-"SuperWeaponSidebar.CameoHeight=48     ; integer, pixels\n"
-"SuperWeaponSidebar.Max=0              ; integer\n"
-"SuperWeaponSidebar.MaxColumns=        ; integer\n"
 
-#: ../../User-Interface.md:676
+#: ../../User-Interface.md:712
 msgid ""
 "[GlobalControls]\n"
-"SuperWeaponSidebarKeysEnabled=false    ; boolean\n"
+"SuperWeaponSidebarKeysEnabled=false         ; boolean\n"
 "\n"
 "[AudioVisual]\n"
-"SuperWeaponSidebar.AllowByDefault=false   ; boolean\n"
+"SuperWeaponSidebar.AllowByDefault=false     ; boolean\n"
 "\n"
-"[SOMESIDE]\n"
-"SuperWeaponSidebar.OnPCX=             ; filename - including the .pcx "
-"extension\n"
-"SuperWeaponSidebar.OffPCX=            ; filename - including the .pcx "
-"extension\n"
-"SuperWeaponSidebar.TopPCX=            ; filename - including the .pcx "
-"extension\n"
-"SuperWeaponSidebar.CenterPCX=         ; filename - including the .pcx "
-"extension\n"
-"SuperWeaponSidebar.BottomPCX=         ; filename - including the .pcx "
-"extension\n"
+"[SOMESIDE]                                  ; Side\n"
+"SuperWeaponSidebar.OnPCX=                   ; filename - including the "
+".pcx extension\n"
+"SuperWeaponSidebar.OffPCX=                  ; filename - including the "
+".pcx extension\n"
+"SuperWeaponSidebar.TopPCX=                  ; filename - including the "
+".pcx extension\n"
+"SuperWeaponSidebar.CenterPCX=               ; filename - including the "
+".pcx extension\n"
+"SuperWeaponSidebar.BottomPCX=               ; filename - including the "
+".pcx extension\n"
 "\n"
-"[SOMESW]\n"
-"SuperWeaponSidebar.Allow=             ; boolean\n"
-"SuperWeaponSidebar.PriorityHouses=    ; List of house types\n"
-"SuperWeaponSidebar.RequiredHouses=    ; List of house types\n"
-"SuperWeaponSidebar.Significance=0     ; integer\n"
+"[SOMESW]                                    ; SuperWeaponType\n"
+"SuperWeaponSidebar.Allow=                   ; boolean\n"
+"SuperWeaponSidebar.PriorityHouses=          ; List of house types\n"
+"SuperWeaponSidebar.RequiredHouses=          ; List of house types\n"
+"SuperWeaponSidebar.Significance=0           ; integer\n"
 msgstr ""
 "[GlobalControls]\n"
-"SuperWeaponSidebarKeysEnabled=false    ; boolean\n"
+"SuperWeaponSidebarKeysEnabled=false         ; boolean\n"
 "\n"
 "[AudioVisual]\n"
-"SuperWeaponSidebar.AllowByDefault=false   ; boolean\n"
+"SuperWeaponSidebar.AllowByDefault=false     ; boolean\n"
 "\n"
-"[SOMESIDE]\n"
-"SuperWeaponSidebar.OnPCX=             ; filename - including the .pcx "
-"extension\n"
-"SuperWeaponSidebar.OffPCX=            ; filename - including the .pcx "
-"extension\n"
-"SuperWeaponSidebar.TopPCX=            ; filename - including the .pcx "
-"extension\n"
-"SuperWeaponSidebar.CenterPCX=         ; filename - including the .pcx "
-"extension\n"
-"SuperWeaponSidebar.BottomPCX=         ; filename - including the .pcx "
-"extension\n"
+"[SOMESIDE]                                  ; Side\n"
+"SuperWeaponSidebar.OnPCX=                   ; filename - including the "
+".pcx extension\n"
+"SuperWeaponSidebar.OffPCX=                  ; filename - including the "
+".pcx extension\n"
+"SuperWeaponSidebar.TopPCX=                  ; filename - including the "
+".pcx extension\n"
+"SuperWeaponSidebar.CenterPCX=               ; filename - including the "
+".pcx extension\n"
+"SuperWeaponSidebar.BottomPCX=               ; filename - including the "
+".pcx extension\n"
 "\n"
-"[SOMESW]\n"
-"SuperWeaponSidebar.Allow=             ; boolean\n"
-"SuperWeaponSidebar.PriorityHouses=    ; List of house types\n"
-"SuperWeaponSidebar.RequiredHouses=    ; List of house types\n"
-"SuperWeaponSidebar.Significance=0     ; integer\n"
+"[SOMESW]                                    ; SuperWeaponType\n"
+"SuperWeaponSidebar.Allow=                   ; boolean\n"
+"SuperWeaponSidebar.PriorityHouses=          ; List of house types\n"
+"SuperWeaponSidebar.RequiredHouses=          ; List of house types\n"
+"SuperWeaponSidebar.Significance=0           ; integer\n"
 
-#: ../../User-Interface.md:698
+#: ../../User-Interface.md:734
 msgid ""
 "[Phobos]\n"
 "SuperWeaponSidebar.RequiredSignificance=0   ; integer\n"
@@ -2127,7 +2132,7 @@ msgstr ""
 "[Phobos]\n"
 "SuperWeaponSidebar.RequiredSignificance=0   ; integer\n"
 
-#: ../../User-Interface.md:704
+#: ../../User-Interface.md:740
 msgid ""
 "While the feature is usable without any extra graphics, you can find "
 "example assets to use with vanilla graphics on [Phobos supplementaries "
@@ -2136,11 +2141,11 @@ msgstr ""
 "虽然该功能可以在没有任何额外图像的情况下使用，但你可以在 [Phobos 补充仓库](https://github.com/Phobos-"
 "developers/PhobosSupplementaries) 找到数与原版界面 UI 图像搭配使用的示例资产。"
 
-#: ../../User-Interface.md:707
+#: ../../User-Interface.md:743
 msgid "Tooltips"
 msgstr "拓展工具条"
 
-#: ../../User-Interface.md:709
+#: ../../User-Interface.md:745
 msgid ""
 "![image](_static/images/tooltips-01.png) *Extended tooltips used in [CnC:"
 " Final War](https://www.moddb.com/mods/cncfinalwar)*"
@@ -2148,7 +2153,7 @@ msgstr ""
 "![image](_static/images/tooltips-01.png) *[CnC: Final "
 "War](https://www.moddb.com/mods/cncfinalwar) 中的拓展拓展工具条*"
 
-#: ../../User-Interface.md:712
+#: ../../User-Interface.md:748
 msgid ""
 "Sidebar tooltips can now display extended information about the "
 "TechnoType/SWType when hovered over it's cameo. In addition the low "
@@ -2158,19 +2163,19 @@ msgstr ""
 "现在当鼠标悬停在图标上时侧边栏拓展工具条提示可以显示关于科技类型／超级武器类型的拓展信息。此外当通过相应标签启用此功能时低字符限制将被取消从而允许长达"
 " 1024 字符长度的工具提示信息。"
 
-#: ../../User-Interface.md:713
+#: ../../User-Interface.md:749
 msgid ""
 "TechnoType's tooltip would display it's name, cost, power, build time and"
 " description (when applicable)."
 msgstr "科技类型的拓展工具条将显示其名称、成本、电力、建造时间和描述（如果适用）。"
 
-#: ../../User-Interface.md:714
+#: ../../User-Interface.md:750
 msgid ""
 "SWType's tooltip would display it's name, cost,  and recharge time (when "
 "applicable)."
 msgstr "超级武器类型的拓展工具条将显示其名称、成本和充能时间（如果适用）。"
 
-#: ../../User-Interface.md:715
+#: ../../User-Interface.md:751
 #, python-format
 msgid ""
 "If `SW.Shots` from Ares is used, a C-style format string default to "
@@ -2181,7 +2186,7 @@ msgstr ""
 "如果使用了 Ares 的 `SW.Shots`，那么将会附加一个 C 语言风格的格式化字符，默认为 `Shots: %d`。格式可以在 csf "
 "中自定义。如果使用双参数格式（例如 `还剩 %d/%d 发`），第二个整数是 `SW.Shots`。"
 
-#: ../../User-Interface.md:716
+#: ../../User-Interface.md:752
 msgid ""
 "Extended tooltips don't use `TXT_MONEY_FORMAT_1` and "
 "`TXT_MONEY_FORMAT_2`. Instead you can specify cost, power and time labels"
@@ -2192,20 +2197,20 @@ msgstr ""
 "`TXT_MONEY_FORMAT_2`。但你可以使用对应的标签指定成本、电力和时间标签（在对应值前显示）。默认为 `$ U+0024`，`⚡ "
 "U+26A1` 和 `⌚ U+231A`。"
 
-#: ../../User-Interface.md:717
+#: ../../User-Interface.md:753
 msgid ""
 "Fixed a bug when switching build queue tabs via QWER didn't make tooltips"
 " disappear as they should, resulting in stuck tooltips."
 msgstr "修复了一个通过 QWER 切换建造队列标签时拓展工具条没有消失的问题，这导致拓展工具条卡住。"
 
-#: ../../User-Interface.md:718
+#: ../../User-Interface.md:754
 msgid ""
 "The tooltips can now go over the sidebar bounds to accommodate for longer"
 " contents. You can control maximum text width with a new tag (paddings "
 "are excluded from the number you specify)."
 msgstr "现在拓展工具条可以超出侧边栏边界以容纳更长的内容。你可以使用新增的标签控制最大文本宽度（不包括边框）。"
 
-#: ../../User-Interface.md:719
+#: ../../User-Interface.md:755
 msgid ""
 "`AnchoredToolTips` positions the tooltip always to the left of sidebar, "
 "only applies to if `ExtendedToolTips` is set to true and they are enabled"
@@ -2214,7 +2219,7 @@ msgstr ""
 "`AnchoredToolTips` 将拓展工具条始终定到侧边栏左侧，仅在 `ExtendedToolTips` 设置为 true "
 "且用户启用时生效。"
 
-#: ../../User-Interface.md:722
+#: ../../User-Interface.md:758
 msgid ""
 "[ToolTips]\n"
 "ExtendedToolTips=false     ; boolean\n"
@@ -2236,7 +2241,7 @@ msgstr ""
 "SWShotsFormat=<none>       ; CSF entry key\n"
 "MaxWidth=0                 ; integer, pixels\n"
 
-#: ../../User-Interface.md:734
+#: ../../User-Interface.md:770
 msgid ""
 "[SOMENAME]            ; TechnoType or SWType\n"
 "UIDescription=<none>  ; CSF entry key\n"
@@ -2244,13 +2249,13 @@ msgstr ""
 "[SOMENAME]            ; TechnoType or SWType\n"
 "UIDescription=<none>  ; CSF entry key\n"
 
-#: ../../User-Interface.md:739
+#: ../../User-Interface.md:775
 msgid ""
 "The descriptions are designed to be toggleable by users. For now you can "
 "only do that externally via client or manually."
 msgstr "描述设计可由用户自行切换。目前你只能通过客户端或进行手动设置。"
 
-#: ../../User-Interface.md:742
+#: ../../User-Interface.md:778
 msgid ""
 "[Phobos]\n"
 "ToolTipDescriptions=true  ; boolean\n"
@@ -2258,7 +2263,7 @@ msgstr ""
 "[Phobos]\n"
 "ToolTipDescriptions=true  ; boolean\n"
 
-#: ../../User-Interface.md:748
+#: ../../User-Interface.md:784
 msgid ""
 "Same as with harvester counter, you can download the improved font (v4 "
 "and higher; can be found on [Phobos supplementaries "
@@ -2268,13 +2273,13 @@ msgstr ""
 "与矿车计数器相同，你可以下载改进的字体（v4 或更高版本；可以在 [Phobos 补充仓库](https://github.com/Phobos-"
 "developers/PhobosSupplementaries) 中找到）否则你需要自己编辑字库文件。"
 
-#: ../../User-Interface.md:751
+#: ../../User-Interface.md:787
 msgid ""
 "The background color and opacity of tooltips can now be customized "
 "globally or per side."
 msgstr "现在可以全局或按阵营自定义拓展工具条的背景色和不透明度。"
 
-#: ../../User-Interface.md:754
+#: ../../User-Interface.md:790
 msgid ""
 "[SOMESIDE]                          ; Side\n"
 "ToolTip.Background.Color=0,0,0      ; integer - R,G,B, defaults to "
@@ -2294,13 +2299,13 @@ msgstr ""
 "ToolTip.Background.BlurSize=0.0     ; float, defaults to [AudioVisual] ->"
 " ToolTip.Background.BlurSize, which defaults to 0.0\n"
 
-#: ../../User-Interface.md:762
+#: ../../User-Interface.md:798
 msgid ""
 "The blur effect is resource intensive. Please make sure you really want "
 "to enable this effect, otherwise leave it to 0.0 so it stays disabled."
 msgstr "模糊效果非常占用资源，请确保你的确想要启用此效果，否则请保持 0.0 以禁用。"
 
-#: ../../User-Interface.md:766
+#: ../../User-Interface.md:802
 msgid ""
 "[Phobos]\n"
 "ToolTipBlur=false  ; boolean, whether the blur effect of tooltips will be"

--- a/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Whats-New.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Phobos \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-15 21:26+0800\n"
+"POT-Creation-Date: 2025-06-23 01:10+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -575,6 +575,10 @@ msgid ""
 "68=House,1,2\n"
 "69=Non-inert,10\n"
 "70=AITargetTypes index,0\n"
+"101=BannerType,0\n"
+"102=Horizontal position,0\n"
+"103=Vertical position,0\n"
+"104=Banner ID,0\n"
 "\n"
 "[EventsRA2]\n"
 "500=Local variable is greater than,48,6,0,0,[LONG DESC],0,1,500,1\n"
@@ -677,6 +681,14 @@ msgid ""
 "608=Set force enemy (Phobos),0,0,2,0,0,0,0,0,0, Force an enemy, it will "
 "not change with the change of hate-value. -1 will remove the forced "
 "enemy, -2 will never have any enemies.,0,1,608\n"
+"800=Display banner and local variable "
+"(Phobos),4,101,104,102,103,3,0,0,0,Draw banner on screen and replace "
+"banner with same ID,0,1,800\n"
+"801=Display banner and global variable "
+"(Phobos),4,101,104,102,103,35,0,0,0,Draw banner on screen and replace "
+"banner with same ID,0,1,801\n"
+"802=Delete banner (Phobos),0,104,0,0,0,0,0,0,0,Delete banner with "
+"ID,0,1,802\n"
 "\n"
 "; FOLLOWING ENTRIES REQUIRE FA2SP.DLL (by secsome)\n"
 "[ScriptTypeLists]\n"
@@ -821,6 +833,10 @@ msgstr ""
 "68=House,1,2\n"
 "69=Non-inert,10\n"
 "70=AITargetTypes index,0\n"
+"101=BannerType,0\n"
+"102=Horizontal position,0\n"
+"103=Vertical position,0\n"
+"104=Banner ID,0\n"
 "\n"
 "[EventsRA2]\n"
 "500=Local variable is greater than,48,6,0,0,[LONG DESC],0,1,500,1\n"
@@ -923,6 +939,14 @@ msgstr ""
 "608=Set force enemy (Phobos),0,0,2,0,0,0,0,0,0, Force an enemy, it will "
 "not change with the change of hate-value. -1 will remove the forced "
 "enemy, -2 will never have any enemies.,0,1,608\n"
+"800=Display banner and local variable "
+"(Phobos),4,101,104,102,103,3,0,0,0,Draw banner on screen and replace "
+"banner with same ID,0,1,800\n"
+"801=Display banner and global variable "
+"(Phobos),4,101,104,102,103,35,0,0,0,Draw banner on screen and replace "
+"banner with same ID,0,1,801\n"
+"802=Delete banner (Phobos),0,104,0,0,0,0,0,0,0,Delete banner with "
+"ID,0,1,802\n"
 "\n"
 "; FOLLOWING ENTRIES REQUIRE FA2SP.DLL (by secsome)\n"
 "[ScriptTypeLists]\n"
@@ -1054,21 +1078,21 @@ msgstr ""
 "26=Global variables,-5\n"
 "27=Global variables,-6\n"
 
-#: ../../Whats-New.md:311
+#: ../../Whats-New.md:318
 msgid "Changelog"
 msgstr "更新日志"
 
-#: ../../Whats-New.md:313
+#: ../../Whats-New.md:320
 msgid "Version TBD (develop branch nightly builds)"
 msgstr "待定版本（开发分支自动构建版本）"
 
-#: ../../Whats-New.md:318 ../../Whats-New.md:442 ../../Whats-New.md:794
-#: ../../Whats-New.md:825 ../../Whats-New.md:1028 ../../Whats-New.md:1056
-#: ../../Whats-New.md:1073 ../../Whats-New.md:1131
+#: ../../Whats-New.md:325 ../../Whats-New.md:454 ../../Whats-New.md:805
+#: ../../Whats-New.md:836 ../../Whats-New.md:1039 ../../Whats-New.md:1067
+#: ../../Whats-New.md:1084 ../../Whats-New.md:1142
 msgid "New:"
 msgstr "新增内容："
 
-#: ../../Whats-New.md:319
+#: ../../Whats-New.md:326
 msgid ""
 "[Allow using waypoints, area guard and attack move with aircraft](Fixed-"
 "or-Improved-Logics.md#extended-aircraft-missions) (by CrimRecya)"
@@ -1076,19 +1100,19 @@ msgstr ""
 "[允许战机使用路径点、区域警戒和移动攻击](Fixed-or-Improved-Logics.md#extended-aircraft-"
 "missions)（by CrimRecya）"
 
-#: ../../Whats-New.md:320
+#: ../../Whats-New.md:327
 msgid ""
 "[Enhanced Straight trajectory](New-or-Enhanced-Logics.md#straight-"
 "trajectory) (by CrimRecya)"
 msgstr "[增强的直线轨迹](New-or-Enhanced-Logics.md#straight-trajectory)（by CrimRecya）"
 
-#: ../../Whats-New.md:321
+#: ../../Whats-New.md:328
 msgid ""
 "[Enable building production queue](User-Interface.md#building-production-"
 "queue) (by CrimRecya)"
 msgstr "[启用建筑生产队列](User-Interface.md#building-production-queue)（by CrimRecya）"
 
-#: ../../Whats-New.md:322
+#: ../../Whats-New.md:329
 msgid ""
 "[Custom exit cell for infantry factory](Fixed-or-Improved-Logics.md"
 "#custom-exit-cell-for-infantry-factory) (by Starkku)"
@@ -1096,7 +1120,7 @@ msgstr ""
 "[自定义兵营退出单元格](Fixed-or-Improved-Logics.md#custom-exit-cell-for-infantry-"
 "factory)（by Starkku）"
 
-#: ../../Whats-New.md:323
+#: ../../Whats-New.md:330
 msgid ""
 "[Option for vehicles to keep target when issued move command](Fixed-or-"
 "Improved-Logics.md#retain-target-on-movement-command) (by Starkku)"
@@ -1104,7 +1128,7 @@ msgstr ""
 "[设置载具在发出移动命令时是否保持目标](Fixed-or-Improved-Logics.md#retain-target-on-"
 "movement-command)（by Starkku）"
 
-#: ../../Whats-New.md:324
+#: ../../Whats-New.md:331
 msgid ""
 "[Skip anim delay for burst fire](Fixed-or-Improved-Logics.md#skip-anim-"
 "delay-for-burst-fire) (by TaranDahl)"
@@ -1112,7 +1136,7 @@ msgstr ""
 "[为有 `Burst` 的武器跳过建筑开火前摇动画](Fixed-or-Improved-Logics.md#skip-anim-delay-"
 "for-burst-fire)（by TaranDahl）"
 
-#: ../../Whats-New.md:325
+#: ../../Whats-New.md:332
 msgid ""
 "[Extending `Power` to all TechnoTypes](Fixed-or-Improved-Logics.md#power-"
 "drain-for-units) (by Morton)"
@@ -1120,13 +1144,13 @@ msgstr ""
 "[将 `Power` 拓展到所有科技类型](Fixed-or-Improved-Logics.md#power-drain-for-"
 "units)（by Morton）"
 
-#: ../../Whats-New.md:326
+#: ../../Whats-New.md:333
 msgid ""
 "[New Parabola trajectory](New-or-Enhanced-Logics.md#parabola-trajectory) "
 "(by CrimRecya)"
 msgstr "[新的抛物线轨迹](New-or-Enhanced-Logics.md#parabola-trajectory)（by CrimRecya）"
 
-#: ../../Whats-New.md:327
+#: ../../Whats-New.md:334
 msgid ""
 "[Type select for buildings](User-Interface.md#type-select-for-buildings) "
 "(code by TaranDahl, doc by Ollerus)"
@@ -1134,7 +1158,7 @@ msgstr ""
 "[建筑的类型选择](User-Interface.md#type-select-for-buildings)（代码 By TaranDahl，文档"
 " by Ollerus）"
 
-#: ../../Whats-New.md:328
+#: ../../Whats-New.md:335
 msgid ""
 "[Raise alert when technos are taking damage](New-or-Enhanced-Logics.md"
 "#raise-alert-when-technos-are-taking-damage) (by TaranDahl)"
@@ -1142,7 +1166,7 @@ msgstr ""
 "[当科技类型受到伤害时发出警报](New-or-Enhanced-Logics.md#raise-alert-when-technos-are-"
 "taking-damage)（by TaranDahl）"
 
-#: ../../Whats-New.md:329
+#: ../../Whats-New.md:336
 msgid ""
 "[Enhanced Bombard trajectory](New-or-Enhanced-Logics.md#bombard-"
 "trajectory) (by CrimRecya & Ollerus, based on knowledge of NaotoYuuki)"
@@ -1150,7 +1174,7 @@ msgstr ""
 "[增强的轰击轨迹](New-or-Enhanced-Logics.md#bombard-trajectory)（by CrimRecya 与 "
 "Ollerus，基于 NaotoYuuki 的知识）"
 
-#: ../../Whats-New.md:330
+#: ../../Whats-New.md:337
 msgid ""
 "[Toggle waypoint for building](Fixed-or-Improved-Logics.md#waypoints-for-"
 "buildings) (by TaranDahl)"
@@ -1158,7 +1182,7 @@ msgstr ""
 "[建筑路径点开关](Fixed-or-Improved-Logics.md#waypoints-for-buildings)（by "
 "TaranDahl）"
 
-#: ../../Whats-New.md:331
+#: ../../Whats-New.md:338
 msgid ""
 "[Bunkerable checks dehardcode](Fixed-or-Improved-Logics.md#bunker-"
 "entering-check-dehardcode) (by TaranDahl)"
@@ -1166,7 +1190,7 @@ msgstr ""
 "[坦克碉堡准入检查的去硬编码化](Fixed-or-Improved-Logics.md#bunker-entering-check-"
 "dehardcode)（by TaranDahl）"
 
-#: ../../Whats-New.md:332
+#: ../../Whats-New.md:339
 msgid ""
 "[No turret unit turn to the target](Fixed-or-Improved-Logics.md#unit-"
 "without-turret-always-turn-to-target) (by CrimRecya & TaranDahl)"
@@ -1174,7 +1198,7 @@ msgstr ""
 "[无炮塔单位转向目标](Fixed-or-Improved-Logics.md#unit-without-turret-always-turn-"
 "to-target)（by CrimRecya 与 TaranDahl）"
 
-#: ../../Whats-New.md:333
+#: ../../Whats-New.md:340
 msgid ""
 "[Damage multiplier for different houses](New-or-Enhanced-Logics.md"
 "#damage-multiplier-for-different-houses) (by CrimRecya)"
@@ -1182,15 +1206,15 @@ msgstr ""
 "[对不同所属方的伤害修正比](New-or-Enhanced-Logics.md#damage-multiplier-for-different-"
 "houses)（by CrimRecya）"
 
-#: ../../Whats-New.md:334
+#: ../../Whats-New.md:341
 msgid "Customizable duration for electric bolts (by Starkku)"
 msgstr "自定义 EBolt 电弧持续时间（by Starkku）"
 
-#: ../../Whats-New.md:335
+#: ../../Whats-New.md:342
 msgid "Customizable FLH tracking for electric bolts (by Starkku)"
 msgstr "自定义 EBolt 跟随 FLH（by Starkku）"
 
-#: ../../Whats-New.md:336
+#: ../../Whats-New.md:343
 msgid ""
 "[Extended gattling rate down logic](New-or-Enhanced-Logics.md#extended-"
 "gattling-rate-down-logic) (by CrimRecya)"
@@ -1198,7 +1222,7 @@ msgstr ""
 "[拓展的盖特掉档逻辑](New-or-Enhanced-Logics.md#extended-gattling-rate-down-"
 "logic)（by CrimRecya）"
 
-#: ../../Whats-New.md:337
+#: ../../Whats-New.md:344
 msgid ""
 "[Sell or undeploy building on impact](New-or-Enhanced-Logics.md#sell-or-"
 "undeploy-building-on-impact) (by CrimRecya)"
@@ -1206,7 +1230,7 @@ msgstr ""
 "[弹头将建筑出售或反部署](New-or-Enhanced-Logics.md#sell-or-undeploy-building-on-"
 "impact)（by CrimRecya）"
 
-#: ../../Whats-New.md:338
+#: ../../Whats-New.md:345
 msgid ""
 "[No rearm and reload in EMP or temporal](New-or-Enhanced-Logics.md#no-"
 "rearm-and-reload-in-emp-or-temporal) (by CrimRecya)"
@@ -1214,7 +1238,7 @@ msgstr ""
 "[EMP 或超时空停止 CD](New-or-Enhanced-Logics.md#no-rearm-and-reload-in-emp-or-"
 "temporal)（by CrimRecya）"
 
-#: ../../Whats-New.md:339
+#: ../../Whats-New.md:346
 msgid ""
 "[Technos recount current burst index when change the firing weapon](New-"
 "or-Enhanced-Logics.md#recount-burst-index) (by CrimRecya)"
@@ -1222,11 +1246,11 @@ msgstr ""
 "[科技类型在更换开火武器时重置当前连发索引](New-or-Enhanced-Logics.md#recount-burst-index)（by "
 "CrimRecya）"
 
-#: ../../Whats-New.md:340
+#: ../../Whats-New.md:347
 msgid "Shield armor inheritance customization (by Ollerus)"
 msgstr "自定义护盾继承单位护甲（by Ollerus）"
 
-#: ../../Whats-New.md:341
+#: ../../Whats-New.md:348
 msgid ""
 "[Damaged unit image changes](New-or-Enhanced-Logics.md#damaged-unit-"
 "image-changes) (by Fryone)"
@@ -1234,7 +1258,7 @@ msgstr ""
 "[单位伤残更换图像](New-or-Enhanced-Logics.md#damaged-unit-image-changes)（by "
 "Fryone）"
 
-#: ../../Whats-New.md:342
+#: ../../Whats-New.md:349
 msgid ""
 "[Customizable spawns queue](New-or-Enhanced-Logics.md#customizable-"
 "spawns-queue) (by TwinkleStar)"
@@ -1242,13 +1266,13 @@ msgstr ""
 "[自定义子机序列](New-or-Enhanced-Logics.md#customizable-spawns-queue)（by "
 "TwinkleStar）"
 
-#: ../../Whats-New.md:343
+#: ../../Whats-New.md:350
 msgid ""
 "[Initial spawns number](New-or-Enhanced-Logics.md#initial-spawns-number) "
 "(by TwinkleStar)"
 msgstr "[初始子机数量](New-or-Enhanced-Logics.md#initial-spawns-number)（by TwinkleStar）"
 
-#: ../../Whats-New.md:344
+#: ../../Whats-New.md:351
 msgid ""
 "[Override target under EMP attack behavior](New-or-Enhanced-Logics.md"
 "#forcing-specific-weapon-against-certain-targets) (By FS-21)"
@@ -1256,7 +1280,7 @@ msgstr ""
 "[覆盖对被 EMP 瘫痪的目标的攻击行为](New-or-Enhanced-Logics.md#forcing-specific-weapon-"
 "against-certain-targets)（by FS-21）"
 
-#: ../../Whats-New.md:345
+#: ../../Whats-New.md:352
 msgid ""
 "[Aircraft spawner recycling improvements (custom offset, animation etc"
 ".)](New-or-Enhanced-Logics.md#aircraft-spawner-customizations) (by "
@@ -1265,7 +1289,7 @@ msgstr ""
 "[子机回收增强（自定义坐标、动画等）](New-or-Enhanced-Logics.md#aircraft-spawner-"
 "customizations)（by TaranDahl）"
 
-#: ../../Whats-New.md:346
+#: ../../Whats-New.md:353
 msgid ""
 "[Technos can maintain a suitable distance after firing](New-or-Enhanced-"
 "Logics.md#keep-range-after-firing) (by CrimRecya)"
@@ -1273,7 +1297,7 @@ msgstr ""
 "[单位在开火后与目标保持适当的距离](New-or-Enhanced-Logics.md#keep-range-after-firing)（by "
 "CrimRecya）"
 
-#: ../../Whats-New.md:347
+#: ../../Whats-New.md:354
 msgid ""
 "[Projectile subject to ground check before firing](New-or-Enhanced-"
 "Logics.md#projectiles-blocked-by-land-or-water) (by CrimRecya)"
@@ -1281,7 +1305,7 @@ msgstr ""
 "[开火前检查抛射体是否抢地](New-or-Enhanced-Logics.md#projectiles-blocked-by-land-or-"
 "water)（by CrimRecya）"
 
-#: ../../Whats-New.md:348
+#: ../../Whats-New.md:355
 msgid ""
 "[Delay automatic attack on the controlled unit](Fixed-or-Improved-"
 "Logics.md#delay-automatic-attack-on-the-controlled-unit) (by CrimRecya)"
@@ -1289,7 +1313,7 @@ msgstr ""
 "[攻击被心控单位的延迟](Fixed-or-Improved-Logics.md#delay-automatic-attack-on-the-"
 "controlled-unit)（by CrimRecya）"
 
-#: ../../Whats-New.md:349
+#: ../../Whats-New.md:356
 msgid ""
 "[`BombParachute` deglobalization](Fixed-or-Improved-Logics.md#bomb-"
 "parachute-anim-deglobalization) (by TaranDahl)"
@@ -1297,7 +1321,7 @@ msgstr ""
 "[抛射体自定义 `BombParachute`](Fixed-or-Improved-Logics.md#bomb-parachute-anim-"
 "deglobalization)（by TaranDahl）"
 
-#: ../../Whats-New.md:350
+#: ../../Whats-New.md:357
 msgid ""
 "[Sinkablity and sinking speed customization](Fixed-or-Improved-Logics.md"
 "#sinking-behavior-dehardcode) (by TaranDahl)"
@@ -1305,23 +1329,23 @@ msgstr ""
 "[自定义能否沉没以及沉没速度](Fixed-or-Improved-Logics.md#sinking-behavior-"
 "dehardcode)（by TaranDahl）"
 
-#: ../../Whats-New.md:351
+#: ../../Whats-New.md:358
 msgid ""
 "[Fast access vehicle](New-or-Enhanced-Logics.md#fast-access-vehicle) (by "
 "CrimRecya)"
 msgstr "[快速上车](New-or-Enhanced-Logics.md#fast-access-vehicle)（by CrimRecya）"
 
-#: ../../Whats-New.md:352
+#: ../../Whats-New.md:359
 msgid "Laser, electric bolt and rad beam scatter (by CrimRecya)"
 msgstr "激光、EBolt 和辐射波的散布（by CrimRecya）"
 
-#: ../../Whats-New.md:353
+#: ../../Whats-New.md:360
 msgid ""
 "[Airburst weapon firing/source coordinate customizations](Fixed-or-"
 "Improved-Logics.md#airburst--splits) (by Starkku)"
 msgstr "[自定义空爆武器中心坐标](Fixed-or-Improved-Logics.md#airburst--splits)（by Starkku）"
 
-#: ../../Whats-New.md:354
+#: ../../Whats-New.md:361
 msgid ""
 "[AlternateFLH on-turret toggle](Fixed-or-Improved-Logics.md#alternate-"
 "flh-customizations) (by Starkku)"
@@ -1329,7 +1353,7 @@ msgstr ""
 "[AlternateFLH 跟随炮塔开关](Fixed-or-Improved-Logics.md#alternate-flh-"
 "customizations)（by Starkku）"
 
-#: ../../Whats-New.md:355
+#: ../../Whats-New.md:362
 msgid ""
 "[Fire weapon when Warhead kills something](New-or-Enhanced-Logics.md"
 "#fire-weapon-when-warhead-kills-something) (by Ollerus)"
@@ -1337,7 +1361,7 @@ msgstr ""
 "[击杀武器](New-or-Enhanced-Logics.md#fire-weapon-when-warhead-kills-"
 "something)（by Ollerus）"
 
-#: ../../Whats-New.md:356
+#: ../../Whats-New.md:363
 msgid ""
 "[Prone speed customization](Fixed-or-Improved-Logics.md#prone-speed-"
 "customization) (by TaranDahl)"
@@ -1345,7 +1369,7 @@ msgstr ""
 "[自定义匍匐速度](Fixed-or-Improved-Logics.md#prone-speed-customization)（by "
 "TaranDahl）"
 
-#: ../../Whats-New.md:357
+#: ../../Whats-New.md:364
 msgid ""
 "[Customize damaged speed ratio of drive/ship loco](Fixed-or-Improved-"
 "Logics.md#damaged-speed-customization) (by NetsuNegi)"
@@ -1353,7 +1377,7 @@ msgstr ""
 "[自定义单位 `Locomotor=(Drive/Ship)` 且处于伤残状态时的速度比率](Fixed-or-Improved-"
 "Logics.md#damaged-speed-customization)（by NetsuNegi）"
 
-#: ../../Whats-New.md:358
+#: ../../Whats-New.md:365
 msgid ""
 "[Customize overpower logic](Fixed-or-Improved-Logics.md#customize-"
 "overpower-logic) (by NetsuNegi)"
@@ -1361,13 +1385,13 @@ msgstr ""
 "[自定义磁暴线圈充能](Fixed-or-Improved-Logics.md#customize-overpower-logic)（by "
 "NetsuNegi）"
 
-#: ../../Whats-New.md:359
+#: ../../Whats-New.md:366
 msgid ""
 "[Promotion animation deglobalization](New-or-Enhanced-Logics.md"
 "#promotion-animation) (by Ollerus)"
 msgstr "[自定义升级动画](New-or-Enhanced-Logics.md#promotion-animation)（by Ollerus）"
 
-#: ../../Whats-New.md:360
+#: ../../Whats-New.md:367
 msgid ""
 "Enhanced [reveal](New-or-Enhanced-Logics.md#reveal-map-for-owner-on-"
 "impact) & [gap](New-or-Enhanced-Logics.md#shroud-map-for-enemies-on-"
@@ -1377,7 +1401,7 @@ msgstr ""
 "impact\">揭示弹</a>与[黑幕弹](New-or-Enhanced-Logics.md#shroud-map-for-enemies-"
 "on-impact)（by NetsuNegi）"
 
-#: ../../Whats-New.md:361
+#: ../../Whats-New.md:368
 msgid ""
 "[Forcing specific weapon by range](New-or-Enhanced-Logics.md#forcing-"
 "specific-weapon-against-certain-targets) (by Ollerus)"
@@ -1385,7 +1409,7 @@ msgstr ""
 "[根据射程选取武器](New-or-Enhanced-Logics.md#forcing-specific-weapon-against-"
 "certain-targets)（by Ollerus）"
 
-#: ../../Whats-New.md:362
+#: ../../Whats-New.md:369
 msgid ""
 "[Jumpjet Tilts While Moving](New-or-Enhanced-Logics.md#jumpjet-tilts-"
 "while-moving) (by CrimRecya)"
@@ -1393,7 +1417,7 @@ msgstr ""
 "[Jumpjet 在移动时倾斜](New-or-Enhanced-Logics.md#jumpjet-tilts-while-moving)（by"
 " CrimRecya）"
 
-#: ../../Whats-New.md:363
+#: ../../Whats-New.md:370
 msgid ""
 "[Spawned aircraft facing to match turret toggle](New-or-Enhanced-"
 "Logics.md#aircraft-spawner-customizations) (by Starkku)"
@@ -1401,19 +1425,19 @@ msgstr ""
 "[子机生成时对齐炮塔方向的开关](New-or-Enhanced-Logics.md#aircraft-spawner-"
 "customizations)（by Starkku）"
 
-#: ../../Whats-New.md:364
+#: ../../Whats-New.md:371
 msgid ""
 "[Removed dependency on `blowfish.dll`](Miscellanous.md#blowfish-"
 "dependency) (by ZivDero)"
 msgstr "[移除 `blowfish.dll` 依赖](Miscellanous.md#blowfish-dependency)（by ZivDero）"
 
-#: ../../Whats-New.md:365
+#: ../../Whats-New.md:372
 msgid ""
 "[Warhead that can not kill](New-or-Enhanced-Logics.md#warhead-that-can-"
 "not-kill) (by FS-21)"
 msgstr "[弹头击杀限制](New-or-Enhanced-Logics.md#warhead-that-can-not-kill)（by FS-21）"
 
-#: ../../Whats-New.md:366
+#: ../../Whats-New.md:373
 msgid ""
 "[Customize parasite culling targets](Fixed-or-Improved-Logics.md"
 "#customizing-parasite-culling-targets) (by NetsuNegi)"
@@ -1421,7 +1445,7 @@ msgstr ""
 "[自定义寄生秒杀目标](Fixed-or-Improved-Logics.md#customizing-parasite-culling-"
 "targets)（by NetsuNegi）"
 
-#: ../../Whats-New.md:367
+#: ../../Whats-New.md:374
 msgid ""
 "[Overload characteristic dehardcoded](New-or-Enhanced-Logics.md#overload-"
 "characteristic-dehardcoded) (by Otamaa)"
@@ -1429,7 +1453,7 @@ msgstr ""
 "[自定义脑车过载](New-or-Enhanced-Logics.md#overload-characteristic-"
 "dehardcoded)（by Otamaa）"
 
-#: ../../Whats-New.md:368
+#: ../../Whats-New.md:375
 msgid ""
 "[RadarInvisible for non-enemy house](Fixed-or-Improved-Logics.md"
 "#radarinvisible-for-non-enemy-house) (By TaranDahl)"
@@ -1437,13 +1461,13 @@ msgstr ""
 "[不仅限于敌方的 `RadarInvisible`](Fixed-or-Improved-Logics.md#radarinvisible-"
 "for-non-enemy-house)（By TaranDahl）"
 
-#: ../../Whats-New.md:369
+#: ../../Whats-New.md:376
 msgid ""
 "New `Pips.HideIfNoStrength` and `SelfHealing.EnabledBy` additions for "
 "shields (by FS-21)"
 msgstr "护盾新增功能 `Pips.HideIfNoStrength` 与 `SelfHealing.EnabledBy`（by FS-21）"
 
-#: ../../Whats-New.md:370
+#: ../../Whats-New.md:377
 msgid ""
 "[Customize harvester dump amount](Fixed-or-Improved-Logics.md#customize-"
 "harvester-dump-amount) (by NetsuNegi)"
@@ -1451,11 +1475,11 @@ msgstr ""
 "[自定义矿车单次倒矿量](Fixed-or-Improved-Logics.md#customize-harvester-dump-"
 "amount)（by NetsuNegi）"
 
-#: ../../Whats-New.md:371
+#: ../../Whats-New.md:378
 msgid "[Select box logic](User-Interface.md#select-box) (by NetsuNegi)"
 msgstr "[选择框逻辑](User-Interface.md#select-box)（by NetsuNegi）"
 
-#: ../../Whats-New.md:372
+#: ../../Whats-New.md:379
 msgid ""
 "[Customize airstrike targets](Fixed-or-Improved-Logics.md#airstrike-"
 "target-eligibility) (by NetsuNegi)"
@@ -1463,7 +1487,7 @@ msgstr ""
 "[自定义空袭目标](Fixed-or-Improved-Logics.md#airstrike-target-eligibility)（by "
 "NetsuNegi）"
 
-#: ../../Whats-New.md:373
+#: ../../Whats-New.md:380
 msgid ""
 "[Aggressive attack move mission](New-or-Enhanced-Logics.md#aggressive-"
 "attack-move-mission) (by CrimRecya)"
@@ -1471,7 +1495,7 @@ msgstr ""
 "[侵略性移动攻击命令](New-or-Enhanced-Logics.md#aggressive-attack-move-mission)（by "
 "CrimRecya）"
 
-#: ../../Whats-New.md:374
+#: ../../Whats-New.md:381
 msgid ""
 "[Amphibious access vehicle](New-or-Enhanced-Logics.md#amphibious-access-"
 "vehicle) (by CrimRecya)"
@@ -1479,7 +1503,7 @@ msgstr ""
 "[两栖载具装载拓展](New-or-Enhanced-Logics.md#amphibious-access-vehicle)（by "
 "CrimRecya）"
 
-#: ../../Whats-New.md:375
+#: ../../Whats-New.md:382
 msgid ""
 "[Allow miners do area guard](Fixed-or-Improved-Logics.md#allow-miners-do-"
 "area-guard) (by TaranDahl)"
@@ -1487,7 +1511,7 @@ msgstr ""
 "[允许矿车区域警戒](Fixed-or-Improved-Logics.md#allow-miners-do-area-guard)（by "
 "TaranDahl）"
 
-#: ../../Whats-New.md:376
+#: ../../Whats-New.md:383
 msgid ""
 "[Make harvesters do addtional scan after unload](Fixed-or-Improved-"
 "Logics.md#make-harvesters-do-addtional-scan-after-unload) (by TaranDahl)"
@@ -1495,7 +1519,7 @@ msgstr ""
 "[使矿车卸载后重新扫描较近的矿区](Fixed-or-Improved-Logics.md#make-harvesters-do-"
 "addtional-scan-after-unload)（by TaranDahl）"
 
-#: ../../Whats-New.md:377
+#: ../../Whats-New.md:384
 msgid ""
 "[Passenger-based insignias](Fixed-or-Improved-Logics.md#customizable-"
 "veterancy-insignias) (by Ollerus)"
@@ -1503,19 +1527,19 @@ msgstr ""
 "[根据乘客切换军衔](Fixed-or-Improved-Logics.md#customizable-veterancy-"
 "insignias)（by Ollerus）"
 
-#: ../../Whats-New.md:378
+#: ../../Whats-New.md:385
 msgid ""
 "[Use `InsigniaType` to set the properties of insignia in a "
 "batch](Miscellanous.md#insignia-type) (by Ollerus)"
 msgstr "[使用 `InsigniaType` 批量设置军衔属性](Miscellanous.md#insignia-type)（by Ollerus）"
 
-#: ../../Whats-New.md:379
+#: ../../Whats-New.md:386
 msgid ""
 "[Tiberium eater logic](New-or-Enhanced-Logics.md#tiberium-eater) (by "
 "NetsuNegi)"
 msgstr "[马夫逻辑](New-or-Enhanced-Logics.md#tiberium-eater)（by NetsuNegi）"
 
-#: ../../Whats-New.md:380
+#: ../../Whats-New.md:387
 msgid ""
 "[Customize the damage taken when falling from a bridge](Fixed-or-"
 "Improved-Logics.md#customize-bridge-falling-down-damage) (by FlyStar)"
@@ -1523,11 +1547,11 @@ msgstr ""
 "[自定义桥上坠落伤害](Fixed-or-Improved-Logics.md#customize-bridge-falling-down-"
 "damage)（by FlyStar）"
 
-#: ../../Whats-New.md:381
+#: ../../Whats-New.md:388
 msgid "Dehardcoded 255 limit of `OverlayType` (by secsome)"
 msgstr "解除了覆盖物最多 255 个的数量限制（by secsome）"
 
-#: ../../Whats-New.md:382
+#: ../../Whats-New.md:389
 msgid ""
 "[Customizable airstrike flare colors](Fixed-or-Improved-Logics.md"
 "#airstrike-flare-customizations) (by Starkku)"
@@ -1535,19 +1559,19 @@ msgstr ""
 "[自定义空袭引导效果](Fixed-or-Improved-Logics.md#airstrike-flare-visual-"
 "customizations)（by Starkku）"
 
-#: ../../Whats-New.md:383
+#: ../../Whats-New.md:390
 msgid ""
 "Allowed player's self-healing effects to be benefited by allied or "
 "`PlayerControl=true` houses (by Ollerus)"
 msgstr "允许玩家的自愈效果可以从友军或 `PlayerControl=true` 的所属方受益（by Ollerus）"
 
-#: ../../Whats-New.md:384
+#: ../../Whats-New.md:391
 msgid ""
 "[Exclusive SuperWeapon Sidebar](User-Interface.md#superweapon-sidebar) "
 "(by NetsuNegi & CrimRecya)"
 msgstr "[超武侧边栏](User-Interface.md#superweapon-sidebar)（by NetsuNegi & CrimRecya）"
 
-#: ../../Whats-New.md:385
+#: ../../Whats-New.md:392
 msgid ""
 "[Customize the scatter caused by aircraft attack mission](Fixed-or-"
 "Improved-Logics.md#customize-the-scatter-caused-by-aircraft-attack-"
@@ -1556,7 +1580,7 @@ msgstr ""
 "[自定义战机攻击任务引发分散](Fixed-or-Improved-Logics.md#customize-the-scatter-caused-"
 "by-aircraft-attack-mission)（by TaranDahl）"
 
-#: ../../Whats-New.md:386
+#: ../../Whats-New.md:393
 msgid ""
 "[Customizable garrison and bunker properties](Fixed-or-Improved-Logics.md"
 "#customizable-garrison-and-bunker-properties) (by Otamaa)"
@@ -1564,7 +1588,7 @@ msgstr ""
 "[自定义驻军建筑与坦克碉堡属性](Fixed-or-Improved-Logics.md#customizable-garrison-and-"
 "bunker-properties)（by Otamaa）"
 
-#: ../../Whats-New.md:387
+#: ../../Whats-New.md:394
 msgid ""
 "[Disable `DamageSound` for buildings](Fixed-or-Improved-Logics.md"
 "#disable-damagesound) (by Otamaa)"
@@ -1572,7 +1596,7 @@ msgstr ""
 "[禁用 `DamageSound`](Fixed-or-Improved-Logics.md#disable-damagesound)（by "
 "Otamaa）"
 
-#: ../../Whats-New.md:388
+#: ../../Whats-New.md:395
 msgid ""
 "[Power plant damage factor](Fixed-or-Improved-Logics.md#power-plant-"
 "damage-factor) (by Otamaa and Ollerus)"
@@ -1580,7 +1604,7 @@ msgstr ""
 "[伤残电厂电量系数](Fixed-or-Improved-Logics.md#power-plant-damage-factor)（by "
 "Otamaa and Ollerus）"
 
-#: ../../Whats-New.md:389
+#: ../../Whats-New.md:396
 msgid ""
 "[Customize whether `Crater=yes` animation would destroy tiberium](Fixed-"
 "or-Improved-Logics.md#customize-whether-crater-yes-animation-would-"
@@ -1589,11 +1613,11 @@ msgstr ""
 "[自定义 `Crater=yes` 的动画能否摧毁矿石](Fixed-or-Improved-Logics.md#customize-"
 "whether-crater-yes-animation-would-destroy-tiberium)（by TaranDahl）"
 
-#: ../../Whats-New.md:390
+#: ../../Whats-New.md:397
 msgid "Weapon target filtering by health percentage (by NetsuNegi)"
 msgstr "武器根据血量百分比筛选目标（by NetsuNegi）"
 
-#: ../../Whats-New.md:391
+#: ../../Whats-New.md:398
 msgid ""
 "[Turretless vehicles with `Voxel=no` support use `FireUp` like infantry"
 "](New-or-Enhanced-Logics.md#turretless-shape-vehicle-fireup) (by FlyStar)"
@@ -1601,65 +1625,107 @@ msgstr ""
 "[无炮塔 Shape 载具开火前摇](New-or-Enhanced-Logics.md#turretless-shape-vehicle-"
 "fireup)（by FlyStar）"
 
-#: ../../Whats-New.md:392
+#: ../../Whats-New.md:399
 msgid "Infantry support `IsGattling=yes` (by FlyStar)"
 msgstr "步兵类现已支持使用 `IsGattling=yes` 开启盖特逻辑（by FlyStar）"
 
-#: ../../Whats-New.md:393
+#: ../../Whats-New.md:400
 msgid ""
 "[Several new Infotypes, no display in specific status and a new single "
 "frame display method](User-Interface.md#digital-display) (by CrimRecya)"
 msgstr ""
-"[多种新的数显信息类型、特定情况下不显示以及一种新的单帧显示方式](User-Interface.md#digital-display)（by CrimRecya）"
+"[多种新的数显信息类型、特定情况下不显示以及一种新的单帧显示方式](User-Interface.md#digital-display)（by "
+"CrimRecya）"
 
-#: ../../Whats-New.md:394
-msgid "[Targeting limitation for berzerk technos](New-or-Enhanced-Logics.md#targeting-limitation-for-berzerk-technos) (by TaranDahl)"
-msgstr "[狂暴单位索敌限制](New-or-Enhanced-Logics.md#targeting-limitation-for-berzerk-technos)（by TaranDahl）"
+#: ../../Whats-New.md:401
+msgid ""
+"[Targeting limitation for berzerk technos](New-or-Enhanced-Logics.md"
+"#targeting-limitation-for-berzerk-technos) (by TaranDahl)"
+msgstr ""
+"[狂暴单位索敌限制](New-or-Enhanced-Logics.md#targeting-limitation-for-berzerk-"
+"technos)（by TaranDahl）"
 
-#: ../../Whats-New.md:395
+#: ../../Whats-New.md:402
 msgid ""
 "Allowed faking digital display for `InfoType=Health` at disguise (by "
 "Ollerus)"
-msgstr ""
-"允许 `InfoType=Health` 伪造出伪装目标的数值（by Ollerus）"
+msgstr "允许 `InfoType=Health` 伪造出伪装目标的数值（by Ollerus）"
 
-#: ../../Whats-New.md:396
+#: ../../Whats-New.md:403
+msgid ""
+"[Warhead activation target health thresholds](Fixed-or-Improved-Logics.md"
+"#customizable-warhead-trigger-conditions) (by FS-21 & Kerbiter)"
+msgstr ""
+"[目标血量作为弹头生效条件](Fixed-or-Improved-Logics.md#customizable-warhead-trigger-"
+"conditions)（by FS-21 & Kerbiter）"
+
+#: ../../Whats-New.md:404
 msgid ""
 "[Customize limit and sound when engineer repair a building](New-or-"
 "Enhanced-Logics.md#engineer-repair-customization) (by NetsuNegi)"
 msgstr ""
-"[自定义工程师维修建筑时的修复值与修复音效](New-or-"
-"Enhanced-Logics.md#engineer-repair-customization)（by NetsuNegi）"
+"[自定义工程师维修建筑时的修复值与修复音效](New-or-Enhanced-Logics.md#engineer-repair-"
+"customization)（by NetsuNegi）"
 
-#: ../../Whats-New.md:397
-msgid "[Customizable debris trailer anim spawn delay](Fixed-or-Improved-Logics.md#customizable-debris-trailer-anim-spawn-delay) (by CrimRecya)"
-msgstr "[自定义 Voxel 碎片尾烟动画生成间隔](Fixed-or-Improved-Logics.md#customizable-debris-trailer-anim-spawn-delay)（by CrimRecya）"
+#: ../../Whats-New.md:405
+msgid ""
+"[Customizable debris trailer anim spawn delay](Fixed-or-Improved-"
+"Logics.md#customizable-debris-trailer-anim-spawn-delay) (by CrimRecya)"
+msgstr ""
+"[自定义 Voxel 碎片尾烟动画生成间隔](Fixed-or-Improved-Logics.md#customizable-debris-"
+"trailer-anim-spawn-delay)（by CrimRecya）"
 
-#: ../../Whats-New.md:399 ../../Whats-New.md:608 ../../Whats-New.md:925
-#: ../../Whats-New.md:1034 ../../Whats-New.md:1059 ../../Whats-New.md:1098
-#: ../../Whats-New.md:1143
+#: ../../Whats-New.md:406
+msgid ""
+"[Display banner](AI-Scripting-and-Mapping.md#display-banner) (by Morton &"
+" ststl)"
+msgstr "[横幅](AI-Scripting-and-Mapping.md#display-banner)（by Morton & ststl）"
+
+#: ../../Whats-New.md:407
+msgid ""
+"[Allows refineries to use multiple ActiveAnim simultaneously](Fixed-or-"
+"Improved-Logics.md#allows-refineries-to-use-multiple-activeanim-"
+"simultaneously) (by TaranDahl)"
+msgstr ""
+"[允许矿场同时播放多个 `ActiveAnim` 动画](Fixed-or-Improved-Logics.md#allows-"
+"refineries-to-use-multiple-activeanim-simultaneously)（by TaranDahl）"
+
+#: ../../Whats-New.md:408
+msgid "Electric/RadBeam trail for laser tails (by NetsuNegi)"
+msgstr "激光尾焰逻辑支持 EBolt／辐射波（by NetsuNegi）"
+
+#: ../../Whats-New.md:409
+msgid ""
+"Add `DebrisMinimums` to keep the count of debris within a certain range "
+"(by CrimRecya)"
+msgstr ""
+"添加了 `DebrisMinimums` 语句以将碎片数量控制在一定范围内（by CrimRecya）"
+
+#: ../../Whats-New.md:411 ../../Whats-New.md:619 ../../Whats-New.md:936
+#: ../../Whats-New.md:1045 ../../Whats-New.md:1070 ../../Whats-New.md:1109
+#: ../../Whats-New.md:1154
 msgid "Vanilla fixes:"
 msgstr "原版问题修复："
 
-#: ../../Whats-New.md:400
+#: ../../Whats-New.md:412
 msgid ""
 "Fixed sidebar not updating queued unit numbers when adding or removing "
 "units when the production is on hold (by CrimRecya)"
 msgstr "修复侧边栏在生产暂停时添加或去除订单未能更新预购单位队列数量的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:401
+#: ../../Whats-New.md:413
 msgid ""
 "Prevent the units with locomotors that cause problems from entering the "
 "tank bunker (by TaranDahl)"
 msgstr "防止使用了可能导致问题的运动模式的单位进入坦克碉堡（by TaranDahl）"
 
-#: ../../Whats-New.md:402
+#: ../../Whats-New.md:414
 msgid ""
 "Buildings with foundation bigger than 1x1 can now recycle spawned "
 "correctly (by TaranDahl)"
 msgstr "占地面积超过 1x1 的建筑现在可以正常回收子机（by TaranDahl）"
 
-#: ../../Whats-New.md:403
+#: ../../Whats-New.md:415
 msgid ""
 "Fixed an issue that `MovementZone=AmphibiousDestroyer` and "
 "`MovementZone=AmphibiousCrusher` technos being unable to enter on water "
@@ -1668,7 +1734,7 @@ msgstr ""
 "修复了 `MovementZone=AmphibiousDestroyer` 与 `MovementZone=AmphibiousCrusher`"
 " 的单位无法进入水上建筑的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:404
+#: ../../Whats-New.md:416
 msgid ""
 "Fixed an issue that laser, electric bolt and rad beam not support "
 "`Inviso=true` projectiles with `FlakScatter=true` to scatter (by "
@@ -1677,7 +1743,7 @@ msgstr ""
 "修复了激光、EBolt、辐射波在 `FlakScatter=true` 的 `Inviso=true` 抛射体上不不跟随散布的问题（by "
 "CrimRecya）"
 
-#: ../../Whats-New.md:405
+#: ../../Whats-New.md:417
 msgid ""
 "Fixed the bug that `EnterBioReactorSound`, `LeaveBioReactorSound`, "
 "`EnterGrinderSound` on technotype does not used (by NetsuNegi)"
@@ -1685,403 +1751,401 @@ msgstr ""
 "修复了 `EnterBioReactorSound`、`LeaveBioReactorSound`、`EnterGrinderSound` "
 "在单位上微观设定无效的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:406
+#: ../../Whats-New.md:418
 msgid ""
 "Fixed the bug that harvester dont stop unloading and cannot unload cargos"
 " anymore when lifting by `IsLocomotor=yes` warhead (by NetsuNegi)"
 msgstr "修复了矿车被 `IsLocomotor=yes` 的弹头抬起也不会停止卸载状态且无法继续正常卸载的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:407
+#: ../../Whats-New.md:419
 msgid ""
 "Fixed an issue that units on the slope tilted at an excessive angle (by "
 "CrimRecya & NetsuNegi)"
 msgstr "修复了单位在斜坡上倾斜角度过大的问题（by CrimRecya 与 NetsuNegi）"
 
-#: ../../Whats-New.md:408
+#: ../../Whats-New.md:420
 msgid ""
 "Fixed an issue that the first passenger who call the transport ship no "
 "longer board the transport ship when the land units call for boarding (by"
 " CrimRecya)"
 msgstr "修复了当陆地单位请求登船时第一个呼叫运输船的乘客不会登船的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:409
+#: ../../Whats-New.md:421
 msgid ""
 "Fixed an issue that impassable invisible barrier generated by the "
 "behavior of infantry continuously entering vehicles (by CrimRecya)"
 msgstr "修复了步兵通过路径点连续进入两个载具等行为会产生空气墙的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:410
+#: ../../Whats-New.md:422
 msgid ""
 "Fixed an issue that teleport units board transport vehicles on the bridge"
 " will create an impassable invisible barrier, which may cause the game to"
 " freeze or even crash (by NetsuNegi)"
 msgstr "修复了单位超时空进入桥上的运输载具会产生空气墙并可能导致游戏卡死乃至崩溃的问题（by NetsuNegi）"
 
-#: ../../Whats-New.md:411
+#: ../../Whats-New.md:423
 msgid ""
 "Fixed an issue that moving MCV with Teleport locomotion will cause "
 "reconnection error (by CrimRecya)"
 msgstr "修复了超时空移动的 MCV 会引发 Reconnection Error 的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:412
+#: ../../Whats-New.md:424
 msgid ""
 "Fixed wrong shadow when a vehicle has hover locomotor and is being lifted"
 " by `IsLocomotor=yes` warhead (by NetsuNegi)"
 msgstr "修复了使用悬浮运动模式的载具被 `IsLocomotor=yes` 弹头抬起时显示的错误阴影（by NetsuNegi）"
 
-#: ../../Whats-New.md:413
+#: ../../Whats-New.md:425
 msgid ""
 "Separated the AirstrikeClass pointer between the attacker/aircraft and "
 "the target to avoid erroneous overwriting issues (by NetsuNegi)"
 msgstr "分离了 AirstrikeClass 中攻击者／战机与目标的指针以避免错误覆盖问题（by NetsuNegi）"
 
-#: ../../Whats-New.md:414
+#: ../../Whats-New.md:426
 msgid ""
 "Fixed the bug that buildings will always be tinted as airstrike owner (by"
 " NetsuNegi)"
 msgstr "修复了建筑总是被染色为空袭所属方颜色的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:415
+#: ../../Whats-New.md:427
 msgid ""
 "Fixed the issue where computer players did not search for new enemies "
 "after defeating them or forming alliances with them (by FlyStar)"
 msgstr "修复了 AI 玩家在消灭一家敌人或敌人结盟后不再搜索新敌人的问题（FlyStar）"
 
-#: ../../Whats-New.md:416
+#: ../../Whats-New.md:428
 msgid ""
 "Fixed the bug that infantry ignored `Passengers` and `SizeLimit` when "
 "entering buildings (by NetsuNegi)"
 msgstr "修复了步兵进入建筑时忽略 `Passengers` 和 `SizeLimit` 的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:417
+#: ../../Whats-New.md:429
 msgid "Fixed the bug that ships can travel on elevated bridges (by NetsuNegi)"
 msgstr "修复了船只可以在高架桥上行驶的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:418
+#: ../../Whats-New.md:430
 msgid ""
 "Fixed an issue where airstrike flare line drawn to target at lower "
 "elevation would clip (by Starkku)"
 msgstr "修复了空袭引导激光高打低时会截断的问题（by Starkku）"
 
-#: ../../Whats-New.md:419
+#: ../../Whats-New.md:431
 msgid ""
 "Fixed the bug that uncontrolled scatter when elite techno attacked by "
 "aircraft or some unit try crush it (by NetsuNegi)"
 msgstr "修复精英单位在被战机攻击或一个单位尝试碾压它时强制散开的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:420
+#: ../../Whats-New.md:432
 msgid ""
 "Second weapon with `ElectricAssault=yes` will not unconditionally attack "
 "your building with `Overpowerable=yes` (by FlyStar)"
 msgstr "有 `ElectricAssault=yes` 的副武不再会无条件地攻击己方 `Overpowerable=yes` 的建筑（by FlyStar）"
 
-#: ../../Whats-New.md:421
+#: ../../Whats-New.md:433
 msgid ""
 "Fixed an issue that the widespread damage caused by detonation on the "
 "bridge/ground cannot affect objects on the ground/bridge who are in the "
 "opposite case (by CrimRecya)"
 msgstr "修复了范围伤害在桥上／地面引爆时无法影响相对情况即在地面／桥上的对象的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:422
+#: ../../Whats-New.md:434
 msgid ""
 "Fixed the bug that `DamageSelf` and `AllowDamageOnSelf` are ineffective "
 "on airforce (by NetsuNegi)"
-msgstr ""
-"修复了 `DamageSelf` 和 `AllowDamageOnSelf` 对空军无效的 Bug（by NetsuNegi）"
+msgstr "修复了 `DamageSelf` 和 `AllowDamageOnSelf` 对空军无效的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:423
+#: ../../Whats-New.md:435
 msgid ""
 "Fixed the bug that damaged particle dont disappear after building has "
 "repaired by engineer (by NetsuNegi)"
 msgstr "修复了建筑在被工程师修复后受损粒子不会移除的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:424
+#: ../../Whats-New.md:436
 msgid ""
 "Fixed the issue of incorrect position of `TrailerAnim` in `VoxelAnim` (by"
 " CrimRecya)"
-msgstr ""
-"修复了 Voxel 碎片 `TrailerAnim` 生成位置不正确的问题（by CrimRecya）"
+msgstr "修复了 Voxel 碎片 `TrailerAnim` 生成位置不正确的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:426 ../../Whats-New.md:720 ../../Whats-New.md:797
-#: ../../Whats-New.md:961 ../../Whats-New.md:1002 ../../Whats-New.md:1014
-#: ../../Whats-New.md:1037 ../../Whats-New.md:1047 ../../Whats-New.md:1063
-#: ../../Whats-New.md:1111 ../../Whats-New.md:1122
+#: ../../Whats-New.md:438 ../../Whats-New.md:731 ../../Whats-New.md:808
+#: ../../Whats-New.md:972 ../../Whats-New.md:1013 ../../Whats-New.md:1025
+#: ../../Whats-New.md:1048 ../../Whats-New.md:1058 ../../Whats-New.md:1074
+#: ../../Whats-New.md:1122 ../../Whats-New.md:1133
 msgid "Phobos fixes:"
 msgstr "Phobos 过往版本问题修复："
 
-#: ../../Whats-New.md:427
+#: ../../Whats-New.md:439
 msgid ""
 "Fixed the bug that `AllowAirstrike=no` cannot completely prevent air "
 "strikes from being launched against it (by NetsuNegi)"
 msgstr "修复了 `AllowAirstrike=no` 未能完全阻止对某个单位进行空袭的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:428
+#: ../../Whats-New.md:440
 msgid ""
 "`600 The shield of the attached object is broken` bug fix for the "
 "triggered event (by FlyStar)"
 msgstr "对 `600 对象护盾被摧毁...` 触发条件的修复（by FlyStar）"
 
-#: ../../Whats-New.md:430 ../../Whats-New.md:772 ../../Whats-New.md:990
+#: ../../Whats-New.md:442 ../../Whats-New.md:783 ../../Whats-New.md:1001
 msgid "Fixes / interactions with other extensions:"
 msgstr "其他扩展引擎相关的修复／交互："
 
-#: ../../Whats-New.md:431
+#: ../../Whats-New.md:443
 msgid ""
 "Allowed `AuxBuilding` and Ares' `SW.Aux/NegBuildings` to count building "
 "upgrades (by Ollerus)"
 msgstr "允许加载物被正常计入 `AuxBuilding` 和 Ares 的 `SW.Aux/NegBuildings`（by Ollerus）"
 
-#: ../../Whats-New.md:432 ../../Whats-New.md:786
+#: ../../Whats-New.md:444 ../../Whats-New.md:797
 msgid ""
 "Taking over Ares' AlphaImage respawn logic to reduce lags from it (by "
 "NetsuNegi)"
 msgstr "接管 Ares 的 AlphaImage 重绘逻辑以减少其造成的卡顿（by NetsuNegi）"
 
-#: ../../Whats-New.md:433
+#: ../../Whats-New.md:445
 msgid ""
 "Fixed an issue where a portion of Ares's trigger event 75/77 was "
 "determined unsuccessfully (by FlyStar)"
 msgstr "修复了 Ares 触发条件 75/77 有时判定不成功的问题（by FlyStar）"
 
-#: ../../Whats-New.md:434
+#: ../../Whats-New.md:446
 msgid ""
 "Fixed the issue where some units crashed after the deployment "
 "transformation (by ststl, FlyStar)"
 msgstr "修复了某些单位部署变形后崩溃的问题（by ststl, FlyStar）"
 
-#: ../../Whats-New.md:435
+#: ../../Whats-New.md:447
 msgid ""
 "Fixed the bug that AlphaImage remained after unit entered tunnel (by "
 "NetsuNegi)"
 msgstr "修复了 AlphaImage 在单位进入隧道后会遗留在隧道口的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:438
+#: ../../Whats-New.md:450
 msgid "0.4"
 msgstr "0.4"
 
-#: ../../Whats-New.md:443
+#: ../../Whats-New.md:455
 msgid "`Crit.AffectsHouses` for critical hit system (by Starkku)"
 msgstr "暴击系统添加 `Crit.AffectsHouses`（by Starkku）"
 
-#: ../../Whats-New.md:444
+#: ../../Whats-New.md:456
 msgid "Warhead or weapon detonation at superweapon target cell (by Starkku)"
 msgstr "在目标单元格处引爆弹头或武器（by Starkku）"
 
-#: ../../Whats-New.md:445
+#: ../../Whats-New.md:457
 msgid "Super Weapons launching other Super Weapons (by Morton)"
 msgstr "弹头发射超武（by Morton）"
 
-#: ../../Whats-New.md:446
+#: ../../Whats-New.md:458
 msgid "Launching Super Weapons on building infiltration (by Morton)"
 msgstr "允许在建筑被渗透时发射超级武器（by Morton）"
 
-#: ../../Whats-New.md:447
+#: ../../Whats-New.md:459
 msgid "Building airstrike target eligibility customization (by Starkku)"
 msgstr "自定义建筑能否作为空袭目标（by Starkku）"
 
-#: ../../Whats-New.md:448
+#: ../../Whats-New.md:460
 msgid "IvanBomb detonation & image display centered on buildings (by Starkku)"
 msgstr "伊文炸弹引爆与图像显示于建筑中心（by Starkku）"
 
-#: ../../Whats-New.md:449
+#: ../../Whats-New.md:461
 msgid "Forcing specific weapon against cloaked or disguised targets (by Starkku)"
 msgstr "强制对隐形或伪装中的目标使用特定武器（by Starkku）"
 
-#: ../../Whats-New.md:450
+#: ../../Whats-New.md:462
 msgid "Customizable ROF random delay (by Starkku)"
 msgstr "自定义 `ROF` 随机间隔（by Starkku）"
 
-#: ../../Whats-New.md:451
+#: ../../Whats-New.md:463
 msgid "Animation with `Tiled=yes` now supports `CustomPalette` (by ststl)"
 msgstr "允许 `Tiled=yes` 的动画使用 `CustomPalette` 自定义色盘（by ststl）"
 
-#: ../../Whats-New.md:452
+#: ../../Whats-New.md:464
 msgid "Toggleable `DieSound` when grinding (by Trsdy)"
 msgstr "允许在被回收时播放 `DieSound`（by Trsdy）"
 
-#: ../../Whats-New.md:453
+#: ../../Whats-New.md:465
 msgid "Shields can inherit Techno ArmorType (by Starkku)"
 msgstr "护盾可以继承科技类型护甲（by Starkku）"
 
-#: ../../Whats-New.md:454
+#: ../../Whats-New.md:466
 msgid ""
 "Income money flying-string display when harvesters or slaves are docking "
 "to refineries or when spies steal credits (by Trsdy)"
 msgstr "矿车、奴隶对接矿场或间谍窃取资金时的 flying-string 显示（by Trsdy）"
 
-#: ../../Whats-New.md:455
+#: ../../Whats-New.md:467
 msgid "Allow random crates to be generated only on lands (by Trsdy)"
 msgstr "允许随机工具箱仅生成在陆地（by Trsdy）"
 
-#: ../../Whats-New.md:456
+#: ../../Whats-New.md:468
 msgid "Iron-curtain effects on infantries and organic units (by ststl)"
 msgstr "允许在步兵和生物单位上使用铁幕效果（by ststl）"
 
-#: ../../Whats-New.md:457
+#: ../../Whats-New.md:469
 msgid "Custom `SlavesFreeSound` (by TwinkleStar)"
 msgstr "自定义 `SlavesFreeSound`（by TwinkleStar）"
 
-#: ../../Whats-New.md:458
+#: ../../Whats-New.md:470
 msgid "Allows jumpjet to crash without rotation (by TwinkleStar)"
 msgstr "允许 Jumpjet 坠毁时不旋转（by TwinkleStar）"
 
-#: ../../Whats-New.md:459
+#: ../../Whats-New.md:471
 msgid "Customizable priority of superweapons timer sorting(by ststl)"
 msgstr "自定义超武计时器优先级（by ststl）"
 
-#: ../../Whats-New.md:460
+#: ../../Whats-New.md:472
 msgid "Customizable aircraft spawner spawn delay (by Starkku)"
 msgstr "自定义子机发射器生成间隔（by Starkku）"
 
-#: ../../Whats-New.md:461
+#: ../../Whats-New.md:473
 msgid "Customizable `Cluster` scatter distance (by Starkku)"
 msgstr "自定义 `Cluster` 散布距离（by Starkku）"
 
-#: ../../Whats-New.md:462
+#: ../../Whats-New.md:474
 msgid "Customizable `FlakScatter` distance (by Starkku)"
 msgstr "自定义 `FlakScatter` 散布距离（by Starkku）"
 
-#: ../../Whats-New.md:463
+#: ../../Whats-New.md:475
 msgid ""
 "Customizable debris & meteor impact and warhead detonation behaviour (by "
 "Starkku & Otamaa)"
 msgstr "自定义碎片 & 流星撞击以及弹头引爆行为（by Starkku 与 Otamaa）"
 
-#: ../../Whats-New.md:464
+#: ../../Whats-New.md:476
 msgid "Custom warhead debris animations (by Starkku)"
 msgstr "自定义弹头碎片动画（by Starkku）"
 
-#: ../../Whats-New.md:465
+#: ../../Whats-New.md:477
 msgid ""
 "Multiple burst shots / burst delay within infantry firing sequence (by "
 "Starkku)"
 msgstr "步兵开火序列的多发 Burst／Burst 间隔（by Starkku）"
 
-#: ../../Whats-New.md:466
+#: ../../Whats-New.md:478
 msgid "Attached particle system for animations (by Starkku)"
 msgstr "动画的附加粒子系统（by Starkku）"
 
-#: ../../Whats-New.md:467
+#: ../../Whats-New.md:479
 msgid ""
 "Removal of hardcoded AA & Gattling weapon selection restrictions (by "
 "Starkku)"
 msgstr "移除硬编码的对空与盖特逻辑的武器选用限制（by Starkku）"
 
-#: ../../Whats-New.md:468
+#: ../../Whats-New.md:480
 msgid "Projectile `SubjectTo(Land/Water)` (by Starkku)"
 msgstr "抛射体的 `SubjectTo(Land/Water)`（by Starkku）"
 
-#: ../../Whats-New.md:469
+#: ../../Whats-New.md:481
 msgid "Real time timers (by Morton)"
 msgstr "实时计时器（by Morton）"
 
-#: ../../Whats-New.md:470
+#: ../../Whats-New.md:482
 msgid ""
 "Default campaign game speed override and custom campaign game speed FPS "
 "(by Morton)"
 msgstr "默认战役游戏速度覆盖与自定义战役速度 FPS（by Morton）"
 
-#: ../../Whats-New.md:471
+#: ../../Whats-New.md:483
 msgid "Trigger actions that allow/forbid MCV to redeploy in game (by Trsdy)"
 msgstr "允许／禁止 MCV 重部署的触发结果（by Trsdy）"
 
-#: ../../Whats-New.md:472
+#: ../../Whats-New.md:484
 msgid ""
 "`AnimList` on zero damage Warheads toggle via `AnimList.ShowOnZeroDamage`"
 " (by Starkku)"
 msgstr "由 `AnimList.ShowOnZeroDamage` 决定 0 伤害弹头上的 `AnimList` 是否播放（by Starkku）"
 
-#: ../../Whats-New.md:473
+#: ../../Whats-New.md:485
 msgid "Including INI files and inheriting INI sections (by Morton)"
 msgstr "包含 INI 文件与继承 INI 节（by Morton）"
 
-#: ../../Whats-New.md:474
+#: ../../Whats-New.md:486
 msgid "Additions to automatic passenger deletion (by Starkku)"
 msgstr "自动删除乘客的补充（by Starkku）"
 
-#: ../../Whats-New.md:475
+#: ../../Whats-New.md:487
 msgid "Buildings considered as vehicles (by Starkku)"
 msgstr "将建筑视为载具（by Starkku）"
 
-#: ../../Whats-New.md:476
+#: ../../Whats-New.md:488
 msgid ""
 "TechnoType target evaluation map zone check behaviour customization (by "
 "Starkku)"
 msgstr "自定义目标评估地图区域检查行为（by Starkku）"
 
-#: ../../Whats-New.md:477
+#: ../../Whats-New.md:489
 msgid "`CanC4=false` building zero damage toggle (by Starkku)"
 msgstr "`CanC4=false` 建筑的 0 伤害开关（by Starkku）"
 
-#: ../../Whats-New.md:478
+#: ../../Whats-New.md:490
 msgid "OpenTopped transport target sharing customization (by Starkku)"
 msgstr "自定义 OpenTopped 运输工具共享目标（by Starkku）"
 
-#: ../../Whats-New.md:479
+#: ../../Whats-New.md:491
 msgid "Vanish animation for `AutoDeath.Behavior=vanish` (by Starkku)"
 msgstr "`AutoDeath.Behavior=vanish` 时的消失动画（by Starkku）"
 
-#: ../../Whats-New.md:480
+#: ../../Whats-New.md:492
 msgid "`AAOnly` for projectiles (by Starkku)"
 msgstr "抛射体上的 `AAOnly`（by Starkku）"
 
-#: ../../Whats-New.md:481
+#: ../../Whats-New.md:493
 msgid ""
 "`CreateUnit` improvements & additions (can spawn infantry and aircraft, "
 "units spawning in air, spawn animation) (by Starkku)"
 msgstr "`CreateUnit` 改进与增强（可以生成步兵和战机、单位可以在空中生成、生成动画）（by Starkku）"
 
-#: ../../Whats-New.md:482
+#: ../../Whats-New.md:494
 msgid "Option to center pause menu background (by Starkku)"
 msgstr "暂停菜单背景居中（by Starkku）"
 
-#: ../../Whats-New.md:483
+#: ../../Whats-New.md:495
 msgid "`LaunchSW.DisplayMoney` (by Starkku)"
 msgstr "`LaunchSW.DisplayMoney`（by Starkku）"
 
-#: ../../Whats-New.md:484
+#: ../../Whats-New.md:496
 msgid "Disguise logic improvements (by Starkku)"
 msgstr "伪装逻辑改进（by Starkku）"
 
-#: ../../Whats-New.md:485
+#: ../../Whats-New.md:497
 msgid "Custom insignias (by Starkku)"
 msgstr "自定义军衔（by Starkku）"
 
-#: ../../Whats-New.md:486
+#: ../../Whats-New.md:498
 msgid "Upgrade logic to allow altering of SpySat status (by Otamaa)"
 msgstr "允许加载物逻辑更改 SpySat 效果（by Otamaa）"
 
-#: ../../Whats-New.md:487
+#: ../../Whats-New.md:499
 msgid ""
 "Allow `ZShapePointMove` to apply during buildup via "
 "`ZShapePointMove.OnBuildup` (by Starkku)"
 msgstr "允许使用 `ZShapePointMove.OnBuildup` 决定拔起动画遵照 `ZShapePointMove`（by Starkku）"
 
-#: ../../Whats-New.md:488
+#: ../../Whats-New.md:500
 msgid ""
 "`UndeploysInto` building selling buildup sequence length customization "
 "(by Starkku)"
 msgstr "自定义可反部署建筑出售序列动画长度（by Starkku）"
 
-#: ../../Whats-New.md:489
+#: ../../Whats-New.md:501
 msgid ""
 "Allow overriding `Shield.AffectTypes` for each Warhead shield interaction"
 " (by Starkku)"
 msgstr "允许为每个弹头设置的 `Shield.AffectTypes`（by Starkku）"
 
-#: ../../Whats-New.md:490
+#: ../../Whats-New.md:502
 msgid "TechnoType conversion warhead & superweapon (by Morton)"
 msgstr "单位转换弹头与超级武器（by Morton）"
 
-#: ../../Whats-New.md:491
+#: ../../Whats-New.md:503
 msgid "TechnoType conversion on ownership change (by Trsdy)"
 msgstr "科技类型根据操作者改变而变形（by Trsdy）"
 
-#: ../../Whats-New.md:492
+#: ../../Whats-New.md:504
 msgid "Unlimited skirmish colors (by Morton)"
 msgstr "无限制遭遇战颜色（by Morton）"
 
-#: ../../Whats-New.md:493
+#: ../../Whats-New.md:505
 msgid ""
 "Example custom locomotor that circles around the target (*NOTE: For "
 "developer use only*) (by Kerbiter, CCHyper, with help from Otamaa; based "
@@ -2090,35 +2154,35 @@ msgstr ""
 "围绕目标旋转的自定义运动模式示例实现（注：仅限开发者使用）（by Kerbiter、CCHyper，Otamaa 提供协助；基于 CnCVK "
 "的早期尝试）"
 
-#: ../../Whats-New.md:494
+#: ../../Whats-New.md:506
 msgid ""
 "Vehicle voxel turret shadows & body multi-section shadows (by TwinkleStar"
 " & Trsdy)"
 msgstr "Voxel 载具炮塔与多组件 Voxel 车体影子（by TwinkleStar 与 Trsdy）"
 
-#: ../../Whats-New.md:495
+#: ../../Whats-New.md:507
 msgid "Crushing tilt and slowdown customization (by Starkku)"
 msgstr "自定义碾压倾斜和减速（by Starkku）"
 
-#: ../../Whats-New.md:496
+#: ../../Whats-New.md:508
 msgid "Extra warhead detonations on weapon (by Starkku)"
 msgstr "在武器上引爆额外弹头（by Starkku）"
 
-#: ../../Whats-New.md:497
+#: ../../Whats-New.md:509
 msgid ""
 "Chrono sparkle animation display customization and improvements (by "
 "Starkku)"
 msgstr "超时空闪烁动画显示的自定义与改进（by Starkku）"
 
-#: ../../Whats-New.md:498
+#: ../../Whats-New.md:510
 msgid "Script action to Chronoshift teams to enemy base (by Starkku)"
 msgstr "超时空传送到敌方基地的动作脚本（by Starkku）"
 
-#: ../../Whats-New.md:499
+#: ../../Whats-New.md:511
 msgid "Customizable ElectricBolt Arcs (by Fryone & Kerbiter)"
 msgstr "自定义 EBolt 电弧（by Fryone 与 Kerbiter）"
 
-#: ../../Whats-New.md:500
+#: ../../Whats-New.md:512
 msgid ""
 "Digital display of HP and SP (by ststl, FlyStar, NaotoYuuki, Saigyouji, "
 "JunJacobYoung, based on knowledge of DeathFish)"
@@ -2126,37 +2190,37 @@ msgstr ""
 "数字化显示生命值和护盾值（by ststl、FlyStar、NaotoYuuki、Saigyouji、JunJacobYoung，基于 "
 "DeathFish 的知识）"
 
-#: ../../Whats-New.md:501
+#: ../../Whats-New.md:513
 msgid ""
 "PipScale pip customizations (size, ammo / spawn / tiberium frames or "
 "offsets) (by Starkku)"
 msgstr "自定义各 PipScale 的 pip（大小、弹药／子机／矿石帧或偏移）（by Starkku）"
 
-#: ../../Whats-New.md:502
+#: ../../Whats-New.md:514
 msgid "Auto-deploy/Deploy block on ammo change (by Fryone)"
 msgstr "根据弹药自动部署／阻止部署（by Fryone）"
 
-#: ../../Whats-New.md:503
+#: ../../Whats-New.md:515
 msgid "`AltPalette` lighting toggle (by Starkku)"
 msgstr "`AltPalette` 亮度开关（by Starkku）"
 
-#: ../../Whats-New.md:504
+#: ../../Whats-New.md:516
 msgid "Unhardcoded timer blinking color scheme (by Starkku)"
 msgstr "对计时器闪烁的配色方案去硬编码（by Starkku）"
 
-#: ../../Whats-New.md:505
+#: ../../Whats-New.md:517
 msgid ""
 "Customizing shield self-healing timer restart when shield is damaged (by "
 "Starkku)"
 msgstr "自定义护盾受击重置自愈计时器（by Starkku）"
 
-#: ../../Whats-New.md:506
+#: ../../Whats-New.md:518
 msgid ""
 "Customizing minimum & maximum amount of damage shield can take from a "
 "single hit (by Starkku)"
 msgstr "自定义护盾单次可承受的最小与最大伤害（by Starkku）"
 
-#: ../../Whats-New.md:507
+#: ../../Whats-New.md:519
 msgid ""
 "`AutoDeath.Technos(Dont)Exist` can optionally track limboed (not "
 "physically on map, e.g transports etc) technos (by Starkku)"
@@ -2164,39 +2228,39 @@ msgstr ""
 "`AutoDeath.Technos(Dont)Exist` 可计入 Limbo 状态（不在地图上，例如在运输工具中等）的科技类型（by "
 "Starkku）"
 
-#: ../../Whats-New.md:508
+#: ../../Whats-New.md:520
 msgid "Wall overlay `Palette` support (by Starkku)"
 msgstr "墙类覆盖物自定义 `Palette` 支持（by Starkku）"
 
-#: ../../Whats-New.md:509
+#: ../../Whats-New.md:521
 msgid "Show designator & inhibitor range (by Morton)"
 msgstr "显示指示者和抑制者范围（by Morton）"
 
-#: ../../Whats-New.md:510
+#: ../../Whats-New.md:522
 msgid "Owner-only sound on unit creation (by Fryone)"
 msgstr "单位创建时仅对所有者播放音效（by Fryone）"
 
-#: ../../Whats-New.md:511
+#: ../../Whats-New.md:523
 msgid ""
 "Allow using `Secondary` weapon against walls if `Primary` cannot target "
 "them (by Starkku)"
 msgstr "如果 `Primary` 无法对墙则切换为使用 `Secondary`（by Starkku）"
 
-#: ../../Whats-New.md:512
+#: ../../Whats-New.md:524
 msgid "Reloading ammo in transports (by Starkku)"
 msgstr "在运输工具内重装填弹药（by Starkku）"
 
-#: ../../Whats-New.md:513
+#: ../../Whats-New.md:525
 msgid "Dump variables to file on scenario end / hotkey (by Morton)"
 msgstr "在场景结束／按下快捷键时将变量输出至文件（by Morton）"
 
-#: ../../Whats-New.md:514
+#: ../../Whats-New.md:526
 msgid ""
 "\"House owns TechnoType\" and \"House doesn't own TechnoType\" trigger "
 "events (by Morton)"
 msgstr "`601 所属方存在科技类型...` 与 `602 所属方不·存在科技类型...` 触发条件（by Morton）"
 
-#: ../../Whats-New.md:515
+#: ../../Whats-New.md:527
 msgid ""
 "Allow toggling `Infantry/UnitsGainSelfHeal` for `MultiplayPassive=true` "
 "houses (by Starkku)"
@@ -2204,23 +2268,23 @@ msgstr ""
 "允许为 `MultiplayPassive=true` 的所属方开关 `Infantry/UnitsGainSelfHeal`（by "
 "Starkku）"
 
-#: ../../Whats-New.md:516
+#: ../../Whats-New.md:528
 msgid ""
 "Customizable straight trajectory detonation & snap distance and pass-"
 "through option (by Starkku)"
 msgstr "自定义直线轨迹引爆和瞬移距离以及穿透选项（by Starkku）"
 
-#: ../../Whats-New.md:517
+#: ../../Whats-New.md:529
 msgid "Airstrike & spy plane fixed spawn distance & height (by Starkku)"
 msgstr "空袭与间谍飞机固定生成距离与高度（by Starkku）"
 
-#: ../../Whats-New.md:518
+#: ../../Whats-New.md:530
 msgid ""
 "Allow enabling application of `Verses` and `PercentAtMax` for negative "
 "damage (by Starkku)"
 msgstr "允许负值杀伤使用 `Verses` 和 `PercentAtMax`（by Starkku）"
 
-#: ../../Whats-New.md:519
+#: ../../Whats-New.md:531
 msgid ""
 "In addition to `PlacementGrid.Translucency`, allow to set the "
 "transparency of the grid when `PlacementPreview` is enabled, using the "
@@ -2229,250 +2293,250 @@ msgstr ""
 "除 `PlacementGrid.Translucency` 外允许在启用 `PlacementPreview` 时使用 "
 "`PlacementGrid.TranslucencyWithPreview` 设置预览格子的透明度（by Belonit）"
 
-#: ../../Whats-New.md:520
+#: ../../Whats-New.md:532
 msgid "Show briefing screen on singleplayer mission start (by Starkku)"
 msgstr "单人任务开始时显示简报屏幕（by Starkku）"
 
-#: ../../Whats-New.md:521
+#: ../../Whats-New.md:533
 msgid ""
 "Allow setting mission par times and related messages in `missionmd.ini` "
 "(by Starkku)"
 msgstr "允许在 `missionmd.ini` 中设置时间限制和相关信息（by Starkku）"
 
-#: ../../Whats-New.md:522
+#: ../../Whats-New.md:534
 msgid ""
 "Allow setting default singleplayer map loading screen and briefing "
 "offsets (by Starkku)"
 msgstr "允许设置单人游戏载入图与简报的偏移（by Starkku）"
 
-#: ../../Whats-New.md:523
+#: ../../Whats-New.md:535
 msgid ""
 "Allow toggling whether or not fire particle systems adjust target "
 "coordinates when firer rotates (by Starkku)"
 msgstr "允许开关 Fire 粒子系统是否在开火者旋转时调整目标坐标（by Starkku）"
 
-#: ../../Whats-New.md:524
+#: ../../Whats-New.md:536
 msgid "`AmbientDamage` warhead & main target ignore customization (by Starkku)"
 msgstr "自定义 `AmbientDamage` 弹头和忽略直接目标（by Starkku）"
 
-#: ../../Whats-New.md:525
+#: ../../Whats-New.md:537
 msgid "Flashing Technos on selecting (by Fryone)"
 msgstr "闪烁选中的科技类型（by Fryone）"
 
-#: ../../Whats-New.md:526
+#: ../../Whats-New.md:538
 msgid "Customizable DropPod properties on a per-InfantryType basis (by Trsdy)"
 msgstr "自定义每个步兵的 DropPod 参数（by Trsdy）"
 
-#: ../../Whats-New.md:527
+#: ../../Whats-New.md:539
 msgid "Projectile return weapon (by Starkku)"
 msgstr "抛射体归返武器（by Starkku）"
 
-#: ../../Whats-New.md:528
+#: ../../Whats-New.md:540
 msgid ""
 "Allow customizing aircraft landing direction per aircraft or per dock (by"
 " Starkku)"
 msgstr "允许每个战机和机场自定义战机着陆方向（by Starkku）"
 
-#: ../../Whats-New.md:529
+#: ../../Whats-New.md:541
 msgid ""
 "Allow animations to play sounds detached from audio event handler (by "
 "Starkku)"
 msgstr "允许动画播放独立于音频事件处理程序的音效（by Starkku）"
 
-#: ../../Whats-New.md:530
+#: ../../Whats-New.md:542
 msgid "Game save option when starting campaigns (by Trsdy)"
 msgstr "开始游戏时是否自动存档的开关（by Trsdy）"
 
-#: ../../Whats-New.md:531
+#: ../../Whats-New.md:543
 msgid "Carryall pickup voice (by Starkku)"
 msgstr "吊运拾起音效（by Starkku）"
 
-#: ../../Whats-New.md:532
+#: ../../Whats-New.md:544
 msgid ""
 "Option to have `Grinding.Weapon` require accumulated credits from "
 "grinding (by Starkku)"
 msgstr "可以设置 `Grinding.Weapon` 需要通过回收来积累足够的资金（by Starkku）"
 
-#: ../../Whats-New.md:533
+#: ../../Whats-New.md:545
 msgid "Re-enable the Veinhole Monster and Weeds from TS (by ZivDero)"
 msgstr "重启 TS 中的泰伯利亚藤蔓怪和泰伯利亚废矿逻辑（by ZivDero）"
 
-#: ../../Whats-New.md:534
+#: ../../Whats-New.md:546
 msgid ""
 "Recreate the weed-charging of SWs like the TS Chemical Missile (by "
 "ZivDero)"
 msgstr "重新创建类似于 TS 中化学飞弹那样的超武根据废矿充能效果（by ZivDero）"
 
-#: ../../Whats-New.md:535
+#: ../../Whats-New.md:547
 msgid "Allow to change the speed of gas particles (by ZivDero)"
 msgstr "允许更改 gas 粒子的速度（by ZivDero）"
 
-#: ../../Whats-New.md:536
+#: ../../Whats-New.md:548
 msgid ""
 "Allow upgrade animations to use `Powered` & `PoweredLight/Effect/Special`"
 " keys (by Starkku)"
 msgstr "允许加载物动画使用 `Powered` 和 `PoweredLight/Effect/Special` 类的标签（by Starkku）"
 
-#: ../../Whats-New.md:537
+#: ../../Whats-New.md:549
 msgid ""
 "Toggle for `Explodes=true` BuildingTypes to not explode during buildup or"
 " being sold (by Starkku)"
 msgstr "独立设置 `Explodes=true` 的建筑是否在拔起和出售时是否爆炸的开关（by Starkku）"
 
-#: ../../Whats-New.md:538
+#: ../../Whats-New.md:550
 msgid ""
 "Toggleable height-based shadow scaling for voxel air units (by Trsdy & "
 "Starkku)"
 msgstr "可开关的 Voxel 空中单位影子随高度缩放效果（by Trsdy 与 Starkku）"
 
-#: ../../Whats-New.md:539
+#: ../../Whats-New.md:551
 msgid ""
 "User setting toggles for harvester counter & power delta indicator (by "
 "Starkku)"
 msgstr "用于矿车计数器和电力变动指示器的用户设置开关（by Starkku）"
 
-#: ../../Whats-New.md:540
+#: ../../Whats-New.md:552
 msgid "Shrapnel weapon target filtering toggle (by Starkku)"
 msgstr "`Shrapnel.UseWeaponTargeting`（by Starkku）"
 
-#: ../../Whats-New.md:541
+#: ../../Whats-New.md:553
 msgid ""
 "Restore functionality of `[CrateRules] -> FreeMCV` with customizable "
 "credits threshold (by Starkku)"
 msgstr "复原 `[CrateRules] -> FreeMCV` 功能并允许自定义资金阈值（by Starkku）"
 
-#: ../../Whats-New.md:542
+#: ../../Whats-New.md:554
 msgid ""
 "Allow customizing the number of vehicles required for unit crates to turn"
 " into money crates (by Starkku)"
 msgstr "允许自定义单位箱子转为钱箱所判定的载具数量阈值（by Starkku）"
 
-#: ../../Whats-New.md:543
+#: ../../Whats-New.md:555
 msgid "Per-VehicleType reroll chance for `CrateGoodie=true` (by Starkku)"
 msgstr "每个 `CrateGoodie=true` 载具独立定义的重新随机概率（by Starkku）"
 
-#: ../../Whats-New.md:544
+#: ../../Whats-New.md:556
 msgid "Warheads spawning powerup crates (by Starkku)"
 msgstr "弹头生成升级工具箱（by Starkku）"
 
-#: ../../Whats-New.md:545
+#: ../../Whats-New.md:557
 msgid "Custom tint on TechnoTypes (by Starkku)"
 msgstr "自定义单位染色（by Starkku）"
 
-#: ../../Whats-New.md:546
+#: ../../Whats-New.md:558
 msgid "Revenge weapon (by Starkku)"
 msgstr "复仇武器（by Starkku）"
 
-#: ../../Whats-New.md:547
+#: ../../Whats-New.md:559
 msgid ""
 "AttachEffect types with new features like custom tint and weapon range "
 "modifier (by Starkku)"
 msgstr "AE 类型支持自定义染色和武器射程修正等新功能（by Starkku）"
 
-#: ../../Whats-New.md:548
+#: ../../Whats-New.md:560
 msgid ""
 "Force shield effect sync on deploy & vs. organic targets effect "
 "customization to complement the Iron Curtain ones (by Starkku)"
 msgstr "力场护盾在（反）部署时继承及针对有生物体的自定义铁幕功能补充（by Starkku）"
 
-#: ../../Whats-New.md:549
+#: ../../Whats-New.md:561
 msgid ""
 "Map trigger action `41 Play Animation At...` now uses additional "
 "parameter to determine if animation can play sound, deal damage etc. (by "
 "Starkku)"
 msgstr "地图触发结果 `41 播放动画在...` 现在使用额外参数来决定是否播放声音和造成杀伤（by Starkku）"
 
-#: ../../Whats-New.md:550
+#: ../../Whats-New.md:562
 msgid ""
 "Allow restricting how many times per frame a single radiation site can "
 "damage a building (by Starkku)"
 msgstr "允许限制同一辐射每帧对一个建筑造成杀伤的次数（by Starkku）"
 
-#: ../../Whats-New.md:551
+#: ../../Whats-New.md:563
 msgid ""
 "Allow explicitly setting the superweapons AI uses for Chronoshift script "
 "actions (by Starkku)"
 msgstr "允许明确定义 AI 使用超时空传送脚本动作时所使用的超级武器（by Starkku）"
 
-#: ../../Whats-New.md:552
+#: ../../Whats-New.md:564
 msgid ""
 "Allow customizing Aircraft weapon strafing regardless of `ROT` and "
 "`Strafing.Shots` values beyond 5 (by Trsdy)"
 msgstr "允许自定义战机武器扫射功能不受 `ROT` 值限制且 `Strafing.Shots` 可以超过 5（by Trsdy）"
 
-#: ../../Whats-New.md:553
+#: ../../Whats-New.md:565
 msgid ""
 "Allow strafing weapons to deduct ammo per shot instead of per strafing "
 "run (by Starkku)"
 msgstr "允许扫射武器按每次开火而非每次扫射扣除弹药（by Starkku）"
 
-#: ../../Whats-New.md:554
+#: ../../Whats-New.md:566
 msgid ""
 "Allow `CloakVisible=true` laser trails optinally be seen only if unit is "
 "detected (by Starkku)"
-msgstr "允许 `CloakVisible=true` 的激光尾迹仅在单位被检测到时可见（by Starkku）"
+msgstr "允许 `CloakVisible=true` 的激光尾焰仅在单位被检测到时可见（by Starkku）"
 
-#: ../../Whats-New.md:555
+#: ../../Whats-New.md:567
 msgid ""
 "Skirmish AI \"sell all buildings and set all technos to hunt\" behavior "
 "dehardcode (by TaranDahl)"
 msgstr "遭遇战 AI「卖家冲锋」行为去硬编码（by TaranDahl）"
 
-#: ../../Whats-New.md:556
+#: ../../Whats-New.md:568
 msgid "Skirmish AI \"gather when MCV deploy\" behavior dehardcode (by TaranDahl)"
 msgstr "遭遇战 AI「在 MCV 部署时集结」行为去硬编码（by TaranDahl）"
 
-#: ../../Whats-New.md:557
+#: ../../Whats-New.md:569
 msgid ""
 "Customizing whether passengers are kicked out when an aircraft fires (by "
 "ststl)"
 msgstr "自定义战机开火时是否踹出乘客（by ststl）"
 
-#: ../../Whats-New.md:558
+#: ../../Whats-New.md:570
 msgid "Shield hit flash (by Starkku)"
 msgstr "护盾受击闪光（by Starkku）"
 
-#: ../../Whats-New.md:559
+#: ../../Whats-New.md:571
 msgid ""
 "Option to scatter `(Anim/Splash)List` animations around impact "
 "coordinates (by Starkku)"
 msgstr "自定义 `(Anim/Splash)List` 在引爆坐标周围散布（by Starkku）"
 
-#: ../../Whats-New.md:560
+#: ../../Whats-New.md:572
 msgid "Customizable wake anim (by TwinkleStar)"
 msgstr "自定义涟漪动画（by TwinkleStar）"
 
-#: ../../Whats-New.md:561
+#: ../../Whats-New.md:573
 msgid "Customizable rocker amplitude (by TwinkleStar & Ollerus)"
 msgstr "自定义掀起幅度（by TwinkleStar 与 Ollerus）"
 
-#: ../../Whats-New.md:562
+#: ../../Whats-New.md:574
 msgid ""
 "AI script action to jump back to previous script after picking a random "
 "script (by handama)"
 msgstr "随机跳转回先前步骤的 AI 脚本动作（by handama）"
 
-#: ../../Whats-New.md:563
+#: ../../Whats-New.md:575
 msgid "Insignias visibility and position adjustments (by Fryone)"
 msgstr "军衔可见性与位置调整（by Fryone）"
 
-#: ../../Whats-New.md:564
+#: ../../Whats-New.md:576
 msgid "Promotion animation (by Fryone)"
 msgstr "升级动画（by Fryone）"
 
-#: ../../Whats-New.md:565
+#: ../../Whats-New.md:577
 msgid ""
 "Allow different technos to share build limit in a group (by ststl & "
 "Ollerus)"
 msgstr "允许不同科技类型共享建造限制组（by ststl 与 Ollerus）"
 
-#: ../../Whats-New.md:566
+#: ../../Whats-New.md:578
 msgid ""
 "Map events `604-605` for checking if a specific Techno enters in a cell "
 "(by FS-21)"
 msgstr "用于检查特定科技类型是否进入单元格的 `604-605` 号地图触发条件（by FS-21）"
 
-#: ../../Whats-New.md:567
+#: ../../Whats-New.md:579
 msgid ""
 "Waypoint path is drawn for all units under player control or if "
 "`[GlobalControls] -> DebugPlanningPaths=yes` (by Trsdy)"
@@ -2480,280 +2544,276 @@ msgstr ""
 "当 `[GlobalControls] -> DebugPlanningPaths=yes` "
 "时为玩家控制的所有单位绘制路径点路径而不是仅限玩家所属方的（by Trsdy）"
 
-#: ../../Whats-New.md:568
+#: ../../Whats-New.md:580
 msgid "`RemoveDisguise` now works on vehicle disguises (by Trsdy)"
 msgstr "允许 `RemoveDisguise` 作用于载具伪装效果（by Trsdy）"
 
-#: ../../Whats-New.md:569
+#: ../../Whats-New.md:581
 msgid ""
 "Allow anchoring extended tooltips to the left side of the sidebar (by "
 "Trsdy)"
 msgstr "允许将扩展拓展工具条锚定在侧边栏左侧（by Trsdy）"
 
-#: ../../Whats-New.md:570
+#: ../../Whats-New.md:582
 msgid ""
 "Toggle to allow spawned aircraft to attack immediately after being "
 "spawned (by Starkku)"
 msgstr "子机生成后是否等待集结的开关（by Starkku）"
 
-#: ../../Whats-New.md:571
+#: ../../Whats-New.md:583
 msgid "`ZAdjust` for OverlayTypes (by Starkku)"
 msgstr "让覆盖物可以读取 `ZAdjust` 标签的值（by Starkku）"
 
-#: ../../Whats-New.md:572
+#: ../../Whats-New.md:584
 msgid ""
 "Allow customizing extra tint intensity for Iron Curtain & Force Shield "
 "(by Starkku)"
 msgstr "允许自定义铁幕和力场护盾的额外染色强度（by Starkku）"
 
-#: ../../Whats-New.md:573
+#: ../../Whats-New.md:585
 msgid ""
 "Option to enable parsing 8-bit RGB values from `[ColorAdd]` instead of "
 "RGB565 (by Starkku)"
 msgstr "允许 `[ColorAdd]` 使用 8 位 RGB 而非 RGB565（by Starkku）"
 
-#: ../../Whats-New.md:574
+#: ../../Whats-New.md:586
 msgid ""
 "Customizing height and speed at which subterranean units travel (by "
 "Starkku)"
 msgstr "自定义钻地单位的地下水平移动高度和速度（by Starkku）"
 
-#: ../../Whats-New.md:575
+#: ../../Whats-New.md:587
 msgid ""
 "Option for Warhead damage to penetrate Iron Curtain or Force Shield (by "
 "Starkku)"
 msgstr "允许弹头穿透铁幕或力场护盾（by Starkku）"
 
-#: ../../Whats-New.md:576
+#: ../../Whats-New.md:588
 msgid "Option for Warhead to remove all shield types at once (by Starkku)"
 msgstr "允许弹头一次性移除所有护盾类型（by Starkku）"
 
-#: ../../Whats-New.md:577
+#: ../../Whats-New.md:589
 msgid ""
 "Allow customizing voxel light source position (by Kerbiter & Morton, "
 "based on knowledge of thomassnedon)"
 msgstr "自定义 Voxel 光照角度（by Kerbiter 与 Morton，基于 thomassnedon 的知识）"
 
-#: ../../Whats-New.md:578
+#: ../../Whats-New.md:590
 msgid ""
 "Option to fix voxel light source being offset and incorrectly tilting on "
 "slopes (by Kerbiter)"
 msgstr "允许使用无额外调整的 Voxel 光照角度计算方式，原版算法会导致在斜坡上使用错误的倾斜角度（by Kerbiter）"
 
-#: ../../Whats-New.md:579
+#: ../../Whats-New.md:591
 msgid "AI superweapon delay timer customization (by Starkku)"
 msgstr "自定义 AI 超级武器发射延迟（by Starkku）"
 
-#: ../../Whats-New.md:580
+#: ../../Whats-New.md:592
 msgid "Disabling `MultipleFactory` bonus from specific BuildingType (by Starkku)"
 msgstr "排除特定工厂的多工厂加成（by Starkku）"
 
-#: ../../Whats-New.md:581
+#: ../../Whats-New.md:593
 msgid "Customizable ChronoSphere teleport delays for units (by Starkku)"
 msgstr "自定义单位被超时空传送超武传送的延迟（by Starkku）"
 
-#: ../../Whats-New.md:582
+#: ../../Whats-New.md:594
 msgid "Allowed and disallowed types for `FactoryPlant` (by Starkku)"
 msgstr "`FactoryPlant` 效果的受益类型限制（by Starkku）"
 
-#: ../../Whats-New.md:583
+#: ../../Whats-New.md:595
 msgid ""
 "Customizable damage & 'crumbling' (destruction) frames for TerrainTypes "
 "(by Starkku)"
 msgstr "自定义地形对象残损与倒坍（摧毁）帧（by Starkku）"
 
-#: ../../Whats-New.md:584
+#: ../../Whats-New.md:596
 msgid "Custom object palettes for TerrainTypes (by Starkku)"
 msgstr "地形对象自定义色盘（by Starkku）"
 
-#: ../../Whats-New.md:585
+#: ../../Whats-New.md:597
 msgid "Forbidding parallel AI queues for specific TechnoTypes (by Starkku)"
 msgstr "禁止特定科技类型的 AI 并行生产队列（by Starkku）"
 
-#: ../../Whats-New.md:586
+#: ../../Whats-New.md:598
 msgid "Nonprovocative Warheads (by Starkku)"
 msgstr "非挑衅弹头（by Starkku）"
 
-#: ../../Whats-New.md:587 ../../Whats-New.md:592
+#: ../../Whats-New.md:599 ../../Whats-New.md:604
 msgid "Buildings considered as destroyable pathfinding obstacles (by Starkku)"
 msgstr "允许建筑被视为可摧毁的寻路障碍（by Starkku）"
 
-#: ../../Whats-New.md:588
+#: ../../Whats-New.md:600
 msgid "`FireOnce` infantry sequence reset toggle (by Starkku)"
 msgstr "禁止 `FireOnce` 重置步兵序列（by Starkku）"
 
-#: ../../Whats-New.md:589
+#: ../../Whats-New.md:601
 msgid "Assign Super Weapon cameo to any sidebar tab (by NetsuNegi)"
 msgstr "自定义超级武器所在栏（by NetsuNegi）"
 
-#: ../../Whats-New.md:590
+#: ../../Whats-New.md:602
 msgid "Customizing effect of level lighting on air units (by Starkku)"
 msgstr "自定义光照等级对空中单位的影响（by Starkku）"
 
-#: ../../Whats-New.md:591
+#: ../../Whats-New.md:603
 msgid ""
 "Reimplemented `Airburst` & `Splits` logic with more customization options"
 " (by Starkku)"
 msgstr "重新实现 `Airburst` 和 `Splits` 逻辑并添加更多自定义项（by Starkku）"
 
-#: ../../Whats-New.md:593
+#: ../../Whats-New.md:605
 msgid "Animation visibility customization settings (by Starkku)"
 msgstr "自定义动画可见性（by Starkku）"
 
-#: ../../Whats-New.md:594
+#: ../../Whats-New.md:606
 msgid "Light effect customizations (by Starkku)"
 msgstr "自定义光效（by Starkku）"
 
-#: ../../Whats-New.md:595
+#: ../../Whats-New.md:607
 msgid "Building unit repair customizations (by Starkku)"
 msgstr "在建筑上自定义单位维修参数（by Starkku）"
 
-#: ../../Whats-New.md:596
+#: ../../Whats-New.md:608
 msgid ""
 "Toggle to disallow buildings from providing build area during buildup (by"
 " Starkku)"
 msgstr "允许禁用建筑还在建造过程中就提供 `BaseNormal` 效果（by Starkku）"
 
-#: ../../Whats-New.md:597
+#: ../../Whats-New.md:609
 msgid ""
 "Allow customizing which building types provide build area for a building "
 "(by Starkku)"
 msgstr "允许自定义建筑为哪些建筑提供 `BaseNormal` 效果（by Starkku）"
 
-#: ../../Whats-New.md:598
+#: ../../Whats-New.md:610
 msgid "`Scorch` / `Flamer` fire animation customization (by Starkku)"
 msgstr "自定义 `Scorch`／`Flamer` 火焰动画（by Starkku）"
 
-#: ../../Whats-New.md:599
+#: ../../Whats-New.md:611
 msgid "Warheads parasite removal customization (by Starkku)"
 msgstr "自定义弹头移除寄生（by Starkku）"
 
-#: ../../Whats-New.md:600
+#: ../../Whats-New.md:612
 msgid "Allow infantry to use land sequences in water (by Starkku)"
 msgstr "允许步兵在水中使用陆地序列（by Starkku）"
 
-#: ../../Whats-New.md:601
+#: ../../Whats-New.md:613
 msgid ""
 "`<Player @ X>` can now be used as owner for pre-placed objects on "
 "skirmish and multiplayer maps (by Starkku)"
 msgstr "`<Player @ X>` 现在可以作为遭遇战／多人游戏地图预置对象的所有者（by Starkku）"
 
-#: ../../Whats-New.md:602
+#: ../../Whats-New.md:614
 msgid "Allow customizing charge turret delays per burst on a weapon (by Starkku)"
 msgstr "允许武器自定义充能炮塔变换间隔（by Starkku）"
 
-#: ../../Whats-New.md:603
+#: ../../Whats-New.md:615
 msgid "Draw visual effects for airburst weapons (by CrimRecya)"
 msgstr "空爆武器正常绘制武器特效（by CrimRecya）"
 
-#: ../../Whats-New.md:604
+#: ../../Whats-New.md:616
 msgid "Unit `Speed` setting now accepts floating point values (by Starkku)"
 msgstr "现在单位的 `Speed` 支持小数（by Starkku）"
 
-#: ../../Whats-New.md:605
+#: ../../Whats-New.md:617
 msgid ""
 "`Strafing` is now disabled by default when using `Trajectory` (by "
 "CrimRecya)"
 msgstr "现在 `Strafing` 在抛射体使用了 `Trajectory` 时默认禁用（by CrimRecya）"
 
-#: ../../Whats-New.md:606
-msgid "[Warhead activation target health thresholds](Fixed-or-Improved-Logics.md#customizable-warhead-trigger-conditions) (by FS-21 & Kerbiter)"
-msgstr "[目标血量作为弹头生效条件](Fixed-or-Improved-Logics.md#customizable-warhead-trigger-conditions)（by FS-21 & Kerbiter）"
-
-#: ../../Whats-New.md:609
+#: ../../Whats-New.md:620
 msgid ""
 "Allow AI to repair structures built from base nodes/trigger action 125/SW"
 " delivery in single player missions (by Trsdy)"
 msgstr "允许 AI 在单人任务中修复由基地节点／125 号触发结果／超级武器所投送的建筑（by Trsdy）"
 
-#: ../../Whats-New.md:610
+#: ../../Whats-New.md:621
 #, python-format
 msgid ""
 "Allow usage of `AlternateFLH%d` of vehicles in `OpenTopped` transport. "
 "(by Trsdy)"
 msgstr "令载具在 `OpenTopped` 运输工具中使用**运输工具的** `AlternateFLH%d`（by Trsdy）"
 
-#: ../../Whats-New.md:611
+#: ../../Whats-New.md:622
 msgid ""
 "Improved the statistic distribution of the spawned crates over the "
 "visible area of the map. (by Trsdy, based on TwinkleStar's work)"
 msgstr "改进了升级工具箱在可见地图区域内生成位置的统计分布（by Trsdy，基于 TwinkleStar 的工作）"
 
-#: ../../Whats-New.md:612
+#: ../../Whats-New.md:623
 msgid ""
 "Teams spawned by trigger action 7,80,107 can use IFV and `OpenTopped` "
 "logic normally (by Trsdy)"
 msgstr "通过触发结果 7／80／107 生成的小队现在可以正常使用 IFV 和 `OpenTopped` 逻辑（by Trsdy）"
 
-#: ../../Whats-New.md:613
+#: ../../Whats-New.md:624
 msgid ""
 "Prevented units from retaining previous order after ownership change (by "
 "Trsdy)"
 msgstr "单位在所属变更后不再保留原指令（by Trsdy）"
 
-#: ../../Whats-New.md:614
+#: ../../Whats-New.md:625
 msgid ""
 "Break the mind-control link when capturing a mind-controlled building "
 "with an engineer (by Trsdy)"
 msgstr "工程师占领被心灵控制的建筑时切断心灵控制链接（by Trsdy）"
 
-#: ../../Whats-New.md:615
+#: ../../Whats-New.md:626
 msgid ""
 "Fixed BibShape drawing for a couple of frames during buildup for "
 "buildings with long buildup animations (by Starkku)"
 msgstr "修复了建造动画较长的建筑其 BibShape 会在建造过程中闪现的问题（by Starkku）"
 
-#: ../../Whats-New.md:616
+#: ../../Whats-New.md:627
 msgid "Cloaked & disguised objects displaying to observers (by Starkku)"
 msgstr "观察者现在可以看到隐形和伪装的对象（by Starkku）"
 
-#: ../../Whats-New.md:617
+#: ../../Whats-New.md:628
 msgid ""
 "Cloaked objects from allies displaying to player in single player "
 "missions (by Trsdy)"
 msgstr "单人任务中玩家可以看到友军的隐形对象（by Trsdy）"
 
-#: ../../Whats-New.md:618
+#: ../../Whats-New.md:629
 msgid ""
 "Skip `NaturalParticleSystem` displaying from in-map pre-placed structures"
 " (by Trsdy)"
 msgstr "地图预置建筑不再产生 `NaturalParticleSystem` 的粒子系统（by Trsdy）"
 
-#: ../../Whats-New.md:619
+#: ../../Whats-New.md:630
 msgid "Made sure that `Suicide=yes` weapon does kill the firer (by Trsdy)"
 msgstr "现在 `Suicide=yes` 的武器可以确保击杀开火者（by Trsdy）"
 
-#: ../../Whats-New.md:620
+#: ../../Whats-New.md:631
 msgid ""
 "Made sure that vxl units being flipped over get killed instead of "
 "rotating up and down (by Trsdy)"
 msgstr "现在确保了被翻转的 Voxel 单位会被击杀而不是占据原单元格持续翻滚（不死亡）（by Trsdy）"
 
-#: ../../Whats-New.md:621
+#: ../../Whats-New.md:632
 msgid ""
 "Allow jumpjet units to visually tilt or be flipped over on the ground "
 "even if `TiltCrashJumpjet=no` (by Trsdy)"
 msgstr "允许 Jumpjet 单位即便 `TiltCrashJumpjet=no` 也可以显示倾斜或翻转效果（by Trsdy）"
 
-#: ../../Whats-New.md:622
+#: ../../Whats-New.md:633
 msgid ""
 "Fixed the range for number of debris spawned by Warhead to use MaxDebris "
 "instead of MaxDebris - 1 (by Starkku)"
 msgstr "现在弹头碎片生成量上线正确使用 `MaxDebris` 而非 `MaxDebris - 1`（by Starkku）"
 
-#: ../../Whats-New.md:623
+#: ../../Whats-New.md:634
 msgid ""
 "Fixed `LandTargeting=1` not preventing from targeting TerrainTypes (trees"
 " etc.) on land (by Starkku)"
 msgstr "修复了 `LandTargeting=1` 没有禁止瞄准陆地上的地形对象（树等）的问题（by Starkku）"
 
-#: ../../Whats-New.md:624
+#: ../../Whats-New.md:635
 msgid ""
 "Fixed `NavalTargeting=6` not preventing from targeting empty water cells "
 "or TerrainTypes (trees etc.) on water (by Starkku)"
 msgstr "修复了 `NavalTargeting=6` 没有禁止瞄准空白水域或水上地形对象（树等）的问题（by Starkku）"
 
-#: ../../Whats-New.md:625
+#: ../../Whats-New.md:636
 msgid ""
 "Fixed `NavalTargeting=7` and/or `LandTargeting=2` resulting in still "
 "targeting TerrainTypes (trees etc.) on land with `Primary` weapon (by "
@@ -2762,22 +2822,22 @@ msgstr ""
 "修复了 `NavalTargeting=7` 和／或 `LandTargeting=2` 仍允许使用主武器对陆地上的地形对象（树等）的问题（by "
 "Starkku）"
 
-#: ../../Whats-New.md:626
+#: ../../Whats-New.md:637
 msgid ""
 "Fixed an issue that causes objects in layers outside ground layer to not "
 "be sorted correctly (caused issues with animation and jumpjet layering "
 "for an instance) (by Starkku)"
 msgstr "修复非 ground 层物体排序异常所导致的问题（例如导致动画和 Jumpjet 图层排序错误）（by Starkku）"
 
-#: ../../Whats-New.md:627
+#: ../../Whats-New.md:638
 msgid "Restored `EVA_StructureSold` for buildings with `UndeploysInto` (by Trsdy)"
 msgstr "复原 `UndeploysInto` 建筑的 `EVA_StructureSold`（by Trsdy）"
 
-#: ../../Whats-New.md:628
+#: ../../Whats-New.md:639
 msgid "Allow MCV to redeploy in campaigns (by Trsdy)"
 msgstr "允许 MCV 在战役中重部署（by Trsdy）"
 
-#: ../../Whats-New.md:629
+#: ../../Whats-New.md:640
 msgid ""
 "Allow buildings with `UndeploysInto` to be sold if `Unsellable=no` but "
 "`ConstructionYard=no` (by Trsdy)"
@@ -2785,13 +2845,13 @@ msgstr ""
 "允许拥有 `UndeploysInto` 的建筑在 `Unsellable=no` 但 `ConstructionYard=no` "
 "的情况下被出售（by Trsdy）"
 
-#: ../../Whats-New.md:630
+#: ../../Whats-New.md:641
 msgid ""
 "Fixed infantry without `C4=true` being killed in water if paradropped, "
 "chronoshifted etc. even if they can normally enter water (by Starkku)"
 msgstr "修复了无 `C4=true` 的步兵通过空降／超时空等方式进入水域会死亡的问题。即便它们正常情况下进入水域（by Starkku）"
 
-#: ../../Whats-New.md:631
+#: ../../Whats-New.md:642
 msgid ""
 "Fixed `WaterBound=true` buildings with `UndeploysInto` not correctly "
 "setting the location for the vehicle to move into when undeployed (by "
@@ -2800,23 +2860,23 @@ msgstr ""
 "修复了 `WaterBound=true` 且拥有 `UndeploysInto` 的建筑在反部署时无法正常设置载具移动位置的问题（by "
 "Starkku）"
 
-#: ../../Whats-New.md:632
+#: ../../Whats-New.md:643
 msgid "Allow more than 5 `AlternateFLH` entries for units (by ststl)"
 msgstr "允许 `AlternateFLH` 条目超过 5 个（by ststl）"
 
-#: ../../Whats-New.md:633
+#: ../../Whats-New.md:644
 msgid ""
 "Buildings with `CanC4=false` will no longer take 1 point of positive "
 "damage if hit by negative damage (by Starkku)"
 msgstr "拥有 `CanC4=false` 的建筑在受到负值杀伤时不再获得 1 点正值伤害（by Starkku）"
 
-#: ../../Whats-New.md:634
+#: ../../Whats-New.md:645
 msgid ""
 "Buildings with primary weapon that has `AG=false` projectile now have "
 "attack cursor when selected (by Starkku)"
 msgstr "使用抛射体 `AG=false` 的主武器的建筑现在在选中时正常显示攻击光标（by Starkku）"
 
-#: ../../Whats-New.md:635
+#: ../../Whats-New.md:646
 msgid ""
 "Transports with `OpenTopped=true` and weapon that has `Burst` above 1 and"
 " passengers firing out no longer have the passenger firing offset shift "
@@ -2825,59 +2885,59 @@ msgstr ""
 "现在 `OpenTopped=true` 且拥有大于 1 的 `Burst` 的武器的运输工具其载员开火不再由于连发的序数而改变侧向偏移位置（by"
 " Starkku）"
 
-#: ../../Whats-New.md:636
+#: ../../Whats-New.md:647
 msgid ""
 "Light tint created by a building is now able to be removed after loading "
 "the game (by Trsdy)"
 msgstr "现在建筑灯光效果可以正常在读档后移除（by Trsdy）"
 
-#: ../../Whats-New.md:637
+#: ../../Whats-New.md:648
 msgid "Prevented crashing jumpjet units from firing (by Trsdy)"
 msgstr "修复了 Jumpjet 单位在坠毁时仍可继续向敌方目标开火的 Bug（by Trsdy）"
 
-#: ../../Whats-New.md:638
+#: ../../Whats-New.md:649
 msgid ""
 "Fixed disguised infantry not using custom palette for drawing the "
 "disguise when needed (by Starkku)"
 msgstr "修复了伪装的步兵在必要时没有使用自定义色盘来绘制伪装图像的问题（by Starkku）"
 
-#: ../../Whats-New.md:639
+#: ../../Whats-New.md:650
 msgid ""
 "Reenabled the obsolete `[General] -> WarpIn` as default anim type when "
 "units are warping in (by Trsdy)"
 msgstr "重启废弃的 `[General] -> WarpIn` 作为单位超时空传送来的默认动画类型（by Trsdy）"
 
-#: ../../Whats-New.md:640
+#: ../../Whats-New.md:651
 msgid ""
 "Fixed permanent health bar display for units targeted by temporal weapons"
 " upon mouse hover (by Trsdy)"
 msgstr "修复了被超时空武器攻击的单位其血条在鼠标掠过其上后不会消失的 Bug（by Trsdy）"
 
-#: ../../Whats-New.md:641
+#: ../../Whats-New.md:652
 msgid ""
 "Buildings with superweapons no longer display `SuperAnimThree` at "
 "beginning of match if pre-placed on the map (by Starkku)"
 msgstr "地图上预先放置的超级武器类建筑在游戏开始时不再显示 `SuperAnimThree`（by Starkku）"
 
-#: ../../Whats-New.md:642
+#: ../../Whats-New.md:653
 msgid ""
 "AI players can now build `Naval=true` and `Naval=false` vehicles "
 "concurrently like human players do (by Starkku)"
 msgstr "现在 AI 玩家可以像人类玩家一样同时建造 `Naval=true` 与 `Naval=false` 的载具（by Starkku）"
 
-#: ../../Whats-New.md:643
+#: ../../Whats-New.md:654
 msgid ""
 "Fixed the bug when jumpjets were snapping into facing bottom-right when "
 "starting movement (by Kerbiter)"
 msgstr "修复了 Jumpjet 单位在开始移动时会突然面向右下方向的 Bug（by Kerbiter）"
 
-#: ../../Whats-New.md:644
+#: ../../Whats-New.md:655
 msgid ""
 "Suppressed the BuildingCaptured EVA events when capturing a building "
 "considered as a vehicle (by Trsdy)"
 msgstr "移除了占领被视为载具的建筑时触发的 `EVA_BuildingCaptured` 事件播报（by Trsdy）"
 
-#: ../../Whats-New.md:645
+#: ../../Whats-New.md:656
 msgid ""
 "Objects with `Palette` set now have their color tint adjusted accordingly"
 " by superweapons, map retint actions etc. if they belong to a house using"
@@ -2887,14 +2947,14 @@ msgstr ""
 "现在拥有 `Palette` 设置的对象可以正常根据超级武器、地图重绘光照行为等调整其色调。只要它们属于使用了任何配色方案的所属方而不仅限于 "
 "`[Colors]` 列表前半部分那些（by Starkku）"
 
-#: ../../Whats-New.md:646
+#: ../../Whats-New.md:657
 msgid ""
 "Animations using `AltPalette` are now remapped to their owner's color "
 "scheme instead of first listed color scheme and no longer draw over "
 "shroud (by Starkku)"
 msgstr "现在使用 `AltPalette` 的动画会被重映射到其所属方的配色方案而不再是被列出的第一个配色方案并且不再绘制于黑幕之上（by Starkku）"
 
-#: ../../Whats-New.md:647
+#: ../../Whats-New.md:658
 msgid ""
 "Fixed `DeployToFire` not considering building placement rules for "
 "`DeploysInto` buildings and as a result not working properly with "
@@ -2903,13 +2963,13 @@ msgstr ""
 "修复了 `DeployToFire` 未考虑 `DeploysInto` 建筑的摆放规则并导致该功能无法与 `WaterBound` "
 "建筑一起正常工作的问题（by Starkku）"
 
-#: ../../Whats-New.md:648
+#: ../../Whats-New.md:659
 msgid ""
 "Fixed `DeployToFire` not recalculating firer's position on land if it "
 "cannot currently deploy (by Starkku)"
 msgstr "修复了 `DeployToFire` 在当前无法部署时未能重新计算开火者在陆地上所处位置的问题（by Starkku）"
 
-#: ../../Whats-New.md:649
+#: ../../Whats-New.md:660
 msgid ""
 "`Arcing=true` projectile elevation inaccuracy can now be fixed by setting"
 " `Arcing.AllowElevationInaccuracy=false` (by Starkku)"
@@ -2917,67 +2977,67 @@ msgstr ""
 "现在可以通过设置 `Arcing.AllowElevationInaccuracy=false` 来修复 `Arcing=true` "
 "抛射体在有高程影响下的精度问题（by Starkku）"
 
-#: ../../Whats-New.md:650
+#: ../../Whats-New.md:661
 msgid ""
 "Fixed position and layer of info tip and reveal production cameo on "
 "selected building (by Belonit)"
 msgstr "修复了被选中建筑上信息提示和显示生产图标的位置和图层问题（by Belonit）"
 
-#: ../../Whats-New.md:651
+#: ../../Whats-New.md:662
 msgid "Fixed `TurretOffset` to be supported for SHP vehicles (by TwinkleStar)"
 msgstr "现在 `TurretOffset` 可以支持 Shape 载具了（by TwinkleStar）"
 
-#: ../../Whats-New.md:652
+#: ../../Whats-New.md:663
 msgid ""
 "`Powered`/`PoweredSpecial` buildings' powered anims will update as usual "
 "when being captured by enemies (by Trsdy)"
 msgstr "修复了 `Powered`／`PoweredSpecial` 的建筑在被敌人占领时其受电力影响的动画不再更新的问题（by Trsdy）"
 
-#: ../../Whats-New.md:653
+#: ../../Whats-New.md:664
 msgid ""
 "Fixed a glitch related to incorrect target setting for missiles (by "
 "Belonit)"
 msgstr "修复导弹目标设置错误导致的图形问题（by Belonit）"
 
-#: ../../Whats-New.md:654
+#: ../../Whats-New.md:665
 msgid ""
 "Skipped parsing `[Header]` section of compaign maps which led to "
 "occasional crashes on Linux (by Trsdy)"
 msgstr "跳过对战役地图 `[Header]` 小节的解析以修复 Linux 系统偶尔崩溃的问题（by Trsdy）"
 
-#: ../../Whats-New.md:655
+#: ../../Whats-New.md:666
 msgid "Fixed units' turret rotation and jumpjet wobble under EMP (by Trsdy)"
 msgstr "修复了 EMP 状态下炮塔仍可转动炮塔以及 Jumpjet 单位仍旧浮动的问题（by Trsdy）"
 
-#: ../../Whats-New.md:656
+#: ../../Whats-New.md:667
 msgid ""
 "Fixed `AmbientDamage` when used with `IsRailgun=yes` being cut off by "
 "elevation changes (by Starkku)"
 msgstr "修复了 `AmbientDamage` 在与 `IsRailgun=yes` 共用时会被高度变化切断的问题（by Starkku）"
 
-#: ../../Whats-New.md:657
+#: ../../Whats-New.md:668
 msgid ""
 "Fixed railgun and fire particles being cut off by elevation changes (by "
 "Starkku)"
 msgstr "修复了轨道炮和火焰粒子被高度变化切断的问题（by Starkku）"
 
-#: ../../Whats-New.md:658
+#: ../../Whats-New.md:669
 msgid ""
 "Fixed teleport units' frozen-still timer being reset after load game (by "
 "Trsdy)"
 msgstr "修复了超时空单位的僵直计时器在载入游戏后被清空的问题（by Trsdy）"
 
-#: ../../Whats-New.md:659
+#: ../../Whats-New.md:670
 msgid "Fixed teleport units being unable to visually tilt on slopes (by Trsdy)"
 msgstr "修复了超时空运动模式的单位无法在斜坡上视觉性倾斜的问题（by Trsdy）"
 
-#: ../../Whats-New.md:660
+#: ../../Whats-New.md:671
 msgid ""
 "Fixed teleport and drill units being unable to be visually flipped (by "
 "Trsdy)"
 msgstr "修复了超时空和钻地单位无法视觉翻转的问题（by Trsdy）"
 
-#: ../../Whats-New.md:661
+#: ../../Whats-New.md:672
 msgid ""
 "Aircraft docking on buildings now respect `[AudioVisual] -> PoseDir` as "
 "the default setting and do not always land facing north or in case of "
@@ -2986,89 +3046,89 @@ msgstr ""
 "现在战机在建筑上停靠时尊重 `[AudioVisual] -> PoseDir` "
 "作为默认设置而不总是朝向北方，或者在地图预置建筑上面向建筑的方向（by Starkku）"
 
-#: ../../Whats-New.md:662
+#: ../../Whats-New.md:673
 msgid ""
 "Spawned aircraft now align with the spawner's facing when landing (by "
 "Starkku)"
 msgstr "现在生成的子机在降落时会与其母舰的朝向对正（by Starkku）"
 
-#: ../../Whats-New.md:663
+#: ../../Whats-New.md:674
 msgid ""
 "Fixed infantries attempted to entering buildings when waypointing "
 "together with engineer/agent/occupier/etc (by Trsdy)"
 msgstr "修复了步兵在与间谍／工程师／可驻军步兵等一起进入路径点时会尝试进入建筑的 Bug（by Trsdy）"
 
-#: ../../Whats-New.md:664
+#: ../../Whats-New.md:675
 msgid "Fixed jumpjet crash speed when crashing onto buildings (by NetsuNegi)"
 msgstr "移除了 Jumpjet 单位坠毁到建筑上时的减速效果（by NetsuNegi）"
 
-#: ../../Whats-New.md:665
+#: ../../Whats-New.md:676
 msgid ""
 "Fixed a desync potentially caused by displaying of cursor over selected "
 "`DeploysInto` units (by Starkku)"
 msgstr "修复了在选中 `DeploysInto` 单位上显示光标时可能引起的不同步问题（by Starkku）"
 
-#: ../../Whats-New.md:666
+#: ../../Whats-New.md:677
 msgid "Skipped drawing the rally point line when undeploying a factory (by Trsdy)"
 msgstr "跳过工厂类建筑反部署时的集结线绘制（by Trsdy）"
 
-#: ../../Whats-New.md:667
+#: ../../Whats-New.md:678
 msgid ""
 "Tint effects are now correctly applied to SHP vehicles and all types of "
 "aircraft as well as building animations regardless of their position (by "
 "Starkku)"
 msgstr "现在染色效果无论对象位置如何都会正确对 Shape 载具、所有类型的战机以及建筑动画生效（by Starkku）"
 
-#: ../../Whats-New.md:668
+#: ../../Whats-New.md:679
 msgid ""
 "Iron Curtained / Force Shielded objects now always use the correct tint "
 "color (by Starkku)"
 msgstr "现在被铁幕或力场护盾保护的对象将始终使用正确的染色效果（by Starkku）"
 
-#: ../../Whats-New.md:669
+#: ../../Whats-New.md:680
 msgid ""
 "Objects in invalid map coordinates are no longer used for starting view "
 "and AI base center calculations (by Starkku)"
 msgstr "位于无效地图坐标中的对象不再用于初始视图和 AI 基地中心计算（by Starkku）"
 
-#: ../../Whats-New.md:670
+#: ../../Whats-New.md:681
 msgid ""
 "Units & buildings with `DecloakToFire=false` weapons can now cloak while "
 "targeting & reloading (by Starkku)"
 msgstr "现在拥有 `DecloakToFire=false` 武器的单位和建筑在瞄准和装填时会隐形（by Starkku）"
 
-#: ../../Whats-New.md:671
+#: ../../Whats-New.md:682
 msgid ""
 "Units with `Sensors=true` will no longer reveal ally buildings (by "
 "Starkku)"
 msgstr "拥有 `Sensors=true` 的单位将不再解除友军建筑的隐形（by Starkku）"
 
-#: ../../Whats-New.md:672
+#: ../../Whats-New.md:683
 msgid ""
 "Air units are now reliably included by target scan with large range and "
 "Warhead detonation by large `CellSpread` (by Starkku)"
 msgstr "现在具有大范围的目标检索和大 `CellSpread` 的弹头爆炸范围可靠的包含了空中单位（by Starkku）"
 
-#: ../../Whats-New.md:673
+#: ../../Whats-New.md:684
 msgid ""
 "Weapons with `AA=true` Projectile can now correctly fire at air units "
 "when both firer and target are over a bridge (by Starkku)"
 msgstr "现在当开火者和目标都在桥上时拥有 `AA=true` 抛射体的武器可以正确的对空中单位射击（by Starkku）"
 
-#: ../../Whats-New.md:674
+#: ../../Whats-New.md:685
 msgid ""
 "Fixed disguised units not using the correct palette if target has custom "
 "palette (by NetsuNegi)"
 msgstr "修复了伪装单位在目标具有自定义调色盘时未使用正确调色盘的问题（by NetsuNegi）"
 
-#: ../../Whats-New.md:675
+#: ../../Whats-New.md:686
 msgid ""
 "Building upgrades now consistently use building's `PowerUpN` animation "
 "settings corresponding to the upgrade's `PowersUpToLevel` where possible "
 "(by Starkku)"
 msgstr "现在建筑加载物将尽可能一致地使用与加载物 `PowersUpToLevel` 相对应的建筑 `PowerUpN` 动画设置（by Starkku）"
 
-#: ../../Whats-New.md:676
+#: ../../Whats-New.md:687
 msgid ""
 "Subterranean units are no longer allowed to perform deploy functions like"
 " firing weapons or `IsSimpleDeployer` while burrowed or burrowing, they "
@@ -3078,19 +3138,19 @@ msgstr ""
 "现在钻地单位在钻地或正在钻地时不再允许执行例如发射武器或 `IsSimpleDeployer` "
 "那样的部署功能，现在它们会先像运输工具释放乘客那样先钻出地面（by Starkku）"
 
-#: ../../Whats-New.md:677
+#: ../../Whats-New.md:688
 msgid ""
 "Fixed `Temporal=true` Warheads potentially crashing game if used to "
 "attack `Slaved=true` infantry (by Starkku)"
 msgstr "修复了 `Temporal=true` 弹头在攻击 `Slaved=true` 步兵时可能崩溃的问题（by Starkku）"
 
-#: ../../Whats-New.md:678
+#: ../../Whats-New.md:689
 msgid ""
 "Fixed some locomotors (Tunnel, Walk, Mech) getting stuck when moving too "
 "fast (by NetsuNegi)"
 msgstr "修复了一些运动模式（Tunnel、Walk、Mech）在移动过快时卡住的问题（by NetsuNegi）"
 
-#: ../../Whats-New.md:679
+#: ../../Whats-New.md:690
 msgid ""
 "Animations with `MakeInfantry` and `UseNormalLight=false` that are drawn "
 "in unit palette will now have cell lighting changes applied on them (by "
@@ -3099,31 +3159,31 @@ msgstr ""
 "现在使用 `MakeInfantry` 和 `UseNormalLight=false` 并使用单位色盘绘制的动画将正常应用单元格的亮度变化（by"
 " Starkku）"
 
-#: ../../Whats-New.md:680
+#: ../../Whats-New.md:691
 msgid ""
 "Fixed Nuke & Dominator Level lighting not applying to AircraftTypes (by "
 "Starkku)"
 msgstr "修复了核弹和心灵支配的光照等级未应用于战机类别的问题（by Starkku）"
 
-#: ../../Whats-New.md:681
+#: ../../Whats-New.md:692
 msgid ""
 "Removed the 0 damage effect from `InfDeath=9` warheads to in-air "
 "infantries (by Trsdy)"
 msgstr "移除了 `InfDeath=9` 的弹头对 Jumpjet 步兵只能造成 0 伤害的效果（by Trsdy）"
 
-#: ../../Whats-New.md:682
+#: ../../Whats-New.md:693
 msgid ""
 "Projectiles created from `AirburstWeapon` now remember their WeaponType "
 "and can apply radiation etc. (by Starkku)"
 msgstr "现在由 `AirburstWeapon` 创建的抛射体会保留完整 WeaponType 并且可以应用辐射等效果（by Starkku）"
 
-#: ../../Whats-New.md:683
+#: ../../Whats-New.md:694
 msgid ""
 "Fixed damaged aircraft not repairing on `UnitReload=true` docks unless "
 "they land on the dock first (by Starkku)"
 msgstr "修复了受损的战机除非先降落于 `UnitReload=true` 的停靠点上否则不能修复的问题（by Starkku）"
 
-#: ../../Whats-New.md:684
+#: ../../Whats-New.md:695
 msgid ""
 "Certain global tileset indices (`ShorePieces`, `WaterSet`, `CliffSet`, "
 "`WaterCliffs`, `WaterBridge`, `BridgeSet` and `WoodBridgeSet`) can now be"
@@ -3133,7 +3193,7 @@ msgstr ""
 "来切换某些全局地块索引（`ShorePieces`、`WaterSet`、`CliffSet`、`WaterCliffs`、`WaterBridge`、`BridgeSet`"
 " 和 `WoodBridgeSet`）以解析月球场景（by Starkku）"
 
-#: ../../Whats-New.md:685
+#: ../../Whats-New.md:696
 msgid ""
 "Fixed infantry `SecondaryFire` / `SecondaryProne` sequences being "
 "displayed in water instead of `WetAttack` (by Starkku)"
@@ -3141,13 +3201,13 @@ msgstr ""
 "修复了步兵在水中显示 `SecondaryFire`／`SecondaryProne` 序列而不是 `WetAttack` 的问题（by "
 "Starkku）"
 
-#: ../../Whats-New.md:686
+#: ../../Whats-New.md:697
 msgid ""
 "Fixed objects with ally target and `AttackFriendlies=true` having their "
 "target reset every frame, particularly AI-owned buildings (by Starkku)"
 msgstr "修复了目标为友军单位且 `AttackFriendlies=true` 的对象每帧重置目标的问题，尤其是 AI 拥有的建筑（by Starkku）"
 
-#: ../../Whats-New.md:687
+#: ../../Whats-New.md:698
 msgid ""
 "Follower vehicle index for preplaced vehicles in maps is now explicitly "
 "constrained to `[Units]` list in map files and is no longer thrown off by"
@@ -3157,42 +3217,42 @@ msgstr ""
 "现在地图预置载具的跟随索引已被明确限制在地图 `[Units]` "
 "列表中并且不再受到无法创建的载具或创建的载具具有其他载具作为初始乘客的情况所干扰（by Starkku）"
 
-#: ../../Whats-New.md:688
+#: ../../Whats-New.md:699
 msgid ""
 "Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-"
 "piggybacked bugfix (by tyuah8)"
 msgstr "修复了 Drive/Jumpjet/Ship/Teleport 运动方式在退出 piggybacked 接口时无法激活的问题（by tyuah8）"
 
-#: ../../Whats-New.md:689
+#: ../../Whats-New.md:700
 msgid "Fixed `Stop` command not working so well in some cases (by CrimRecya)"
 msgstr "修复了 `停止` 命令有时候不灵光的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:690
+#: ../../Whats-New.md:701
 msgid ""
 "Use 2D distance instead of 3D to check whether in air team members have "
 "arrived destination (by CrimRecya)"
 msgstr "现在作为小队成员的空中单位将使用 2D 距离而不是 3D 距离来判断是否达到任务目的地（by CrimRecya）"
 
-#: ../../Whats-New.md:691
+#: ../../Whats-New.md:702
 msgid ""
 "Subterranean movement now benefits from speed multipliers from all "
 "sources such as veterancy, AttachEffect etc. (by Starkku)"
 msgstr "现在钻地运动方式享受来自升级、AttachEffect 等所有来源的速度加成（by Starkku）"
 
-#: ../../Whats-New.md:692
+#: ../../Whats-New.md:703
 msgid ""
 "Fixed an issue where a unit will leave an impassable invisible barrier in"
 " its original position when it is teleported by ChronoSphere onto an "
 "uncrushable unit and self destruct (by NetsuNegi)"
 msgstr "修复了一个单位被超时空传送超武传送到一个不可碾压的单位上并自爆时会在原地留下空气墙的问题（by NetsuNegi）"
 
-#: ../../Whats-New.md:693
+#: ../../Whats-New.md:704
 msgid ""
 "Fixed the bug that parasite will vanish if it missed its target when its "
 "previous cell is occupied (by TaranDahl)"
 msgstr "修复了寄生单位在错过目标且其先前单元格被占用时会直接消失的 Bug（by TaranDahl）"
 
-#: ../../Whats-New.md:694
+#: ../../Whats-New.md:705
 msgid ""
 "Aircraft will now behave as expected according to it's `MovementZone` and"
 " `SpeedType` when moving onto different surfaces. In particular, this "
@@ -3203,38 +3263,38 @@ msgstr ""
 "战机现在会根据其 `MovementZone` 和 `SpeedType` "
 "在移动到不同地形上时表现得像预期一样。特别是，这修复了原版中战机被命令移动到水面却将移动命令改为附近的岸边这一异常行为（by CrimRecya）"
 
-#: ../../Whats-New.md:695
+#: ../../Whats-New.md:706
 msgid ""
 "Fixed the bug that destroyed unit may leaves sensors (by tyuah8 & "
 "NetsuNegi)"
 msgstr "修复了单位被摧毁仍会遗留反隐形探测效果的问题（by tyuah8 与 NetsuNegi）"
 
-#: ../../Whats-New.md:696
+#: ../../Whats-New.md:707
 msgid ""
 "`FreeUnit` uses its own `SpeedType` to determine where to spawn (by "
 "NetsuNegi)"
 msgstr "`FreeUnit` 使用单位自己的 `SpeedType` 来寻找生成位置（by NetsuNegi）"
 
-#: ../../Whats-New.md:697
+#: ../../Whats-New.md:708
 msgid ""
 "Fixed the bug where naval ships set to `AllowedToStartInMultiplayer=yes` "
 "may spawn incorrectly on land (by NetsuNegi)"
 msgstr "修复了海军舰船设为 `AllowedToStartInMultiplayer=yes` 可能生成在陆地上的 Bug（by NetsuNegi）"
 
-#: ../../Whats-New.md:698
+#: ../../Whats-New.md:709
 msgid ""
 "Fixed the bug where pathfinding issues occur when a building performs "
 "undeploy (by NetsuNegi)"
 msgstr "修复了建筑执行 `UndeploysInto` 时的寻路问题（by NetsuNegi）"
 
-#: ../../Whats-New.md:699
+#: ../../Whats-New.md:710
 msgid ""
 "Units are now unable to kick out from a factory that is in construction "
 "process, and will not always stuck in the factory (by CrimRecya & "
 "TaranDahl)"
 msgstr "单位现在不会再从正在建造的工厂中驶出，并且将不再会被卡在工厂内（by CrimRecya 与 TaranDahl）"
 
-#: ../../Whats-New.md:700
+#: ../../Whats-New.md:711
 msgid ""
 "Fixed a crash caused by electric bolt not invalidating Owner (by "
 "NetsuNegi)"
@@ -3243,32 +3303,32 @@ msgstr ""
 "004C2C19](https://modenc.renegadeprojects.com/Internal_Error#eip_004C2C19)（by"
 " NetsuNegi）"
 
-#: ../../Whats-New.md:701
+#: ../../Whats-New.md:712
 msgid ""
 "Fixed a jumpjet crash related to voxel shadow drawing (by hejiajun107, "
 "Xkein, ZivDero)"
 msgstr "修复与 Voxel 阴影绘制相关的 Jumpjet 崩溃问题（by hejiajun107、Xkein、ZivDero）"
 
-#: ../../Whats-New.md:702
+#: ../../Whats-New.md:713
 msgid ""
 "Fixed issues caused by incorrect reference removal (f.ex. If the unit "
 "cloaks/enters transport, it cannot gain experience from previously "
 "launched spawners/C4/projectiles)"
 msgstr "修复了错误脱引用导致的问题（例如，如果单位隐形／进入运输工具则无法自此前发射的子机／抛射体以及安置的 C4 炸弹获得经验）"
 
-#: ../../Whats-New.md:703
+#: ../../Whats-New.md:714
 msgid ""
 "Fixed an issue that caused `IsSonic=true` wave drawing to crash the game "
 "if the wave traveled over a certain distance (by Starkku)"
 msgstr "修复了一个如果 `IsSonic=true` 的波绘制超过一定距离会导致游戏崩溃的问题（by Starkku）"
 
-#: ../../Whats-New.md:704
+#: ../../Whats-New.md:715
 msgid ""
 "Fixed `Hospital=yes` building can't kick out infantry after loading a "
 "save (by FlyStar)"
 msgstr "修复了 `Hospital=yes` 的建筑在读档后无法让步兵离开的问题（by FlyStar）"
 
-#: ../../Whats-New.md:705
+#: ../../Whats-New.md:716
 msgid ""
 "Electric bolts that are supposed to update their position based on units "
 "current firing coords (by default, those fired by vehicles) now do so "
@@ -3277,57 +3337,57 @@ msgstr ""
 "现在那些本应跟随单位当前开火坐标更新位置的 EBolt 效果（默认指由载具发射的）能够正确的对超过 1 个同时创建的 EBolt 效果生效（by "
 "Starkku）"
 
-#: ../../Whats-New.md:706
+#: ../../Whats-New.md:717
 msgid ""
 "Fixed an issue where `FireAngle` would not work properly under certain "
 "circumstances (by TaranDahl)"
 msgstr "修复了 `FireAngle` 在某些情况下未能正常工作的问题（by TaranDahl）"
 
-#: ../../Whats-New.md:707
+#: ../../Whats-New.md:718
 msgid ""
 "Fixed the bug that healing weapons could not automatically acquire aerial"
 " targets (by TaranDahl)"
 msgstr "修复了治疗武器无法自动获取到空中目标的 Bug（by TaranDahl）"
 
-#: ../../Whats-New.md:708
+#: ../../Whats-New.md:719
 msgid ""
 "Technos are no longer unable to stop when it is above the elevated "
 "bridge, and they are still not allowed to stop moving under the elevated "
 "bridge, but can stop other missions (by CrimRecya)"
 msgstr "单位不再会因为在桥上而无法停止，目前它们在桥下还无法停止移动，但可以停止其他任务（by CrimRecya）"
 
-#: ../../Whats-New.md:709
+#: ../../Whats-New.md:720
 msgid ""
 "Fixed an issue that aircraft carriers can not find suitable locations for"
 " attacks when under elevated bridges on their own (by CrimRecya)"
 msgstr "修复了航空母舰在桥下时无法找到恰当攻击位置的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:710
+#: ../../Whats-New.md:721
 msgid ""
 "Fixed an issue that in air aircraft carriers being unable to attack when "
 "it is near by elevated bridges (by CrimRecya & TaranDahl)"
 msgstr "修复了空天母舰靠近高架桥梁时无法攻击的问题（by CrimRecya 与 TaranDahl）"
 
-#: ../../Whats-New.md:711
+#: ../../Whats-New.md:722
 msgid ""
 "Fixed an issue that aircraft carriers cannot retract its spawned aircraft"
 " when on the bridge (by CrimRecya)"
 msgstr "修复了航空母舰在桥上无法回收子机的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:712
+#: ../../Whats-New.md:723
 msgid ""
 "Fixed an issue where the shadow of jumpjet remained on the ground when it"
 " was above the elevated bridge (by CrimRecya)"
 msgstr "修复了 Jumpjet 在桥梁上方时其影子残留在地面的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:713
+#: ../../Whats-New.md:724
 msgid ""
 "Fixed an issue where AI would select unreachable buildings and get stuck "
 "when looking for buildings like tank bunkers, bio reactors, etc. (by "
 "TaranDahl)"
 msgstr "修复了 AI 会找实际无法抵达的坦克碉堡、生化反应炉等建筑作为目标而导致卡住的问题（by TaranDahl）"
 
-#: ../../Whats-New.md:714
+#: ../../Whats-New.md:725
 msgid ""
 "Fixed the bug that a unit can overlap with `Teleport` units after it's "
 "been damaged by a fallen unit lifted by `IsLocomotor=yes` warheads (by "
@@ -3336,61 +3396,61 @@ msgstr ""
 "修复了一个单位被另一个由 `IsLocomotor=yes` 弹头吊起的单位砸过后其所在单元格可以被一个 `Teleport` "
 "运动模式的单位作为超时空移动的目的地的问题（by NetsuNegi）"
 
-#: ../../Whats-New.md:715
+#: ../../Whats-New.md:726
 msgid ""
 "Fixed an issue that harvesters with amphibious movement zone can not "
 "automatically return to refineries with `WaterBound` on water surface (by"
 " NetsuNegi)"
 msgstr "修复了两栖矿车无法自动返回拥有 `WaterBound` 的矿场的问题（by NetsuNegi）"
 
-#: ../../Whats-New.md:716
+#: ../../Whats-New.md:727
 msgid ""
 "Fixed an issue that game crashes (EIP:7FB178) when infantry are about to "
 "enter an occupiable building that has been removed and is not real dead "
 "(by CrimRecya)"
 msgstr "修复了当步兵进入一个已被移除但并未真正死亡的可驻军建筑时导致的游戏崩溃问题（EIP:7FB178）（by CrimRecya）"
 
-#: ../../Whats-New.md:717
+#: ../../Whats-New.md:728
 msgid ""
 "Fixed an issue that game crashes when spawnee has been removed and is not"
 " real dead (by CrimRecya)"
 msgstr "修复了当子机已被移除但并未真正死亡时导致的游戏崩溃问题（by CrimRecya）"
 
-#: ../../Whats-New.md:718
+#: ../../Whats-New.md:729
 msgid ""
 "Fixed `VoiceDeploy` not played, when deployed through hot-key/command bar"
 " (by Fryone)"
 msgstr "修复了通过快捷键／底边栏按钮部署时不播放 `VoiceDeploy` 的问题（by Fryone）"
 
-#: ../../Whats-New.md:721
+#: ../../Whats-New.md:732
 msgid ""
 "Fixed a few errors of calling for superweapon launch by `LaunchSW` or "
 "building infiltration (by Trsdy)"
 msgstr "修复了通过 `LaunchSW` 或渗透建筑来调用超级武器发射相关的若干错误（by Trsdy）"
 
-#: ../../Whats-New.md:722
+#: ../../Whats-New.md:733
 msgid "Add `ImmuneToCrit` for shields (by Trsdy)"
 msgstr "添加护盾版的 `ImmuneToCrit`（by Trsdy）"
 
-#: ../../Whats-New.md:723
+#: ../../Whats-New.md:734
 msgid ""
 "Reimplemented the bugfix for jumpjet units' facing when firing, discard "
 "the inappropriate `JumpjetTurnToTarget` tag (by Trsdy)"
 msgstr "重新实现了 Jumpjet 开火朝向 Bug 修复，弃用不合适的 `JumpjetTurnToTarget` 标签（by Trsdy）"
 
-#: ../../Whats-New.md:724
+#: ../../Whats-New.md:735
 msgid ""
 "`Gunner=true` transports now correctly change turret if a passenger is "
 "removed by `PassengerDeletion` (by Starkku)"
 msgstr "现在 `Gunner=true` 的运输工具可以在载员被 `PassengerDeletion` 删除时正确更换炮塔图像（by Starkku）"
 
-#: ../../Whats-New.md:725
+#: ../../Whats-New.md:736
 msgid ""
 "`PassengerDeletion.Soylent` now correctly calculates refund value if "
 "removed passenger has no explicitly set `Soylent` value (by Starkku)"
 msgstr "现在 `PassengerDeletion.Soylent` 可以在载员未设置 `Soylent` 的情况下正确计算退款金额（by Starkku）"
 
-#: ../../Whats-New.md:726
+#: ../../Whats-New.md:737
 msgid ""
 "Superweapon `Detonate.Weapon` & `Detonate.Warhead` now use the firing "
 "house to deal damage and apply Phobos warhead effects even if no firing "
@@ -3399,68 +3459,68 @@ msgstr ""
 "现在超武的 `Detonate.Weapon` 和 `Detonate.Warhead` 即便找不到发射建筑也会使用发射者的所属方来造成伤害并使用"
 " Phobos 弹头效果（by Starkku）"
 
-#: ../../Whats-New.md:727
+#: ../../Whats-New.md:738
 msgid ""
 "`CreateUnit` now uses civilian house as owner instead if the intended "
 "owner house has been defeated (this is in-line with how `MakeInfantry` "
 "works) (by Starkku)"
 msgstr "现在 `CreateUnit` 会在目标所属方失败时转为中立所属方（与 `MakeInfantry` 的工作方式一致）（by Starkku）"
 
-#: ../../Whats-New.md:728
+#: ../../Whats-New.md:739
 msgid ""
 "`IsHouseColor` laser trails on techno now correctly change color when it "
 "changes owner (by Trsdy)"
-msgstr "现在 `IsHouseColor` 的激光尾迹可以在所属方变更时正确改变颜色（by Trsdy）"
+msgstr "现在 `IsHouseColor` 的激光尾焰可以在所属方变更时正确改变颜色（by Trsdy）"
 
-#: ../../Whats-New.md:729
+#: ../../Whats-New.md:740
 msgid ""
 "Fixed `Layer.UseObjectLayer=true` to work correctly for all cases where "
 "object changes layer (by Starkku)"
 msgstr "修复了 `Layer.UseObjectLayer=true` 以在所有对象改变层级的情形下都能正确工作（by Starkku）"
 
-#: ../../Whats-New.md:730
+#: ../../Whats-New.md:741
 msgid ""
 "Fixed `DetonateOnAllMapObjects.RequireVerses` not considering shield "
 "armor types (by Starkku)"
 msgstr "修复了 `DetonateOnAllMapObjects.RequireVerses` 未考虑护甲类型的问题（by Starkku）"
 
-#: ../../Whats-New.md:731
+#: ../../Whats-New.md:742
 msgid ""
 "Fixed new Phobos script actions not picking team leader correctly based "
 "on `LeadershipRating` (by Starkku)"
 msgstr "修复了 Phobos 新增动作脚本未能正确根据 `LeadershipRating` 选择队长的问题（by Starkku）"
 
-#: ../../Whats-New.md:732
+#: ../../Whats-New.md:743
 msgid ""
 "Fixed an issue with `Gunner=true` vehicles not correctly using the first "
 "passenger's mode with multiple passengers inside (by Starkku)"
 msgstr "修复了 `Gunner=true` 载具存在多名载员时未能正确使用首位载员 `IFVMode` 的问题（by Starkku）"
 
-#: ../../Whats-New.md:733
+#: ../../Whats-New.md:744
 msgid ""
 "Used `MindControl.Anim` for buildings deployed from mind-controlled "
 "vehicles (by Trsdy)"
 msgstr "为从被心灵控制的载具部署而来的建筑应用 `MindControl.Anim` 动画（by Trsdy）"
 
-#: ../../Whats-New.md:734
+#: ../../Whats-New.md:745
 msgid ""
 "Optimized extension class implementation, should improve performance all "
 "around (by Otamaa & Starkku)"
 msgstr "优化了扩展类的实现，应该能提高整体性能（by Otamaa 与 Starkku）"
 
-#: ../../Whats-New.md:735
+#: ../../Whats-New.md:746
 msgid ""
 "Fixed `Interceptor` not resetting target if the intercepted projectile "
 "changes type to non-interceptable one afterwards (by Starkku)"
 msgstr "修复了 `Interceptor` 在拦截的抛射体变为不可拦截抛射体后未能重置目标的问题（by Starkku）"
 
-#: ../../Whats-New.md:736
+#: ../../Whats-New.md:747
 msgid ""
 "Fixed `PlacementPreview` setting for BuildingTypes not being parsed from "
 "INI (by Starkku)"
 msgstr "修复了 `[BuildingType] -> PlacementPreview` 未从 INI 解析的问题（by Starkku）"
 
-#: ../../Whats-New.md:737
+#: ../../Whats-New.md:748
 msgid ""
 "Fixed Phobos animation additions that support `CreateUnit.Owner` not also"
 " checking `MakeInfantryOwner` (by Starkku)"
@@ -3468,13 +3528,13 @@ msgstr ""
 "修复使用了 `CreateUnit.Owner` 的 Phobos 动画新增逻辑后导致不再检查 `MakeInfantryOwner` "
 "的问题（by Starkku）"
 
-#: ../../Whats-New.md:738
+#: ../../Whats-New.md:749
 msgid ""
 "Fixed `AutoDeath` to consider all conditions for objects in limbo (by "
 "Starkku)"
 msgstr "修复 `AutoDeath` 未考虑 Limbo 单位作为条件的问题（by Starkku）"
 
-#: ../../Whats-New.md:739
+#: ../../Whats-New.md:750
 msgid ""
 "Shields will no longer take damage if the parent techno has `Immune=true`"
 " or has `TypeImmune=true` and the damage comes from instance of same "
@@ -3483,42 +3543,42 @@ msgstr ""
 "护盾现在可以正常根据单位上的 `Immune=true` 和 `TypeImmune=true` 正常忽略这些语句所免疫的伤害（by "
 "Starkku）"
 
-#: ../../Whats-New.md:740
+#: ../../Whats-New.md:751
 msgid "Fixed interceptors causing multiplayer games to desync (by Starkku)"
 msgstr "修复了抛射体拦截导致的 Reconnection Error 问题（by Starkku）"
 
-#: ../../Whats-New.md:741
+#: ../../Whats-New.md:752
 msgid ""
 "Optimized performance for map trigger retint action light source fix (by "
 "Starkku)"
 msgstr "优化了地图触发器重绘光源修复的性能表现（by Starkku）"
 
-#: ../../Whats-New.md:742
+#: ../../Whats-New.md:753
 msgid ""
 "Fixed a number of issues with Warhead Shield respawn / self heal rate "
 "modifiers like timers getting reset unnecessarily, the timer being "
 "adjusted wrong after the Warhead effect runs out etc. (by Starkku)"
 msgstr "修复了弹头护盾重生／自愈相关的多个问题例如计时器在不必要的情况下重置以及弹头效果结束后计时器被错误地调整等（by Starkku）"
 
-#: ../../Whats-New.md:743
+#: ../../Whats-New.md:754
 msgid ""
 "Fixed a problem with disguise visibility logic that could cause game to "
 "crash on loading a map (by Starkku)"
 msgstr "修复了伪装可见性可能导致地图加载时崩溃的问题（by Starkku）"
 
-#: ../../Whats-New.md:744
+#: ../../Whats-New.md:755
 msgid ""
 "Fixed owned `LimboDelivery` buildings not being saved correctly in "
 "savegames (by Starkku)"
 msgstr "修复了已有 `LimboDelivery` 建筑没有正确写入存档的问题（by Starkku）"
 
-#: ../../Whats-New.md:745
+#: ../../Whats-New.md:756
 msgid ""
 "Fixed a typo in weapon selector code causing issues with `NoAmmoWeapon` "
 "and related checks (by Starkku)"
 msgstr "修复了武器选择代码中导致 `NoAmmoWeapon` 及相关检查出错的拼写错误（by Starkku）"
 
-#: ../../Whats-New.md:746
+#: ../../Whats-New.md:757
 msgid ""
 "Fixed `DetonateOnAllMapObjects` behaving erratically or potentially "
 "crashing if it destroys buildings using Ares' advanced rubble (by "
@@ -3527,67 +3587,67 @@ msgstr ""
 "修复了 `DetonateOnAllMapObjects` 在摧毁使用了 Ares 的高级废墟逻辑的建筑上行为异常甚至存在潜在崩溃风险的问题（by"
 " Starkku）"
 
-#: ../../Whats-New.md:747
+#: ../../Whats-New.md:758
 msgid ""
 "Fixed game crashing on loading save games if the saved game state had "
 "active radiation sites (by Starkku)"
 msgstr "修复了辐射逻辑导致游戏读档崩溃的问题（by Starkku）"
 
-#: ../../Whats-New.md:748
+#: ../../Whats-New.md:759
 msgid "Fixed a desync error caused by air/top layer sorting (by Starkku)"
 msgstr "修复了 air／top 图层排序引发的 Reconnection Error 文件（by Starkku）"
 
-#: ../../Whats-New.md:749
+#: ../../Whats-New.md:760
 msgid ""
 "Fixed heal / repair weapons being unable to remove parasites from "
 "shielded targets if they were unable to heal / repair the parent unit (by"
 " Starkku)"
 msgstr "修复了寄生在无法治疗／维修的单位中的寄生者无法被自愈／维修武器驱逐的问题"
 
-#: ../../Whats-New.md:750
+#: ../../Whats-New.md:761
 msgid ""
 "Fixed `Inviso=true` interceptor projectiles applying damage on "
 "interceptable, armor type-having projectiles twice (by Starkku)"
 msgstr "修复了拦截者使用 `Inviso=true` 抛射体会对可拦截且拥有护甲类型的被拦截抛射体造成两次伤害的问题（by Starkku）"
 
-#: ../../Whats-New.md:751
+#: ../../Whats-New.md:762
 msgid ""
 "Fixed `AutoDeath` causing crashes when used to kill a parasite unit "
 "inside an another unit (by Starkku)"
 msgstr "修复了 `AutoDeath` 在击杀当前寄生在另一个单位中的寄生者时导致崩溃的问题（by Starkku）"
 
-#: ../../Whats-New.md:752
+#: ../../Whats-New.md:763
 msgid ""
 "Phobos Warhead effects combined with `CellSpread` now correctly apply to "
 "buildings if any of the foundation cells are hit (by Starkku)"
 msgstr "现在 Phobos 弹头效果可以在 `CellSpread` 套住建筑所占据的任意单元格时均可正确作用（by Starkku）"
 
-#: ../../Whats-New.md:753
+#: ../../Whats-New.md:764
 msgid ""
 "Phobos Warhead effects on zero-`CellSpread` Warheads no longer apply to "
 "target if projectile detonates prematurely, far-away from target (by "
 "Starkku)"
 msgstr "现在 Phobos 弹头效果在 `CellSpread` 为 0 时不会在抛射体提前引爆的情况下依旧作用于目标（by Starkku）"
 
-#: ../../Whats-New.md:754
+#: ../../Whats-New.md:765
 msgid ""
 "Fixed radiation site damage not taking the radiation level reduction into"
 " accord (by Starkku)"
 msgstr "修复了辐射伤害未考虑辐射等级衰减的问题（by Starkku）"
 
-#: ../../Whats-New.md:755
+#: ../../Whats-New.md:766
 msgid ""
 "Correctly update laser trail position while techno is cloaked even if "
 "trail is not drawn (by Starkku)"
-msgstr "现在在单位隐形时即便没有绘制尾迹也会正确更新激光尾迹的位置（by Starkku）"
+msgstr "现在在单位隐形时即便没有绘制尾迹也会正确更新激光尾焰的位置（by Starkku）"
 
-#: ../../Whats-New.md:756
+#: ../../Whats-New.md:767
 msgid ""
 "Fixed `Shield.Respawn.Amount` not defaulting to shield type default if "
 "not set (by Starkku)"
 msgstr "修复了 `Shield.Respawn.Amount` 在未设置时未正确使用护盾类型默认值的问题（by Starkku）"
 
-#: ../../Whats-New.md:757
+#: ../../Whats-New.md:768
 msgid ""
 "Fixed an issue where the hotkey message text in frame-by-frame mode "
 "incorrectly referenced `TXT_DISPLAY_DAMAGE_DESC` instead of "
@@ -3596,7 +3656,7 @@ msgstr ""
 "修复了逐帧模式快捷键的消息提示文本读取了 `TXT_DISPLAY_DAMAGE_DESC` 而不是 "
 "`TXT_FRAME_BY_FRAME_DESC` 的问题（by DeathFish）"
 
-#: ../../Whats-New.md:758
+#: ../../Whats-New.md:769
 msgid ""
 "Buildings considered vehicles (`ConsideredVehicle=true` or not set in "
 "conjunction with `UndeploysInto` & 1x1 foundation) are now considered "
@@ -3605,29 +3665,29 @@ msgstr ""
 "现在被视为载具的建筑（`ConsideredVehicle=true` 或同时拥有 `UndeploysInto` 与 "
 "`Foundation=1x1` 的建筑）在目标类型检查时被视为载具（by Starkku）"
 
-#: ../../Whats-New.md:759
+#: ../../Whats-New.md:770
 msgid ""
 "Fixed Phobos Warhead effects not reliably being applied on damage area as"
 " opposed to full weapon-based Warhead detonation (by Starkku)"
 msgstr "修复了 Phobos 弹头效果未能像由武器引爆的完整弹头那样可靠地作用于伤害区域的问题（by Starkku）"
 
-#: ../../Whats-New.md:760
+#: ../../Whats-New.md:771
 msgid "Fixed `LimboKill` not working reliably (by CrimRecya)"
 msgstr "修复了 `LimboKill` 未能可靠地移除虚拟建筑的问题（by CrimRecya）"
 
-#: ../../Whats-New.md:761
+#: ../../Whats-New.md:772
 msgid ""
 "Fixed `SelfHealGainType=none` not working (changed to `noheal`) (by "
 "Starkku)"
 msgstr "修复了 `SelfHealGainType=none` 无效的问题（改为 `noheal`）（by Starkku）"
 
-#: ../../Whats-New.md:762
+#: ../../Whats-New.md:773
 msgid ""
 "Fixed AircraftTypes gaining self-healing from `UnitsGainSelfHeal` by "
 "default (while not displaying the pip) when they should not (by Starkku)"
 msgstr "修复了默认情况下战机类型错误地通过 `UnitsGainSelfHeal` 获得自愈能力（同时也不现实 pip）的问题（by Starkku）"
 
-#: ../../Whats-New.md:763
+#: ../../Whats-New.md:774
 msgid ""
 "Fixed `LaunchSW.IgnoreInhibitors` and `SW.Next.IgnoreInhibitors` "
 "overriding corresponding `IgnoreDesignators` and `IgnoreInhibitors` "
@@ -3636,14 +3696,14 @@ msgstr ""
 "修复了 `LaunchSW.IgnoreInhibitors` 和 `SW.Next.IgnoreInhibitors` 覆盖对应 "
 "`IgnoreDesignators` 和 `IgnoreInhibitors` 设置的问题（by Ollerus）"
 
-#: ../../Whats-New.md:764
+#: ../../Whats-New.md:775
 msgid ""
 "Type conversion on Warheads and Superweapons will no longer recursively "
 "convert units if applicable conversion pairs are listed, and only first "
 "applicable pair takes effect (by Starkku)"
 msgstr "单位转换弹头和超武在存在有效的转换对应关系时不再递归执行而是仅使用列表中更早读到的那组对应关系（by Starkku）"
 
-#: ../../Whats-New.md:765
+#: ../../Whats-New.md:776
 msgid ""
 "Fixed `Ammo.DeployUnlockMinimumAmount`/`Ammo.DeployUnlockMaximumAmount` "
 "behavior inside tank bunkers (by Fryone)"
@@ -3652,39 +3712,39 @@ msgstr ""
 "`Ammo.DeployUnlockMinimumAmount`／`Ammo.DeployUnlockMaximumAmount` 行为（by "
 "Fryone）"
 
-#: ../../Whats-New.md:766
+#: ../../Whats-New.md:777
 msgid ""
 "Fixed `Ammo.AddOnDeploy` behavior inside tank bunkers for non-converters "
 "(by Fryone)"
 msgstr "修复了坦克碉堡内无 `Convert.Deploy` 载具的 `Ammo.AddOnDeploy` 行为（by Fryone）"
 
-#: ../../Whats-New.md:767
+#: ../../Whats-New.md:778
 msgid ""
 "Fixed an issue that caused new attack and move script actions to pick "
 "buildings with `InvisibleInGame=yes` as targets (by FS-21)"
 msgstr "修复了新攻击和移动脚本将 `InvisibleInGame=yes` 建筑视为目标的问题（by FS-21）"
 
-#: ../../Whats-New.md:768
+#: ../../Whats-New.md:779
 msgid "Fixed `Insignia.Weapon` failing to parse in map (by Ollerus)"
 msgstr "修复了地图内置 `Insignia.Weapon` 解析失败的问题（by Ollerus）"
 
-#: ../../Whats-New.md:769
+#: ../../Whats-New.md:780
 msgid "Fixed `AltNextScenario` not taking effect (by FlyStar)"
 msgstr "修复了 `AltNextScenario` 无效的问题（by FlyStar）"
 
-#: ../../Whats-New.md:770
+#: ../../Whats-New.md:781
 msgid ""
 "Fixed `DefaultDisguise` showing wrong house colors for different players "
 "(by NetsuNegi & Ollerus)"
 msgstr "修复了 `DefaultDisguise` 为不同玩家显示不同所属方颜色的问题（by NetsuNegi 与 Ollerus）"
 
-#: ../../Whats-New.md:773
+#: ../../Whats-New.md:784
 msgid ""
 "Weapons fired by EMPulse superweapons *(Ares feature)* now fully respect "
 "the firing building's FLH (by Starkku)"
 msgstr "现在由 EMPulse 超级武器（*Ares 功能*）发射的武器将完全遵照发射建筑的 FLH 设置（by Starkku）"
 
-#: ../../Whats-New.md:774
+#: ../../Whats-New.md:785
 msgid ""
 "Weapons fired by EMPulse superweapons *(Ares feature)* now respect "
 "`Floater` and Phobos-added `Gravity` setting (by Starkku)"
@@ -3692,7 +3752,7 @@ msgstr ""
 "现在由 EMPulse 超级武器（*Ares 功能*）发射的武器遵守 `Floater` 与 Phobos 添加的 `Gravity` 设定（by"
 " Starkku）"
 
-#: ../../Whats-New.md:775
+#: ../../Whats-New.md:786
 msgid ""
 "`IsSimpleDeployer` units with Hover locomotor and `DeployToLand` no "
 "longer get stuck after deploying or play their move sound indefinitely "
@@ -3701,7 +3761,7 @@ msgstr ""
 "拥有 Hover 运动模式的 `IsSimpleDeployer` 且 `DeployToLand` "
 "的单位在部署后不再会卡住或无限播放移动音效（by Starkku）"
 
-#: ../../Whats-New.md:776
+#: ../../Whats-New.md:787
 msgid ""
 "All forms of type conversion (including Ares') now correctly update the "
 "warp-in delay if unit with teleport `Locomotor` was converted while the "
@@ -3710,26 +3770,26 @@ msgstr ""
 "现在所有单位转换形式（包括 Ares 的）在使用超时空 `Locomotor` 的单位处于僵直状态被转换时可以正确的更新传送延迟（by "
 "Starkku）"
 
-#: ../../Whats-New.md:777
+#: ../../Whats-New.md:788
 msgid ""
 "All forms of type conversion (including Ares') now correctly update "
 "`MoveSound` if a moving unit has their type changed (by Starkku)"
 msgstr "现在所有单位转换形式（包括 Ares 的）在移动单位的类型被转换时可以正确更新 `MoveSound`（by Starkku）"
 
-#: ../../Whats-New.md:778
+#: ../../Whats-New.md:789
 msgid ""
 "All forms of type conversion (including Ares') now correctly update "
 "`OpenTopped` state of passengers in transport that is converted (by "
 "Starkku)"
 msgstr "现在所有单位转换形式（包括 Ares 的）在运输工具被转换时可以正确更新乘客的 `OpenTopped` 状态"
 
-#: ../../Whats-New.md:779
+#: ../../Whats-New.md:790
 msgid ""
 "Infantry type conversion from `Deployer=yes` to `no` now correctly update"
 " the sequence anim (by Trsdy)"
 msgstr "现在从由于类型转换导致 `Deployer=yes` 变为 `no` 的步兵能够正确更新序列动画（by Trsdy）"
 
-#: ../../Whats-New.md:780
+#: ../../Whats-New.md:791
 msgid ""
 "Fixed an issue introduced by Ares that caused building `ActiveAnim` to be"
 " incorrectly restored while `SpecialAnim` was playing and the building "
@@ -3738,23 +3798,23 @@ msgstr ""
 "修复了 Ares 引入的建筑正在播放 `SpecialAnim` 时被出售／抹除／摧毁会错误恢复 `ActiveAnim` 的问题（by "
 "Starkku 与 Trsdy）"
 
-#: ../../Whats-New.md:781
+#: ../../Whats-New.md:792
 msgid "Appended Ares' `SW.Shots` usage to extended tooltips (by Trsdy)"
 msgstr "允许将 Ares 的 `SW.Shots` 添加至扩展拓展工具条（by Trsdy）"
 
-#: ../../Whats-New.md:782
+#: ../../Whats-New.md:793
 msgid ""
 "Fixed Ares' Abductor weapon leaves permanent placement stats when "
 "abducting moving vehicles (by Trsdy)"
 msgstr "修复了 Ares 超时空监狱吸取移动载具时会留下空气墙的问题（by Trsdy）"
 
-#: ../../Whats-New.md:783
+#: ../../Whats-New.md:794
 msgid ""
 "Suppressed Ares' swizzle warning when parsing `Tags` and `TaskForces` (by"
 " Trsdy)"
 msgstr "在解析标签和特遣部队时抑制 Ares 的 swizzle 警告（by Trsdy）"
 
-#: ../../Whats-New.md:784
+#: ../../Whats-New.md:795
 msgid ""
 "Fixed Academy *(Ares feature)* not working on the initial payloads *(Ares"
 " feature)* of vehicles built from a war factory (by Trsdy, supersedes "
@@ -3763,43 +3823,43 @@ msgstr ""
 "修复了训练所（*Ares 功能*）在由战车工厂所生产载具的初始载员（*Ares 功能*）上不起作用的问题（by Trsdy，取代了 Aephiex"
 " 的实现）"
 
-#: ../../Whats-New.md:785
+#: ../../Whats-New.md:796
 msgid ""
 "Fixed Ares' InitialPayload not being created for vehicles spawned by "
 "trigger actions (by Trsdy)"
 msgstr "修复了 Ares 的初始荷载未为触发行为生成的载具创建的问题（by Trsdy）"
 
-#: ../../Whats-New.md:790
+#: ../../Whats-New.md:801
 msgid "0.3.0.1"
 msgstr "0.3.0.1"
 
-#: ../../Whats-New.md:795
+#: ../../Whats-New.md:806
 msgid "Additional sync logging in case of desync errors occuring (by Starkku)"
 msgstr "现在发生 Reconnection Error 时所生成的 `SYNC#.txt` 将记录更多信息（by Starkku）"
 
-#: ../../Whats-New.md:798
+#: ../../Whats-New.md:809
 msgid "`AutoDeath` support for objects in limbo (by Trsdy)"
 msgstr "`AutoDeath` 也支持 Limbo 的对象了（by Trsdy）"
 
-#: ../../Whats-New.md:799
+#: ../../Whats-New.md:810
 msgid ""
 "Buildings sold by `AutoDeath` no longer play a click sound effect (by "
 "Trsdy)"
 msgstr "建筑被 `AutoDeath` 出售时不再播放点击音效（by Trsdy）"
 
-#: ../../Whats-New.md:800
+#: ../../Whats-New.md:811
 msgid ""
 "Fixed shield animation being hidden while underground or in tunnels fix "
 "not working correctly (by Starkku)"
 msgstr "修复了护盾动画在地下或隧道中被隐藏的问题，之前的修复未能解决（by Starkku）"
 
-#: ../../Whats-New.md:801
+#: ../../Whats-New.md:812
 msgid ""
 "Restore the `MindClearedSound` when deploying a mind-controlled unit into"
 " a building loses the mind-control (by Trsdy)"
 msgstr "复原当被心控载具部署成建筑而解除心控时播放的 `MindClearedSound`（by Trsdy）"
 
-#: ../../Whats-New.md:802
+#: ../../Whats-New.md:813
 msgid ""
 "Fixed `RadSiteWarhead.Detonate` not detonating precisely on the affected "
 "object (thus requiring `CellSpread`) (by Starkku)"
@@ -3807,23 +3867,23 @@ msgstr ""
 "修复了 `RadSiteWarhead.Detonate` 未能在受影响对象上精确引爆（因此需要 `CellSpread`）的问题（by "
 "Starkku）"
 
-#: ../../Whats-New.md:803
+#: ../../Whats-New.md:814
 msgid ""
 "Fixed script action 10103 'Load Into Transports' unintentionally skipping"
 " next action (by FS-21)"
 msgstr "修复了动作脚本 `10103 - 装载入运输载具` 会意外跳过下一个动作的问题（by FS-21）"
 
-#: ../../Whats-New.md:804
+#: ../../Whats-New.md:815
 msgid ""
 "Changed mission retry dialog button order to better match old order "
 "people are used to (by Trsdy)"
 msgstr "更改了任务重开对话框按钮顺序以更好地符合人们旧有习惯的顺序（by Trsdy）"
 
-#: ../../Whats-New.md:805
+#: ../../Whats-New.md:816
 msgid "Allow PowerPlant Enhancer to be affected by EMP (by Trsdy)"
 msgstr "允许电厂增幅器受到 EMP 影响（by Trsdy）"
 
-#: ../../Whats-New.md:806
+#: ../../Whats-New.md:817
 msgid ""
 "Animation `Weapon` with `Damage.DealtByInvoker=true` now uses the "
 "invoker's house to deal damage and apply Phobos warhead effects even if "
@@ -3832,561 +3892,561 @@ msgstr ""
 "现在动画 `Damage.DealtByInvoker=true` 时其 `Weapon` "
 "即便调用者在武器开火时已死亡也会使用调用者的所属方来造成伤害并应用 Phobos 弹头效果（by Starkku）"
 
-#: ../../Whats-New.md:807
+#: ../../Whats-New.md:818
 msgid ""
 "Fixed a crash when trying to create radiation outside map bounds (by "
 "Otamaa)"
 msgstr "修复了尝试在地图边界外创建辐射时导致的崩溃（by Otamaa）"
 
-#: ../../Whats-New.md:808
+#: ../../Whats-New.md:819
 msgid ""
 "Fixed new AI attack scripts not allowing zero damage weapons to pick "
 "targets (by Starkku)"
 msgstr "修复了新的 AI 攻击脚本不允许 0 伤害武器选择目标的问题（by Starkku）"
 
-#: ../../Whats-New.md:809
+#: ../../Whats-New.md:820
 msgid ""
 "Fixed floating point value parsing precision to match the game (by "
 "Starkku)"
 msgstr "修复了浮点值解析精度以匹配游戏（by Starkku）"
 
-#: ../../Whats-New.md:810
+#: ../../Whats-New.md:821
 msgid ""
 "Power output / drain should now correctly be applied for buildings "
 "created via `LimboDelivery` in campaigns (by Starkku)"
 msgstr "现在战役中通过 `LimboDelivery` 创建的建筑的电力／负载可以正确生效（by Starkku）"
 
-#: ../../Whats-New.md:811
+#: ../../Whats-New.md:822
 msgid ""
 "Fixed shield health bar showing empty bar when shield is still on very "
 "low health instead of depleted (by Starkku)"
 msgstr "修复了护盾在丝血状态下会直接显示空血条而非即将耗尽的问题（by Starkku）"
 
-#: ../../Whats-New.md:812
+#: ../../Whats-New.md:823
 msgid ""
 "Fixed `CanTarget` not considering objects on bridges when checking if "
 "cell is empty (by Starkku)"
 msgstr "修复了 `CanTarget` 在检查单元格是否为空时未考虑桥上物体的问题（by Starkku）"
 
-#: ../../Whats-New.md:813
+#: ../../Whats-New.md:824
 msgid ""
 "Fixed vehicle deploy weapons not working if the unit is cloaked and "
 "weapon has `DecloakToFire=true` (by NetsuNegi & Starkku)"
 msgstr "修复了单位在隐形状态无法使用 `DecloakToFire=true` 的武器开火的问题（by NetsuNegi 与 Starkku）"
 
-#: ../../Whats-New.md:814
+#: ../../Whats-New.md:825
 msgid ""
 "Fixed `IsAnimated` terrain not updating correctly in all circumstances "
 "(by Starkku)"
 msgstr "修复了 `IsAnimated` 地形对象在所有情况下都不会正确更新的问题（by Starkku）"
 
-#: ../../Whats-New.md:815
+#: ../../Whats-New.md:826
 msgid ""
 "Fixed `CreateUnit` interaction with bridges (spawning under when "
 "shouldn't etc) (by Starkku)"
 msgstr "修复了 `CreateUnit` 与桥的交互问题（不应生成在桥下时仍会生成等）（by Starkku）"
 
-#: ../../Whats-New.md:816
+#: ../../Whats-New.md:827
 msgid ""
 "`CanTarget` now considers bridges as land like game's normal weapon "
 "selection does (by Starkku)"
 msgstr "现在 `CanTarget` 会像常规武器目标选择逻辑一样将桥梁视为陆地（by Starkku）"
 
-#: ../../Whats-New.md:817
+#: ../../Whats-New.md:828
 msgid ""
 "`AreaFire.Target` now takes cells with bridges into consideration "
 "depending on firer's elevation (by Starkku)"
 msgstr "现在 `AreaFire.Target` 会根据开火者所在高度处理桥梁所在的单元格（by Starkku）"
 
-#: ../../Whats-New.md:821
+#: ../../Whats-New.md:832
 msgid "0.3"
 msgstr "0.3"
 
-#: ../../Whats-New.md:826
+#: ../../Whats-New.md:837
 msgid "LaserTrails initial implementation (by Kerbiter & ChrisLv_CN)"
-msgstr "激光尾迹初始实现（by Kerbiter 与 ChrisLv_CN）"
+msgstr "激光尾焰初始实现（by Kerbiter 与 ChrisLv_CN）"
 
-#: ../../Whats-New.md:827
+#: ../../Whats-New.md:838
 msgid "Anim-to-Unit logic and ability to randomize `DestroyAnim` (by Otamaa)"
 msgstr "动画生成单位逻辑与随机 `DestroyAnim`（by Otamaa）"
 
-#: ../../Whats-New.md:828
+#: ../../Whats-New.md:839
 msgid "Shield modification warheads (by Starkku)"
 msgstr "护盾修改弹头（by Starkku）"
 
-#: ../../Whats-New.md:829
+#: ../../Whats-New.md:840
 msgid "Shield BreakWeapon & InitialStrength (by Starkku)"
 msgstr "护盾 `BreakWeapon` 与 `InitialStrength`（by Starkku）"
 
-#: ../../Whats-New.md:830
+#: ../../Whats-New.md:841
 msgid "Initial Strength for TechnoTypes (by Uranusian)"
 msgstr "单位的 `InitialStrength`（by Uranusian）"
 
-#: ../../Whats-New.md:831
+#: ../../Whats-New.md:842
 msgid ""
 "Re-enable obsolete `[JumpjetControls]` for TechnoTypes' default Jumpjet "
 "properties (by Uranusian)"
 msgstr "重启废弃的`[JumpjetControls]`作为单位的 Jumpjet 参数默认值（by Uranusian）"
 
-#: ../../Whats-New.md:832
+#: ../../Whats-New.md:843
 msgid "Weapon targeting filter (by Uranusian & Starkku)"
 msgstr "武器瞄准筛选（by Uranusian 与 Starkku）"
 
-#: ../../Whats-New.md:833
+#: ../../Whats-New.md:844
 msgid "Secondary weapon fallback customization (by Starkku)"
 msgstr "禁用副武器自动推算（by Starkku）"
 
-#: ../../Whats-New.md:834
+#: ../../Whats-New.md:845
 msgid "Burst-specific FLHs for TechnoTypes (by Starkku)"
 msgstr "Burst 开火坐标（by Starkku）"
 
-#: ../../Whats-New.md:835
+#: ../../Whats-New.md:846
 msgid "Burst delays for weapons (by Starkku)"
 msgstr "武器自定义 `BurstDelays`（by Starkku）"
 
-#: ../../Whats-New.md:836
+#: ../../Whats-New.md:847
 msgid "AreaFire weapon target customization (by Starkku)"
 msgstr "自定义 `AreaFire` 目标（by Starkku）"
 
-#: ../../Whats-New.md:837
+#: ../../Whats-New.md:848
 msgid "Auto-firing TechnoType weapons (by Starkku)"
 msgstr "自动发射武器（by Starkku）"
 
-#: ../../Whats-New.md:838
+#: ../../Whats-New.md:849
 msgid "PowerPlant Enhancer (by secsome)"
 msgstr "电厂增幅器（by secsome）"
 
-#: ../../Whats-New.md:839
+#: ../../Whats-New.md:850
 msgid "Unlimited Global / Local Variables (by secsome)"
 msgstr "无限制数量的全局／局部变量（by secsome）"
 
-#: ../../Whats-New.md:840
+#: ../../Whats-New.md:851
 msgid ""
 "Adds a \"Load Game\" button to the retry dialog on mission failure (by "
 "secsome)"
 msgstr "在任务失败的重开对话框中添加了一个「载入游戏」按钮（by secsome）"
 
-#: ../../Whats-New.md:841
+#: ../../Whats-New.md:852
 msgid "Default disguise for individual InfantryTypes (by secsome)"
 msgstr "步兵类型微观定义默认伪装（by secsome）"
 
-#: ../../Whats-New.md:842
+#: ../../Whats-New.md:853
 msgid "Quicksave hotkey command (by secsome)"
 msgstr "快速存档快捷键（by secsome）"
 
-#: ../../Whats-New.md:843
+#: ../../Whats-New.md:854
 msgid "Save Game trigger action (by secsome)"
 msgstr "保存游戏的触发结果（by secsome）"
 
-#: ../../Whats-New.md:844
+#: ../../Whats-New.md:855
 msgid "Numeric Variables (by secsome)"
 msgstr "数字化变量（by secsome）"
 
-#: ../../Whats-New.md:845
+#: ../../Whats-New.md:856
 msgid "TechnoType's tooltip would display it's build time now (by secsome)"
 msgstr "现在单位的拓展工具条会显示生产时间（by secsome）"
 
-#: ../../Whats-New.md:846
+#: ../../Whats-New.md:857
 msgid "Customizable tooltip background color and opacity (by secsome)"
 msgstr "可自定义的拓展工具条背景颜色和透明度（by secsome）"
 
-#: ../../Whats-New.md:847
+#: ../../Whats-New.md:858
 msgid "FrameByFrame & FrameStep hotkey command (by secsome)"
 msgstr "逐帧模式及逐帧步进快捷键（by secsome）"
 
-#: ../../Whats-New.md:848
+#: ../../Whats-New.md:859
 msgid ""
 "Allow `NotHuman=yes` infantry to use random `Death` anim sequence (by "
 "Otamaa)"
 msgstr "允许 `NotHuman=yes` 的步兵可以使用随机的 `Death` 动画序列（by Otamaa）"
 
-#: ../../Whats-New.md:849
+#: ../../Whats-New.md:860
 msgid ""
 "Ability for warheads to trigger specific `NotHuman=yes` infantry `Death` "
 "anim sequence (by Otamaa)"
 msgstr "允许弹头触发 `NotHuman=yes` 步兵的特定 `Death` 动画序列（by Otamaa）"
 
-#: ../../Whats-New.md:850
+#: ../../Whats-New.md:861
 msgid "XDrawOffset for animations (by Morton)"
 msgstr "动画的 `XDrawOffset`（by Morton）"
 
-#: ../../Whats-New.md:851
+#: ../../Whats-New.md:862
 msgid "Customizable OpenTopped properties (by Otamaa)"
 msgstr "自定义 `OpenTopped` 属性（by Otamaa）"
 
-#: ../../Whats-New.md:852
+#: ../../Whats-New.md:863
 msgid "Automatic Passenger Deletion (by FS-21)"
 msgstr "自动删除乘客（by FS-21）"
 
-#: ../../Whats-New.md:853
+#: ../../Whats-New.md:864
 msgid "Script actions for new AI attacks (by FS-21)"
 msgstr "新的 AI 攻击动作脚本（by FS-21）"
 
-#: ../../Whats-New.md:854
+#: ../../Whats-New.md:865
 msgid "Script actions for modifying AI Trigger Current Weight (by FS-21)"
 msgstr "修改 AI 触发器当前权重的动作脚本（by FS-21）"
 
-#: ../../Whats-New.md:855
+#: ../../Whats-New.md:866
 msgid ""
 "Script action for waiting & repeat the same new AI attack if no target "
 "was found (by FS-21)"
 msgstr "未发现目标时等待并重复原有动作的 AI 攻击脚本（by FS-21）"
 
-#: ../../Whats-New.md:856
+#: ../../Whats-New.md:867
 msgid ""
 "Script action that modifies the Team's Trigger Weight when ends the new "
 "attack action (by FS-21)"
 msgstr "在当前新攻击动作结束时修改 AI 触发器当前权重的动作脚本（by FS-21）"
 
-#: ../../Whats-New.md:857
+#: ../../Whats-New.md:868
 msgid "Script action for picking a random script from a list (by FS-21)"
 msgstr "从列表中随机选择脚本的动作脚本（by FS-21）"
 
-#: ../../Whats-New.md:858
+#: ../../Whats-New.md:869
 msgid "Script action for new AI movements towards certain objects (by FS-21)"
 msgstr "向特定对象移动的新 AI 移动脚本（by FS-21）"
 
-#: ../../Whats-New.md:859
+#: ../../Whats-New.md:870
 msgid ""
 "Script action that modify target distance in the new move actions (by "
 "FS-21)"
 msgstr "修改新移动动作中目标距离的动作脚本（by FS-21）"
 
-#: ../../Whats-New.md:860
+#: ../../Whats-New.md:871
 msgid "Script action that modify how ends the new move actions (by FS-21)"
 msgstr "修改新移动动作结束条件的动作脚本（by FS-21）"
 
-#: ../../Whats-New.md:861
+#: ../../Whats-New.md:872
 msgid "Script action that un-register Team success (by FS-21)"
 msgstr "取消注册小队成功的脚本动作（by FS-21）"
 
-#: ../../Whats-New.md:862
+#: ../../Whats-New.md:873
 msgid "Script action to regroup temporarily around the Team Leader (by FS-21)"
 msgstr "围绕队长临时集合的动作脚本（by FS-21）"
 
-#: ../../Whats-New.md:863
+#: ../../Whats-New.md:874
 msgid "Script action to randomly skip next action (by FS-21)"
 msgstr "随机跳过下一个动作的动作脚本（by FS-21）"
 
-#: ../../Whats-New.md:864
+#: ../../Whats-New.md:875
 msgid "Script action for timed script action jumps (by FS-21)"
 msgstr "定时跳转脚本动作（by FS-21）"
 
-#: ../../Whats-New.md:865
+#: ../../Whats-New.md:876
 msgid "ObjectInfo now shows current Target and AI Trigger data (by FS-21)"
 msgstr "现在 Object 信息可以显示当前的目标和 AI 触发数据（by FS-21）"
 
-#: ../../Whats-New.md:866
+#: ../../Whats-New.md:877
 msgid "Shield absorption and passthrough customization (by Morton)"
 msgstr "自定义护盾吸收和穿透（by Morton）"
 
-#: ../../Whats-New.md:867
+#: ../../Whats-New.md:878
 msgid "Limbo Delivery of buildings (by Morton)"
 msgstr "虚拟投放（by Morton）"
 
-#: ../../Whats-New.md:868
+#: ../../Whats-New.md:879
 msgid "Ore stage threshold for `HideIfNoOre` (by Otamaa)"
 msgstr "`HideIfNoOre` 的矿石阶段阈值（by Otamaa）"
 
-#: ../../Whats-New.md:869
+#: ../../Whats-New.md:880
 msgid "Image reading in art rules for all TechnoTypes (by Morton)"
 msgstr "在 art 中为所有科技类型使用 `Image` 指定图像（by Morton）"
 
-#: ../../Whats-New.md:870
+#: ../../Whats-New.md:881
 msgid "Attached animation layer customization (by Starkku)"
 msgstr "自定义附着动画图层（by Starkku）"
 
-#: ../../Whats-New.md:871
+#: ../../Whats-New.md:882
 msgid "Jumpjet unit layer deviation customization (by Starkku)"
 msgstr "自定义 Jumpjet 单位图层偏移（by Starkku）"
 
-#: ../../Whats-New.md:872
+#: ../../Whats-New.md:883
 msgid "IsSimpleDeployer deploy direction & animation customizations (by Starkku)"
 msgstr "自定义 `IsSimpleDeployer` 载具部署（by Starkku）"
 
-#: ../../Whats-New.md:873
+#: ../../Whats-New.md:884
 msgid "Customizable projectile gravity (by secsome)"
 msgstr "自定义抛射体重力（by secsome）"
 
-#: ../../Whats-New.md:874
+#: ../../Whats-New.md:885
 msgid ""
 "Gates can now link with walls correctly via `NSGates` or `EWGates` (by "
 "Uranusian)"
 msgstr "现在由 `NSGates` `EWGates` 设定的闸门可以正常与围墙连接（by Uranusian）"
 
-#: ../../Whats-New.md:875
+#: ../../Whats-New.md:886
 msgid "Per-warhead toggle for decloak of damaged targets (by Starkku)"
 msgstr "自定义被伤害目标解除隐形（by Starkku）"
 
-#: ../../Whats-New.md:876
+#: ../../Whats-New.md:887
 msgid ""
 "`DeployFireWeapon=-1` now allows the deployed infantries using both "
 "weapons as undeployed (by Uranusian)"
 msgstr "现在 `DeployFireWeapon=-1` 可以让部署状态的步兵像未部署的步兵那样使用两种武器（by Uranusian）"
 
-#: ../../Whats-New.md:877
+#: ../../Whats-New.md:888
 msgid "Power delta (surplus) counter for sidebar (by Morton)"
 msgstr "在侧边栏显示电力变动（盈余）计数器（by Morton）"
 
-#: ../../Whats-New.md:878
+#: ../../Whats-New.md:889
 msgid "Added Production and Money to Dump Object Info command (by FS-21)"
 msgstr "输出对象信息快捷键现在可以显示建筑生产与资金信息（by FS-21）"
 
-#: ../../Whats-New.md:879
+#: ../../Whats-New.md:890
 msgid "`EnemyUIName=` Now also works for other TechnoTypes (by Otamaa)"
 msgstr "现在 `EnemyUIName=` 已扩展至所有科技类型（by Otamaa）"
 
-#: ../../Whats-New.md:880
+#: ../../Whats-New.md:891
 msgid "`DestroyAnim` & `DestroySound` for TerrainTypes (by Otamaa)"
 msgstr "地形对象的 `DestroyAnim` 与 `DestroySound`（by Otamaa）"
 
-#: ../../Whats-New.md:881
+#: ../../Whats-New.md:892
 msgid "Weapons fired on warping in / out (by Starkku)"
 msgstr "超时空移动时发射武器（by Starkku）"
 
-#: ../../Whats-New.md:882
+#: ../../Whats-New.md:893
 msgid ""
 "`Storage.TiberiumIndex` for customizing resource storage in structures "
 "(by FS-21)"
 msgstr "使用 `Storage.TiberiumIndex` 自定义建筑存储的矿物类型（by FS-21）"
 
-#: ../../Whats-New.md:883
+#: ../../Whats-New.md:894
 msgid "Grinder improvements & customizations (by Starkku)"
 msgstr "回收站增强与自定义（by Starkku）"
 
-#: ../../Whats-New.md:884
+#: ../../Whats-New.md:895
 msgid "Attached animation position customization (by Starkku)"
 msgstr "自定义附着动画位置（by Starkku）"
 
-#: ../../Whats-New.md:885
+#: ../../Whats-New.md:896
 msgid "Trigger Action 505 for Firing SW at specified location (by FS-21)"
 msgstr "触发结果 `505 在坐标释放超级武器...`（by FS-21）"
 
-#: ../../Whats-New.md:886
+#: ../../Whats-New.md:897
 msgid "Trigger Action 506 for Firing SW at waypoint (by FS-21)"
 msgstr "触发动作 `506 在路径点释放超级武器...`（by FS-21）"
 
-#: ../../Whats-New.md:887
+#: ../../Whats-New.md:898
 msgid ""
 "New behaviors for objects' self-destruction under certain conditions (by "
 "Trsdy & FS-21)"
 msgstr "单位在特定情况下自毁的新增行为（by Trsdy 与 FS-21）"
 
-#: ../../Whats-New.md:888
+#: ../../Whats-New.md:899
 msgid ""
 "Slaves' ownership decision when corresponding slave miner is destroyed "
 "(by Trsdy)"
 msgstr "奴隶矿场被毁后的奴隶归属判定（by Trsdy）"
 
-#: ../../Whats-New.md:889
+#: ../../Whats-New.md:900
 msgid "Customize buildings' selling sound and EVA voice (by Trsdy)"
 msgstr "自定义建筑出售音效与 EVA 播报（by Trsdy）"
 
-#: ../../Whats-New.md:890
+#: ../../Whats-New.md:901
 msgid ""
 "`ForceWeapon.Naval.Decloacked` for overriding uncloaked underwater attack"
 " behavior (by FS-21)"
 msgstr "使用 `ForceWeapon.Naval.Decloacked` 覆盖攻击未隐形水下单位时的行为（by FS-21）"
 
-#: ../../Whats-New.md:891
+#: ../../Whats-New.md:902
 msgid "Shrapnel enhancement (by secsome)"
 msgstr "溅射增强（by secsome）"
 
-#: ../../Whats-New.md:892
+#: ../../Whats-New.md:903
 msgid "Shared Ammo for transports to passengers (by FS-21)"
 msgstr "运输工具与乘客共享弹药（by FS-21）"
 
-#: ../../Whats-New.md:893
+#: ../../Whats-New.md:904
 msgid "Additional critical hit logic customizations (by Starkku)"
 msgstr "额外暴击逻辑自定义项（by Starkku）"
 
-#: ../../Whats-New.md:894
+#: ../../Whats-New.md:905
 msgid "Laser trails for VoxelAnims (by Otamaa)"
 msgstr "Voxel 碎片激光尾焰（by Otamaa）"
 
-#: ../../Whats-New.md:895
+#: ../../Whats-New.md:906
 msgid "Local warhead screen shaking (by Starkku)"
 msgstr "限制屏幕抖动于当前视角（by Starkku）"
 
-#: ../../Whats-New.md:896
+#: ../../Whats-New.md:907
 msgid "Feedback weapon (by Starkku)"
 msgstr "反馈武器（by Starkku）"
 
-#: ../../Whats-New.md:897
+#: ../../Whats-New.md:908
 msgid "TerrainType & ore minimap color customization (by Starkku)"
 msgstr "自定义地形对象与矿石的小地图颜色（by Starkku）"
 
-#: ../../Whats-New.md:898
+#: ../../Whats-New.md:909
 msgid "Single-color weapon lasers (by Starkku)"
 msgstr "单色激光（by Starkku）"
 
-#: ../../Whats-New.md:899
+#: ../../Whats-New.md:910
 msgid "Customizable projectile trajectory (by secsome)"
 msgstr "自定义抛射体轨迹（by secsome）"
 
-#: ../../Whats-New.md:900
+#: ../../Whats-New.md:911
 msgid "Display damage numbers debug hotkey command (by Starkku)"
 msgstr "显示伤害数字快捷键（by Starkku）"
 
-#: ../../Whats-New.md:901
+#: ../../Whats-New.md:912
 msgid "Toggleable display of TransactMoney amounts (by Starkku)"
 msgstr "可开关的金币弹金额显示（by Starkku）"
 
-#: ../../Whats-New.md:902
+#: ../../Whats-New.md:913
 msgid "Building-provided self-healing customization (by Starkku)"
 msgstr "自定义建筑提供的自愈（by Starkku）"
 
-#: ../../Whats-New.md:903
+#: ../../Whats-New.md:914
 msgid "Building placement preview (by Otamaa & Belonit)"
 msgstr "建筑放置预览（by Otamaa 与 Belonit）"
 
-#: ../../Whats-New.md:904
+#: ../../Whats-New.md:915
 msgid "Passable & buildable-upon TerrainTypes (by Starkku)"
 msgstr "可通行和可建造于其上的地形对象（by Starkku）"
 
-#: ../../Whats-New.md:905
+#: ../../Whats-New.md:916
 msgid ""
 "Toggle for passengers to automatically change owner if transport owner "
 "changes (by Starkku)"
 msgstr "可开关的载员跟随运输供给转换所属方效果（by Starkku）"
 
-#: ../../Whats-New.md:906
+#: ../../Whats-New.md:917
 msgid "Superweapon launch on warhead detonation (by Trsdy)"
 msgstr "弹头发射超武（by Trsdy）"
 
-#: ../../Whats-New.md:907
+#: ../../Whats-New.md:918
 msgid "Preserve IronCurtain status upon `DeploysInto`/`UndeploysInto` (by Trsdy)"
 msgstr "`DeploysInto`／`UndeploysInto`保留铁幕状态（by Trsdy）"
 
-#: ../../Whats-New.md:908
+#: ../../Whats-New.md:919
 msgid ""
 "Correct owner house for Warhead Anim/SplashList & Play Animation trigger "
 "animations (by Starkku)"
 msgstr "现在弹头 `AnimList` 与 `SplashList` 以及播放动画触发所生成的动画均拥有所属方（by Starkku）"
 
-#: ../../Whats-New.md:909
+#: ../../Whats-New.md:920
 msgid "Customizable FLH When Infantry Is Crouched Or Deployed (by FS-21)"
 msgstr "自定义步兵匍匐与部署 FLH（by FS-21）"
 
-#: ../../Whats-New.md:910
+#: ../../Whats-New.md:921
 msgid ""
 "Enhanced projectile interception logic, including projectile strength & "
 "armor types (by Starkku)"
 msgstr "增强的抛射体拦截逻辑，包括抛射体的 `Strength` 与 `Armor` 设定（by Starkku）"
 
-#: ../../Whats-New.md:911
+#: ../../Whats-New.md:922
 msgid "Initial Strength for Cloned Infantry (by FS-21)"
 msgstr "克隆步兵的初始生命值（by FS-21）"
 
-#: ../../Whats-New.md:912
+#: ../../Whats-New.md:923
 msgid ""
 "OpenTopped transport rangefinding & deactivated state customizations (by "
 "Starkku)"
 msgstr "自定义 `OpenTopped` 载具测距与瘫痪状态行为（by Starkku）"
 
-#: ../../Whats-New.md:913
+#: ../../Whats-New.md:924
 msgid "Forbidding parallel AI queues by type (by NetsuNegi & Trsdy)"
 msgstr "按类禁止 AI 克隆生产（by NetsuNegi 与 Trsdy）"
 
-#: ../../Whats-New.md:914
+#: ../../Whats-New.md:925
 msgid "Animation damage / weapon improvements (by Starkku)"
 msgstr "动画伤害／武器增强（by Starkku）"
 
-#: ../../Whats-New.md:915
+#: ../../Whats-New.md:926
 msgid "Warhead self-damaging toggle (by Starkku)"
 msgstr "弹头自伤开关（by Starkku）"
 
-#: ../../Whats-New.md:916
+#: ../../Whats-New.md:927
 msgid "Trailer animations inheriting owner (by Starkku)"
 msgstr "尾烟动画能够继承所属方（by Starkku）"
 
-#: ../../Whats-New.md:917
+#: ../../Whats-New.md:928
 msgid "Warhead detonation on all objects on map (by Starkku)"
 msgstr "全图弹头（by Starkku）"
 
-#: ../../Whats-New.md:918
+#: ../../Whats-New.md:929
 msgid ""
 "Implemented support for PCX images for campaign loading screen (by "
 "FlyStar)"
 msgstr "实现了战役载入图的 PCX 图像支持（by FlyStar）"
 
-#: ../../Whats-New.md:919
+#: ../../Whats-New.md:930
 msgid ""
 "Implemented support for PCX images for observer loading screen (by "
 "Uranusian)"
 msgstr "实现了观察者载入图的 PCX支持（by Uranusian）"
 
-#: ../../Whats-New.md:920
+#: ../../Whats-New.md:931
 msgid "Animated (non-tiberium spawning) TerrainTypes (by Starkku)"
 msgstr "可动（且非矿柱的）地形对象（by Starkku）"
 
-#: ../../Whats-New.md:921
+#: ../../Whats-New.md:932
 msgid "Toggleable passenger killing for `Explodes=true` units (by Starkku)"
 msgstr "可开关的 `Explodes=true` 单位乘客祭天（by Starkku）"
 
-#: ../../Whats-New.md:922
+#: ../../Whats-New.md:933
 msgid ""
 "New condition for automatic self-destruction logic when TechnoTypes "
 "exist/don't exist (by FlyStar)"
 msgstr "当科技类型存在／不存在时自动自毁逻辑的新行为（by FlyStar）"
 
-#: ../../Whats-New.md:923
+#: ../../Whats-New.md:934
 msgid ""
 "For developers: now you can use command line arg to control main "
 "exception handler (by Multfinite)"
 msgstr "开发者功能：现在可以通过命令行参数控制主循环的异常处理程序"
 
-#: ../../Whats-New.md:926
+#: ../../Whats-New.md:937
 msgid ""
 "Fixed laser drawing code to allow for thicker lasers in house color draw "
 "mode (by Kerbiter & ChrisLv_CN)"
 msgstr "修复了激光绘制代码以允许其可在所属方颜色模式下绘制更粗的激光（by Kerbiter 与 ChrisLv_CN）"
 
-#: ../../Whats-New.md:927
+#: ../../Whats-New.md:938
 msgid "Fixed `DeathWeapon` not detonating properly (by Uranusian)"
 msgstr "修复了 `DeathWeapon` 没有正确引爆的问题（by Uranusian）"
 
-#: ../../Whats-New.md:928
+#: ../../Whats-New.md:939
 msgid ""
 "Fixed lasers & other effects drawing from wrong offset with weapons that "
 "use `Burst` (by Starkku)"
 msgstr "修复了激光和其他特效在使用 `Burst` 的武器上从错误的偏移位置绘制的问题（by Starkku）"
 
-#: ../../Whats-New.md:929
+#: ../../Whats-New.md:940
 msgid ""
 "Fixed buildings with `Naval=yes` ignoring `WaterBound=no` to be forced to"
 " place onto water (by Uranusian)"
 msgstr "修复了建筑拥有 `Naval=yes` 会无视 `WaterBound=no` 强制只能放置在水域的问题（by Uranusian）"
 
-#: ../../Whats-New.md:930
+#: ../../Whats-New.md:941
 msgid ""
 "Fixed temporal weapon crash under certain conditions where stack dump "
 "starts with 0051BB7D (by secsome)"
 msgstr "修复了 Stack Dump 以 0051BB7D 开头的特定情况下超时空武器崩溃（by secsome）"
 
-#: ../../Whats-New.md:931
+#: ../../Whats-New.md:942
 msgid ""
 "Fixed the bug when retinting map lighting with a map action corrupted "
 "light sources (by secsome)"
 msgstr "修复了通过地图触发结果重绘地图光照时建筑光源不正常的 Bug（by secsome）"
 
-#: ../../Whats-New.md:932
+#: ../../Whats-New.md:943
 msgid ""
 "Fixed the bug when reading a map which puts `Preview(Pack)` after `Map` "
 "lead to the game fail to draw the preview (by secsome)"
 msgstr "修复了读取地图时若地图的 `Preview(Pack)` 节被放置于 Map 之后会导致无法绘制预览图的 Bug（by secsome）"
 
-#: ../../Whats-New.md:933
+#: ../../Whats-New.md:944
 msgid "Fixed the bug that GameModeOptions are not correctly saved (by secsome)"
 msgstr "修复了游戏模式选项未能正确保存的 Bug（by secsome）"
 
-#: ../../Whats-New.md:934
+#: ../../Whats-New.md:945
 msgid ""
 "Fixed the bug that AITriggerTypes do not recognize building upgrades (by "
 "Uranusian)"
 msgstr "修复了 AITriggerTypes 没能识别建筑加载物的 Bug（by Uranusian）"
 
-#: ../../Whats-New.md:935
+#: ../../Whats-New.md:946
 msgid ""
 "Fixed AI Aircraft docks bug when Ares tag `[GlobalControls] -> "
 "AllowParallelAIQueues=no` is set (by FS-21)"
@@ -4394,13 +4454,13 @@ msgstr ""
 "修复了当设置 Ares 标签 `[GlobalControls] -> AllowParallelAIQueues=no` 时 AI "
 "战机对接机场的 Bug（by FS-21）"
 
-#: ../../Whats-New.md:936
+#: ../../Whats-New.md:947
 msgid ""
 "Fixed the bug when occupied building's `MuzzleFlashX` is drawn on the "
 "center of the building when `X` goes past 10 (by Otamaa)"
 msgstr "修复了当驻军建筑的 `MuzzleFlashX` 在 `X` 超过 10 后绘制在建筑中心的 Bug（by Otamaa）"
 
-#: ../../Whats-New.md:937
+#: ../../Whats-New.md:948
 msgid ""
 "Fixed jumpjet units that are `Crashable` not crashing to ground properly "
 "if destroyed while being pulled by a `Locomotor` warhead (by Starkku)"
@@ -4408,85 +4468,85 @@ msgstr ""
 "修复了拥有 `Crashable` 的 Jumpjet 类单位在被 `Locomotor` 弹头牵引时被摧毁则无法正常坠毁的 Bug（by "
 "Starkku）"
 
-#: ../../Whats-New.md:938
+#: ../../Whats-New.md:949
 msgid ""
 "Fixed aircraft & jumpjet units not being affected by speed modifiers (by "
 "Starkku)"
 msgstr "修复了战机与 Jumpjet 单位不受速度加成影响的问题（by Starkku）"
 
-#: ../../Whats-New.md:939
+#: ../../Whats-New.md:950
 msgid "Fixed vehicles (both voxel & SHP) to fully respect `Palette` (by Starkku)"
 msgstr "修复了（Voxel 与 Shape）载具不完全遵循 `Palette` 设定的问题（by Starkku）"
 
-#: ../../Whats-New.md:940
+#: ../../Whats-New.md:951
 msgid ""
 "Fixed mind control indicator animations not reappearing on mind "
 "controlled objects that are cloaked and then uncloaked (by Starkku)"
 msgstr "修复了心灵控制指示动画在被心控对象隐形并重新显形后未能重新出现的问题（by Starkku）"
 
-#: ../../Whats-New.md:941
+#: ../../Whats-New.md:952
 msgid ""
 "Fixed Nuke carrier and payload weapons not respecting `Bright` setting on"
 " weapon (by Starkku)"
 msgstr "修复了核弹载体与载荷武器不尊重过武器 `Bright` 设定的问题（by Starkku）"
 
-#: ../../Whats-New.md:942
+#: ../../Whats-New.md:953
 msgid ""
 "Fixed buildings not reverting to undamaged graphics when HP was restored "
 "above `[AudioVisual] -> ConditionYellow` via `SelfHealing` (by Starkku)"
 msgstr "修复了建筑自愈恢复到 `[AudioVisual] -> ConditionYellow` 以上却没有恢复非残损图像的问题（by Starkku）"
 
-#: ../../Whats-New.md:943
+#: ../../Whats-New.md:954
 msgid ""
 "Fixed jumpjet units being unable to turn to the target when firing from a"
 " different direction (by Trsdy)"
 msgstr "修复了 Jumpjet 单位从其他方向开火时无法转向目标的 Bug（by Trsdy）"
 
-#: ../../Whats-New.md:944
+#: ../../Whats-New.md:955
 msgid ""
 "Fixed turreted jumpjet units always facing bottom-right direction when "
 "stop moving (by Trsdy)"
 msgstr "修复了 Jumpjet 单位总是在停止移动时朝向右下方向的 Bug（by Trsdy）"
 
-#: ../../Whats-New.md:945
+#: ../../Whats-New.md:956
 msgid ""
 "Fixed jumpjet objects being unable to detect cloaked objects beneath (by "
 "Trsdy)"
 msgstr "修复了 Jumpjet 单位无法探测下方隐形物体的问题（by Trsdy）"
 
-#: ../../Whats-New.md:946
+#: ../../Whats-New.md:957
 msgid ""
 "Anim owner is now set for warhead AnimList/SplashList anims and Play Anim"
 " at Waypoint trigger animations (by Starkku)"
 msgstr "现在弹头 `AnimList`／`SplashList` 及在路径点播放动画触发的动画拥有所属方了（by Starkku）"
 
-#: ../../Whats-New.md:947
+#: ../../Whats-New.md:958
 msgid ""
 "Fixed AI script action Deploy getting stuck with vehicles with "
 "`DeploysInto` if there was no space to deploy at initial location (by "
 "Starkku)"
 msgstr "修复了 AI 部署脚本动作导致拥有 `DeploysInto` 的载具在其原位置空间不足而卡住的问题（by Starkku）"
 
-#: ../../Whats-New.md:948
+#: ../../Whats-New.md:959
 msgid ""
 "Fixed `Foundation=0x0` causing crashes if used on TerrainTypes (by "
 "Starkku)"
 msgstr "修复了 `Foundation=0x0` 用于地形对象会导致崩溃的问题（by Starkku）"
 
-#: ../../Whats-New.md:949
+#: ../../Whats-New.md:960
 msgid ""
 "Projectiles now remember the house of the firer even if the firer is "
 "destroyed before the projectile detonates. Does not currently apply to "
 "Ares-introduced Warhead effects (by Starkku)"
 msgstr "现在即便开火者在抛射体引爆前被摧毁抛射体也可以保留开火者的所属方。目前暂不适用于某些 Ares 引入的弹头效果（by Starkku）"
 
-#: ../../Whats-New.md:950
+#: ../../Whats-New.md:961
 msgid ""
 "Buildings now correctly use laser parameters set for Secondary weapons "
 "instead of reading them from Primary weapon (by Starkku)"
 msgstr "现在建筑可以正确的使用副武器设置的激光参数而不再是从主武器读取（by Starkku）"
 
-#: ../../Whats-New.md:951
+#: ../../Whats-New.md:962
 msgid ""
 "Fixed an issue that caused vehicles killed by damage dealt by a known "
 "house but without a known source TechnoType (f.ex animation warhead "
@@ -4494,21 +4554,21 @@ msgid ""
 "trigger events etc. (by Starkku)"
 msgstr "修复了只有所属方但没有开火者的杀伤击杀载具时未能正确记录因而无法触发地图事件等问题（by Starkku）"
 
-#: ../../Whats-New.md:952
+#: ../../Whats-New.md:963
 msgid ""
 "Translucent RLE SHPs will now be drawn using a more precise and "
 "performant algorithm that has no green tint and banding (only applies to "
 "Z-aware drawing mode for now) (by Apollo)"
 msgstr "现在半透明的 RLE SHP 将使用更精确且性能更高的算法进行绘制，不会出现绿色色调和条纹（by Apollo）"
 
-#: ../../Whats-New.md:953
+#: ../../Whats-New.md:964
 msgid ""
 "Fixed transports recursively put into each other not having a correct "
 "killer set after second transport when being killed by something (by "
 "Kerbiter)"
 msgstr "修复了被递归嵌套放置的运输工具被击杀时从第二层运输工具开始击杀来源设置不正确的问题（by Kerbiter）"
 
-#: ../../Whats-New.md:954
+#: ../../Whats-New.md:965
 msgid ""
 "Fixed projectiles with `Inviso=true` suffering from potential inaccuracy "
 "problems if combined with `Airburst=yes` or Warhead with `EMEffect=true` "
@@ -4517,56 +4577,56 @@ msgstr ""
 "修复了带有 `Inviso=true` 的抛射体在与 `Airburst=yes` 或拥有 `EMEffect=true` "
 "的弹头结合使用时可能出现的精度问题（by Starkku）"
 
-#: ../../Whats-New.md:955
+#: ../../Whats-New.md:966
 msgid ""
 "Fixed the bug when `MakeInfantry` logic on BombClass resulted in "
 "`Neutral` side infantry (by Otamaa)"
 msgstr "修复了 `MakeInfantry` 逻辑在 BombClass（伊文炸弹）上导致生成 `Neutral` 阵营步兵的 Bug（by Otamaa）"
 
-#: ../../Whats-New.md:956
+#: ../../Whats-New.md:967
 msgid ""
 "Fixed railgun particles being drawn to wrong coordinate against buildings"
 " with non-default `TargetCoordOffset` or when force-firing on bridges (by"
 " Starkku)"
 msgstr "修复了轨道炮粒子对于具有非默认 `TargetCoordOffset` 的建筑或在桥上强制开火时被绘制到错误坐标的问题（by Starkku）"
 
-#: ../../Whats-New.md:957
+#: ../../Whats-New.md:968
 msgid ""
 "Fixed building `TargetCoordOffset` not being taken into accord for "
 "several things like fire angle calculations and target lines (by Starkku)"
 msgstr "修复了建筑 `TargetCoordOffset` 未将开火角度和目标指示线考虑在内的问题（by Starkku）"
 
-#: ../../Whats-New.md:958
+#: ../../Whats-New.md:969
 msgid "Allowed observers to see a selected building's radial indicator (by Trsdy)"
 msgstr "允许了观察者查看选中建筑的范围指示器（by Trsdy）"
 
-#: ../../Whats-New.md:959
+#: ../../Whats-New.md:970
 msgid ""
 "Allow voxel projectiles to use `AnimPalette` and `FirersPalette` (by "
 "NetsuNegi)"
 msgstr "允许了 Voxel 抛射体使用 `AnimPalette` 和 `FirersPalette`（by NetsuNegi）"
 
-#: ../../Whats-New.md:962
+#: ../../Whats-New.md:973
 msgid ""
 "Fixed shields being able to take damage when the parent TechnoType was "
 "under effects of a `Temporal` Warhead (by Starkku)"
 msgstr "修复了单位被 `Temporal` 弹头冻结时其护盾仍可受伤的问题（by Starkku）"
 
-#: ../../Whats-New.md:963
+#: ../../Whats-New.md:974
 msgid "Improved shield behavior for forced damage (by Uranusian)"
 msgstr "改进了护盾在强制承受伤害时的行为（by Uranusian）"
 
-#: ../../Whats-New.md:964
+#: ../../Whats-New.md:975
 msgid ""
 "Fixed `SplashList` animations playing when a unit is hit on a bridge over"
 " water (by Uranusian)"
 msgstr "修复了命中桥上单位时会播放 `SplashList` 动画的问题（by Uranusian）"
 
-#: ../../Whats-New.md:965
+#: ../../Whats-New.md:976
 msgid "Fixed shielded objects not decloaking if shield takes damage (by Starkku)"
 msgstr "修复了带有护盾的物体在受击时不会解除隐形的问题（by Starkku）"
 
-#: ../../Whats-New.md:966
+#: ../../Whats-New.md:977
 msgid ""
 "Fixed critical hit animation playing even if no critical hits were dealt "
 "due to `Crit.Affects` or `ImmuneToCrit` settings (by Starkku)"
@@ -4574,13 +4634,13 @@ msgstr ""
 "修复了即便修复了由于 `Crit.Affects` 或`ImmuneToCrit` 设定未能造成暴击伤害时仍会播放暴击动画的问题（by "
 "Starkku）"
 
-#: ../../Whats-New.md:967
+#: ../../Whats-New.md:978
 msgid ""
 "Fixed `RemoveDisguise` not working on `PermaDisguise` infantry (by "
 "Starkku)"
 msgstr "修复了 `RemoveDisguise` 未能在 `PermaDisguise` 步兵上工作的问题（by Starkku）"
 
-#: ../../Whats-New.md:968
+#: ../../Whats-New.md:979
 msgid ""
 "Fixed single-color laser (IsHouseColor, IsSingleColor, LaserTrails) glow "
 "falloff to match the vanilla appearance (by Starkku)"
@@ -4588,47 +4648,47 @@ msgstr ""
 "修复了单色激光（`IsHouseColor`、`IsSingleColor`、LaserTrails）的光照算法以保持与原版效果一致（by "
 "Starkku）"
 
-#: ../../Whats-New.md:969
+#: ../../Whats-New.md:980
 msgid ""
 "Fixed a potential cause of crashes concerning shield animations (such in "
 "conjunction with cloaking) (by Starkku)"
 msgstr "修复了一个可能导致崩溃的护盾动画问题（by Starkku）"
 
-#: ../../Whats-New.md:970
+#: ../../Whats-New.md:981
 msgid ""
 "Fixed interceptors intercepting projectiles fired by friendly objects if "
 "the said object died after firing the projectile (by Starkku)"
 msgstr "修复了友军对象在死亡后其发射的抛射体会被抛射体拦截逻辑视为应拦截目标的问题（by Starkku）"
 
-#: ../../Whats-New.md:971
+#: ../../Whats-New.md:982
 msgid ""
 "Fixed interceptor weapons with `Inviso=true` projectiles detonating the "
 "projectile at wrong coordinates (by Starkku)"
 msgstr "修复了  `Inviso=true` 抛射体拦截武器在错误左边处引爆的问题（by Starkku）"
 
-#: ../../Whats-New.md:972
+#: ../../Whats-New.md:983
 msgid ""
 "Fixed some possible configuration reading issues when using Phobos with "
 "patches that rename `uimd.ini` (by Belonit)"
 msgstr "修复了 Phobos 与重命名 `uimd.ini` 的补丁共用时可能出现的配置文件读取文件（by Belonit）"
 
-#: ../../Whats-New.md:973
+#: ../../Whats-New.md:984
 msgid "Fixed a game crash when using the Map Snapshot command (by Otamaa)"
 msgstr "修复了抓取地图快捷键导致的游戏崩溃（by Otamaa）"
 
-#: ../../Whats-New.md:974
+#: ../../Whats-New.md:985
 msgid ""
 "Fixed issue with incorrect input in edit dialog element when using IME "
 "(by Belonit)"
 msgstr "修复了使用输入法时编辑对话框内容输入错误的问题（by Belonit）"
 
-#: ../../Whats-New.md:975
+#: ../../Whats-New.md:986
 msgid ""
 "Fixed an issue where tooltip text could be clipped by tooltip rectangle "
 "border if using `MaxWidth` > 0 (by Starkku)"
 msgstr "修复了 `MaxWidth` > 0 时拓展工具条文本可能被拓展工具条矩形边框截断的问题（by Starkku）"
 
-#: ../../Whats-New.md:976
+#: ../../Whats-New.md:987
 msgid ""
 "Fixed projectiles with `Trajectory=Straight` suffering from potential "
 "inaccuracy problems if combined with `Airburst=yes` or Warhead with "
@@ -4637,75 +4697,75 @@ msgstr ""
 "修复了带有 `Trajectory=Straight` 的抛射体在与 `Airburst=yes` 或拥有 `EMEffect=true` "
 "的弹头结合使用时可能出现的精度问题（by Starkku）"
 
-#: ../../Whats-New.md:977
+#: ../../Whats-New.md:988
 msgid "Minor performance optimization related to shields (by Trsdy)"
 msgstr "对护盾进行了轻微的性能优化（by Trsdy）"
 
-#: ../../Whats-New.md:978
+#: ../../Whats-New.md:989
 msgid ""
 "Fixed teleporting miners (Chrono Miner) considered to be idle by "
 "harvester counter, improved related game performance (by Trsdy)"
 msgstr "修复了超时空矿车被矿车计数器误判为摆烂的问题，并进行了相关的性能优化（by Trsdy）"
 
-#: ../../Whats-New.md:979
+#: ../../Whats-New.md:990
 msgid ""
 "Fixed negative damage weapons considering shield health when evaluating "
 "targets even if Warhead had `Shield.Penetrate` set to true (by Starkku)"
 msgstr "修复了负伤害武器在选择目标时即便在弹头 `Shield.Penetrate` 设为 true 也仍会考虑护盾值的问题（by Starkku）"
 
-#: ../../Whats-New.md:980
+#: ../../Whats-New.md:991
 msgid ""
 "Fixed engineers considering shield health instead of building health when"
 " determining if they can repair or capture a building (by Starkku)"
 msgstr "修复了工程师在判断能否维修／占领建筑时考虑护盾值而非建筑生命值的问题（by Starkku）"
 
-#: ../../Whats-New.md:981
+#: ../../Whats-New.md:992
 msgid ""
 "Fixed shield animations (`IdleAnim`, `BreakAnim` and `HitAnim`) showing "
 "up even if the object shield is attached to is currently underground (by "
 "Starkku)"
 msgstr "修复了护盾动画（`IdleAnim`、`BreakAnim` 和 `HitAnim`）在其附着对象处于地下时仍然显示的问题（by Starkku）"
 
-#: ../../Whats-New.md:982
+#: ../../Whats-New.md:993
 msgid ""
 "Fixed shields not being removed from sinking units until they have fully "
 "finished sinking (by Starkku)"
 msgstr "修复了护盾在单位完全沉没前未被移除的问题（by Starkku）"
 
-#: ../../Whats-New.md:983
+#: ../../Whats-New.md:994
 msgid "Fixed techno-extdata update after type conversion (by Trsdy)"
 msgstr "修复了单位转换后的数据更新问题（by Trsdy）"
 
-#: ../../Whats-New.md:984
+#: ../../Whats-New.md:995
 msgid ""
 "Fixed Phobos Warhead effects (crits, new shield modifiers etc.) "
 "considering sinking units valid targets (by Starkku)"
 msgstr "修复了 Phobos 弹头效果（暴击、护盾修改等）将正在下沉的单位视为有效目标的问题（by Starkku）"
 
-#: ../../Whats-New.md:985
+#: ../../Whats-New.md:996
 msgid ""
 "Fixed an issue where `FireOnce=yes` deploy weapons on vehicles would "
 "still fire multiple times if deploy command is issued repeatedly or when "
 "not idle (by Starkku)"
 msgstr "修复了拥有 `FireOnce=yes` 的部署武器在重复下达部署质量或非闲置状态仍会多次开火的问题（by Starkku）"
 
-#: ../../Whats-New.md:986
+#: ../../Whats-New.md:997
 msgid ""
 "Fixed a game crash when checking `BuildLimit` if Phobos is running "
 "without Ares (by Belonit)"
 msgstr "修复了当 Phobos 未与 Ares 共同使用时检查 `BuildLimit` 会导致游戏崩溃的问题（by Belonit）"
 
-#: ../../Whats-New.md:987
+#: ../../Whats-New.md:998
 msgid ""
 "Corrected the misinterpretation in the definition of `DiskLaser.Radius` "
 "(by Trsdy)"
 msgstr "更正了定义 `DiskLaser.Radius` 错误解释的问题（by Trsdy）"
 
-#: ../../Whats-New.md:988
+#: ../../Whats-New.md:999
 msgid "Fixed GlobalVariables failed working among scenarios (by Trsdy)"
 msgstr "修复了全局变量在多个场景失效的问题（by Trsdy）"
 
-#: ../../Whats-New.md:991
+#: ../../Whats-New.md:1002
 msgid ""
 "Weapons fired by EMPulse superweapons *(Ares feature)* without "
 "`EMPulse.TargetSelf=true` can now create radiation (by Starkku)"
@@ -4713,57 +4773,57 @@ msgstr ""
 "现在由 EMPulse 超级武器（*Ares 功能*）发射的武器在没有 `EMPulse.TargetSelf=true` "
 "的情况下也可以正常产生辐射（by Starkku）"
 
-#: ../../Whats-New.md:993
+#: ../../Whats-New.md:1004
 msgid "Non-DLL:"
 msgstr "非 DLL 内容："
 
-#: ../../Whats-New.md:994
+#: ../../Whats-New.md:1005
 msgid ""
 "Implemented a tool (sed wrapper) to semi-automatically upgrade INIs to "
 "use latest Phobos tags (by Kerbiter)"
 msgstr "做了一个 sed 脚本工具来半自动的更新 INI 内容为最新版 Phobos 的对应标签（by Kerbiter）"
 
-#: ../../Whats-New.md:998
+#: ../../Whats-New.md:1009
 msgid "0.2.2.2"
 msgstr "0.2.2.2"
 
-#: ../../Whats-New.md:1003
+#: ../../Whats-New.md:1014
 msgid "Fixed shield type info not saving properly (by Uranusian)"
 msgstr "修复了护盾类型信息未能正确保存的问题（by Uranusian）"
 
-#: ../../Whats-New.md:1004
+#: ../../Whats-New.md:1015
 msgid ""
 "Fixed extended building upgrades logic not properly interacting with "
 "Ares' BuildLimit check (by Uranusian)"
 msgstr "修复了拓展的建筑加载物逻辑与 Ares 的 BuildLimit 检查交互异常的问题（by Uranusian）"
 
-#: ../../Whats-New.md:1005
+#: ../../Whats-New.md:1016
 msgid "Fix more random crashes for `CameoPriority` (by Uranusian)"
 msgstr "修复了更多由 `CameoPriority` 导致的随机崩溃问题（by Uranusian）"
 
-#: ../../Whats-New.md:1006
+#: ../../Whats-New.md:1017
 msgid ""
 "Fix aircraft weapons causing game freeze when burst index was not "
 "correctly reset after firing (by Starkku)"
 msgstr "修复了战机开火后 Burst 索引未能正确重置导致的游戏卡死问题（by Starkku）"
 
-#: ../../Whats-New.md:1010
+#: ../../Whats-New.md:1021
 msgid "0.2.2.1"
 msgstr "0.2.2.1"
 
-#: ../../Whats-New.md:1015
+#: ../../Whats-New.md:1026
 msgid "Fixed random crashes about `CameoPriority` (by Uranusian)"
 msgstr "修复了 `CameoPriority` 导致的随机崩溃（by Uranusian）"
 
-#: ../../Whats-New.md:1016
+#: ../../Whats-New.md:1027
 msgid "Fixed trigger action 125 not functioning properly (by Uranusian)"
 msgstr "修复了触发结果 125 号未能正常工作的问题（by Uranusian）"
 
-#: ../../Whats-New.md:1017
+#: ../../Whats-New.md:1028
 msgid "Fixed area warhead detonation not falling back to firer house (by Otamaa)"
 msgstr "修复了范围弹头的所属问题（by Otamaa）"
 
-#: ../../Whats-New.md:1018
+#: ../../Whats-New.md:1029
 msgid ""
 "RadSite hook adjustment for `FootClass` to support Ares `RadImmune`; also"
 " various fixes to radiation / desolators (by Otamaa)"
@@ -4771,83 +4831,83 @@ msgstr ""
 "对 `FootClass` 的钩子进行调整以支持 Ares 的 `RadImmune` 相关逻辑；同时对辐射／辐射工兵进行了多项修复（by "
 "Otamaa）"
 
-#: ../../Whats-New.md:1019
+#: ../../Whats-New.md:1030
 msgid "Fixed `Crit.Affects` not functioning properly (by Uranusian)"
 msgstr "修复了 `Crit.Affects` 未能正常工作的问题（by Uranusian）"
 
-#: ../../Whats-New.md:1020
+#: ../../Whats-New.md:1031
 msgid ""
 "Fixed improper upgrade owner transfer which resulted in built ally / "
 "enemy building upgrades keeping the player who built them alive (by "
 "Kerbiter)"
 msgstr "修复了建造在其他所属方建筑上的加载物会导致本应战败的所属方保持存活的问题（by Kerbiter）"
 
-#: ../../Whats-New.md:1024
+#: ../../Whats-New.md:1035
 msgid "0.2.2"
 msgstr "0.2.2"
 
-#: ../../Whats-New.md:1029
+#: ../../Whats-New.md:1040
 msgid ""
 "Customizable producing progress \"bars\" like CnC:Remastered did (by "
 "Uranusian)"
 msgstr "自定义像 CNC 重置版那样的生产进度「条」（by Uranusian）"
 
-#: ../../Whats-New.md:1030
+#: ../../Whats-New.md:1041
 msgid "Customizable cameo sorting priority (by Uranusian)"
 msgstr "自定义图标排序优先级（by Uranusian）"
 
-#: ../../Whats-New.md:1031
+#: ../../Whats-New.md:1042
 msgid "Customizable harvester ore gathering animation (by secsome, Uranusian)"
 msgstr "自定义矿车采矿动画（by secsome, Uranusian）"
 
-#: ../../Whats-New.md:1032
+#: ../../Whats-New.md:1043
 msgid ""
 "Allow making technos unable to be issued with movement order (by "
 "Uranusian)"
 msgstr "允许设置单位无法被下达移动指令（by Uranusian）"
 
-#: ../../Whats-New.md:1035
+#: ../../Whats-New.md:1046
 msgid ""
 "Fixed non-IME keyboard input to be working correctly for languages / "
 "keyboard layouts that use character ranges other than Basic Latin and "
 "Latin-1 Supplement (by Belonit)"
 msgstr "修复了非输入法键盘输入在基础拉丁或拉丁 -1 以外的语言／键盘布局中无法正常工作的问题（by Belonit）"
 
-#: ../../Whats-New.md:1038
+#: ../../Whats-New.md:1049
 msgid "Fixed the critical damage logic not functioning properly (by Uranusian)"
 msgstr "修复了暴击伤害逻辑无法正常工作的问题（by Uranusian）"
 
-#: ../../Whats-New.md:1039
+#: ../../Whats-New.md:1050
 msgid "Fixed the bug when executing the stop command game crashes (by Uranusian)"
 msgstr "修复了执行停止命令时游戏崩溃的 Bug（by Uranusian）"
 
-#: ../../Whats-New.md:1043
+#: ../../Whats-New.md:1054
 msgid "0.2.1.1"
 msgstr "0.2.1.1"
 
-#: ../../Whats-New.md:1048
+#: ../../Whats-New.md:1059
 msgid ""
 "Fixed occasional crashes introduced by `Speed=0` stationary vehicles code"
 " (by Starkku)"
 msgstr "修复了由 `Speed=0` 静止载具代码引起的偶发性崩溃问题（by Starkku）"
 
-#: ../../Whats-New.md:1052
+#: ../../Whats-New.md:1063
 msgid "0.2.1"
 msgstr "0.2.1"
 
-#: ../../Whats-New.md:1057
+#: ../../Whats-New.md:1068
 msgid ""
 "Setting VehicleType `Speed` to 0 now makes game treat them as stationary "
 "(by Starkku)"
 msgstr "现在载具将在 `Speed` 设置为 0 时使游戏将它们视为静止（by Starkku）"
 
-#: ../../Whats-New.md:1060
+#: ../../Whats-New.md:1071
 msgid ""
 "Fixed the bug when after a failed placement the building/defence tab "
 "hotkeys won't trigger placement mode again (by Uranusian)"
 msgstr "修复了在摆放失败后使用切换到建筑栏和防御栏的快捷键无法再次进入放置模式的问题（by Uranusian）"
 
-#: ../../Whats-New.md:1061
+#: ../../Whats-New.md:1072
 msgid ""
 "Fixed the bug when building with `UndeployInto` plays "
 "`EVA_NewRallypointEstablished` while undeploying (by secsome)"
@@ -4855,189 +4915,189 @@ msgstr ""
 "修复了拥有 `UndeployInto` 的建筑在反部署时会播放 `EVA_NewRallypointEstablished` 的问题（by "
 "secsome）"
 
-#: ../../Whats-New.md:1064
+#: ../../Whats-New.md:1075
 msgid ""
 "Fixed the bug when trigger action `125 Build At...` wasn't actually "
 "producing a building when the target cells were occupied (by secsome)"
 msgstr "修复了触发结果 `125 将建筑建于...` 在目标单元格被占用时无法生产建筑的问题（by secsome）"
 
-#: ../../Whats-New.md:1069
+#: ../../Whats-New.md:1080
 msgid "0.2"
 msgstr "0.2"
 
-#: ../../Whats-New.md:1074
+#: ../../Whats-New.md:1085
 msgid ""
 "Shield logic for TechnoTypes (by Uranusian, secsome, Belonit) with "
 "warhead additions (by Starkku)"
 msgstr "护盾逻辑（by Uranusian、secsome、Belonit）及对应新增弹头功能（by Starkku）"
 
-#: ../../Whats-New.md:1075
+#: ../../Whats-New.md:1086
 msgid "Custom Radiation Types (by AlexB, Otamaa, Belonit, Uranusian)"
 msgstr "自定义辐射（by AlexB、Otamaa、Belonit、Uranusian）"
 
-#: ../../Whats-New.md:1076
+#: ../../Whats-New.md:1087
 msgid ""
 "New ScriptType actions `71 Timed Area Guard`, `72 Load Onto Transports`, "
 "`73 Wait until ammo is full` (by FS-21)"
 msgstr "新增动作脚本 `71 区域警戒(时间计数)`、`72 装载入运输载具`、`73 等待弹药装满`（by FS-21）"
 
-#: ../../Whats-New.md:1077
+#: ../../Whats-New.md:1088
 msgid ""
 "Ore drills now have customizable ore type, range, ore growth stage and "
 "amount of cells generated (by Kerbiter)"
 msgstr "现在矿柱可以自定义矿石的类型、范围、生长阶段和生长的单元格数（by Kerbiter）"
 
-#: ../../Whats-New.md:1078
+#: ../../Whats-New.md:1089
 msgid ""
 "Basic projectile interception logic (by AutoGavy, ChrisLv_CN, Kerbiter, "
 "Erzoid/SukaHati)"
 msgstr "基础的抛射体拦截逻辑（by AutoGavy、ChrisLv_CN、Kerbiter、Erzoid／SukaHati）"
 
-#: ../../Whats-New.md:1079
+#: ../../Whats-New.md:1090
 msgid ""
 "Customizable harvester active/total counter next to credits counter (by "
 "Uranusian)"
 msgstr "在资金计数器旁自定义「工作矿车／矿车总量」计数器（by Uranusian）"
 
-#: ../../Whats-New.md:1080
+#: ../../Whats-New.md:1091
 msgid "Select Next Idle Harvester hotkey command (by Kerbiter)"
 msgstr "选择下一个空闲矿车快捷键（by Kerbiter）"
 
-#: ../../Whats-New.md:1081
+#: ../../Whats-New.md:1092
 msgid "Dump Object Info hotkey command (by secsome & FS-21)"
 msgstr "输出对象信息快捷键（by secsome 与 FS-21）"
 
-#: ../../Whats-New.md:1082
+#: ../../Whats-New.md:1093
 msgid "Remove Disguise and Remove Mind Control warhead effects (by secsome)"
 msgstr "解除伪装和解除心控弹头效果（by secsome）"
 
-#: ../../Whats-New.md:1083
+#: ../../Whats-New.md:1094
 msgid "Custom per-warhead `SplashLists` (by Uranusian)"
 msgstr "弹头微观定义 `SplashLists`（by Uranusian）"
 
-#: ../../Whats-New.md:1084
+#: ../../Whats-New.md:1095
 msgid ""
 "`AnimList.PickRandom` used to randomize `AnimList` with no side effects "
 "(by secsome)"
 msgstr "添加了 `AnimList.PickRandom` 用于实现没有副作用的随机 `AnimList`（by secsome）"
 
-#: ../../Whats-New.md:1085
+#: ../../Whats-New.md:1096
 msgid "Chance-based critical damage system on warheads (by AutoGavy)"
 msgstr "基于概率的弹头暴击伤害系统（by AutoGavy）"
 
-#: ../../Whats-New.md:1086
+#: ../../Whats-New.md:1097
 msgid "Optional mind control range limit (by Uranusian)"
 msgstr "自定义心控有效距离上限（by Uranusian）"
 
-#: ../../Whats-New.md:1087
+#: ../../Whats-New.md:1098
 msgid ""
 "Multiple mind controllers can now release units on overload (by Uranusian"
 " & secsome)"
 msgstr "多重心控单位（原版脑车）可以在过载时及时释放单位（by Uranusian & secsome）"
 
-#: ../../Whats-New.md:1088
+#: ../../Whats-New.md:1099
 msgid ""
 "Spawns now can be killed on low power and have limited pursuing range (by"
 " FS-21)"
 msgstr "现在子机可以在母舰断电时坠毁并且具有有限的追击范围（by FS-21）"
 
-#: ../../Whats-New.md:1089
+#: ../../Whats-New.md:1100
 msgid "Spawns can now have the same exp. level as owner techno (by Uranusian)"
 msgstr "现在子机可以同步母舰的经验等级（by Uranusian）"
 
-#: ../../Whats-New.md:1090
+#: ../../Whats-New.md:1101
 msgid ""
 "`TurretOffset` now accepts `F,L,H` and `F,L` values instead of just `F` "
 "value (by Kerbiter)"
 msgstr "现在 `TurretOffset` 可以接受 `F,L,H` 和 `F,L` 那样的值而不仅限于一个 `F`（by Kerbiter）"
 
-#: ../../Whats-New.md:1091
+#: ../../Whats-New.md:1102
 msgid "ElectricBolt arc visuals can now be disabled per-arc (by Otamaa)"
 msgstr "现在可以单独关闭 EBolt 特效中的特定电弧（by Otamaa）"
 
-#: ../../Whats-New.md:1092
+#: ../../Whats-New.md:1103
 msgid "Semantic locomotor aliases for modder convenience (by Belonit)"
 msgstr "为 modder 们添加了简化的 Locomotor 别称（by Belonit）"
 
-#: ../../Whats-New.md:1093
+#: ../../Whats-New.md:1104
 msgid ""
 "Ability to specify amount of shots for strafing aircraft and burst "
 "simulation (by Starkku)"
 msgstr "可以为战机扫射指定次数以及模拟 `Burst`（by Starkku）"
 
-#: ../../Whats-New.md:1094
+#: ../../Whats-New.md:1105
 msgid ""
 "Customizeable Teleport/Chrono Locomotor properties per TechnoType (by "
 "Otamaa)"
 msgstr "自定义超时空运动模式的参数（by Otamaa）"
 
-#: ../../Whats-New.md:1095
+#: ../../Whats-New.md:1106
 msgid "Maximum waypoints amount increased from 702 to 2147483647 (by secsome)"
 msgstr "路径点数量上限由 702 提升到 2147483647（by secsome）"
 
-#: ../../Whats-New.md:1096
+#: ../../Whats-New.md:1107
 msgid "Customizeable Missing Cameo file (by Uranusian)"
 msgstr "自定义缺省图标（by Uranusian）"
 
-#: ../../Whats-New.md:1099
+#: ../../Whats-New.md:1110
 msgid ""
 "Map previews with zero size won't crash the game anymore (by Kerbiter & "
 "Belonit)"
 msgstr "0 尺寸的地图预览图不再会导致游戏崩溃（by Kerbiter 与 Belonit）"
 
-#: ../../Whats-New.md:1100
+#: ../../Whats-New.md:1111
 msgid "Tileset 255+ bridge fix (by E1 Elite)"
 msgstr "Tileset 255+ 情况的桥梁修复（by E1 Elite）"
 
-#: ../../Whats-New.md:1101
+#: ../../Whats-New.md:1112
 msgid ""
 "Fixed fatal errors when `Blowfish.dll` couldn't be registered in the "
 "system properly due to missing admin rights (by Belonit)"
 msgstr "修复了由于确实管理员权限导致 `Blowfish.dll` 无法正确注册而引发的 Fatal Error（by Belonit）"
 
-#: ../../Whats-New.md:1102
+#: ../../Whats-New.md:1113
 msgid ""
 "Fix to take Burst into account for aircraft weapon shots beyond the first"
 " one (by Starkku)"
 msgstr "修复了战机扫射武器仅有第一发考虑 `Burst` 的问题（by Starkku）"
 
-#: ../../Whats-New.md:1103
+#: ../../Whats-New.md:1114
 msgid ""
 "Fixed the bug when units are already dead but still in map (for sinking, "
 "crashing, dying animation, etc.), they could die again (by Uranusian)"
 msgstr "修复了已经死亡但仍存在于地图上的单位（例如沉没、坠毁、播放死亡动画等）可以再次死亡的 Bug（by Uranusian）"
 
-#: ../../Whats-New.md:1104
+#: ../../Whats-New.md:1115
 msgid ""
 "Fixed the bug when cloaked Desolator was unable to fire his deploy weapon"
 " (by Otamaa)"
 msgstr "修复了隐形的辐射工兵无法部署发射武器的 Bug（by Otamaa）"
 
-#: ../../Whats-New.md:1105
+#: ../../Whats-New.md:1116
 msgid ""
 "Fixed the bug when `InfiniteMindControl` with `Damage=1` will auto-"
 "release the victim to control new one (by Uranusian)"
 msgstr "修复了 `InfiniteMindControl` 在 `Damage=1` 的情况下只能控制 1 个单位的问题（by Uranusian）"
 
-#: ../../Whats-New.md:1106
+#: ../../Whats-New.md:1117
 msgid ""
 "Fixed the bug that script action `Move to cell` was still using leftover "
 "cell calculations from previous games (by secsome)"
 msgstr "修复了脚本动作 `移动到单元格` 使用先代游戏残留单元格算法的 Bug（by secsome）"
 
-#: ../../Whats-New.md:1107
+#: ../../Whats-New.md:1118
 msgid ""
 "Fixed the bug when trigger action `125 Build At...` didn't play buildup "
 "anim (by secsome)"
 msgstr "修复了触发结果 `125 将建筑建于...` 不播放建造动画的 Bug（by secsome）"
 
-#: ../../Whats-New.md:1108
+#: ../../Whats-New.md:1119
 msgid ""
 "Fixed `DebrisMaximums` (spawned debris type amounts cannot go beyond "
 "specified maximums anymore) (by Otamaa)"
 msgstr "修复了 `DebrisMaximums`（生成的碎片不再超过其对应的最大数量）（by Otamaa）"
 
-#: ../../Whats-New.md:1109
+#: ../../Whats-New.md:1120
 msgid ""
 "Fixes to `DeployFire` logic (`DeployFireWeapon`, `FireOnce`, stop command"
 " now work properly) (by Starkku)"
@@ -5045,13 +5105,13 @@ msgstr ""
 "修复了 `DeployFire` 逻辑（现在 `DeployFireWeapon`、`FireOnce`、停止命令可以正常工作）（by "
 "Starkku）"
 
-#: ../../Whats-New.md:1112
+#: ../../Whats-New.md:1123
 msgid ""
 "Properly rewritten a fix for mind-controlled vehicles deploying into "
 "buildings (by FS-21)"
 msgstr "彻底重写了被心控载具部署成建筑的修复方案（by FS-21）"
 
-#: ../../Whats-New.md:1113
+#: ../../Whats-New.md:1124
 msgid ""
 "Properly rewritten `DeployToFire` fix, tag `Deployed.RememberTarget` is "
 "deprecated, now always on (by Kerbiter)"
@@ -5059,97 +5119,97 @@ msgstr ""
 "彻底重写了 `DeployToFire` 的修复，标签 `Deployed.RememberTarget` 已弃用，现在总是启用（by "
 "Kerbiter）"
 
-#: ../../Whats-New.md:1114
+#: ../../Whats-New.md:1125
 msgid "New warheads now work with Ares' `GenericWarhead` superweapon (by Belonit)"
 msgstr "现在新的弹头效果可以用于 Ares 的 `GenericWarhead` 类超级武器（by Belonit）"
 
-#: ../../Whats-New.md:1118
+#: ../../Whats-New.md:1129
 msgid "0.1.1"
 msgstr "0.1.1"
 
-#: ../../Whats-New.md:1123
+#: ../../Whats-New.md:1134
 msgid ""
 "Fixed an occasional crash when selecting units with a selection box (by "
 "Kerbiter)"
 msgstr "修复了框选单位时偶尔崩溃的问题（by Kerbiter）"
 
-#: ../../Whats-New.md:1127
+#: ../../Whats-New.md:1138
 msgid "0.1"
 msgstr "0.1"
 
-#: ../../Whats-New.md:1132
+#: ../../Whats-New.md:1143
 msgid "Full-color PCX graphics support (by Belonit)"
 msgstr "全彩 PCX 支持（by Belonit）"
 
-#: ../../Whats-New.md:1133
+#: ../../Whats-New.md:1144
 msgid "Support for PCX loading screens of any size (by Belonit)"
 msgstr "支持了任意尺寸的 PCX 载入图（by Belonit）"
 
-#: ../../Whats-New.md:1134
+#: ../../Whats-New.md:1145
 msgid ""
 "Extended sidebar tooltips with descriptions, recharge time and power "
 "consumption/generation (by Kerbiter & Belonit)"
 msgstr "扩展侧边栏拓展工具条时其带有描述、充能时间和电力能耗／产出（by Kerbiter 与 Belonit）"
 
-#: ../../Whats-New.md:1135
+#: ../../Whats-New.md:1146
 msgid "Selection priority filtering for box selection (by Kerbiter)"
 msgstr "低优先级框选（by Kerbiter）"
 
-#: ../../Whats-New.md:1136
+#: ../../Whats-New.md:1147
 msgid "Shroud, reveal and money transact warheads (by Belonit)"
 msgstr "黑幕弹、揭示弹、金币弹（by Belonit）"
 
-#: ../../Whats-New.md:1137
+#: ../../Whats-New.md:1148
 msgid "Custom game icon command line arg (by Belonit)"
 msgstr "使用命令行参数自定义游戏图标（by Belonit）"
 
-#: ../../Whats-New.md:1138
+#: ../../Whats-New.md:1149
 msgid "Ability to disable black spawn position dots on map preview (by Belonit)"
 msgstr "允许禁用空置出生点黑点（by Belonit）"
 
-#: ../../Whats-New.md:1139
+#: ../../Whats-New.md:1150
 msgid ""
 "Ability to specify applicable building owner for building upgrades (by "
 "Kerbiter)"
 msgstr "允许为建筑加载物指定适当的建筑所属方，也就是可以建造在别人的建筑上（by Kerbiter）"
 
-#: ../../Whats-New.md:1140
+#: ../../Whats-New.md:1151
 msgid "Customizable disk laser radius (by Belonit & Kerbiter)"
 msgstr "自定义飞碟激光半径（by Belonit 与 Kerbiter）"
 
-#: ../../Whats-New.md:1141
+#: ../../Whats-New.md:1152
 msgid "Ability to switch to GDI sidebar layout for any side (by Belonit)"
 msgstr "允许为任意阵营 UI 切换 GDI 式侧边栏布局（by Belonit）"
 
-#: ../../Whats-New.md:1144
+#: ../../Whats-New.md:1155
 msgid ""
 "Deploying mind-controlled TechnoTypes won't make them permanently mind-"
 "controlled anymore (unfinished fix by DCoder)"
 msgstr "部署被心灵控制的单位不再会时其永远处于被心控状态（实际上直接刷漆了）（DCoder 未完成的修复）"
 
-#: ../../Whats-New.md:1145
+#: ../../Whats-New.md:1156
 msgid ""
 "SHP debris hardcoded shadows now respect `Shadow=no` tag value (by "
 "Kerbiter)"
 msgstr "SHP 碎片硬编码显示的阴影现在遵守 `Shadow=no` 设置（by Kerbiter）"
 
-#: ../../Whats-New.md:1146
+#: ../../Whats-New.md:1157
 msgid ""
 "`DeployToFire` vehicles won't lose target on deploy anymore (unfinished "
 "fix by DCoder)"
 msgstr "`DeployToFire` 的载具不再会于部署时丢失目标（DCoder 未完成的修复）"
 
-#: ../../Whats-New.md:1147
+#: ../../Whats-New.md:1158
 msgid ""
 "Fixed QWER hotkey tab switching not hiding the displayed tooltip as it "
 "should (by Belonit)"
 msgstr "修复了当通过 QWER 快捷键切换标签页时未能正确隐藏拓展工具条的问题（by Belonit）"
 
-#: ../../Whats-New.md:1148
+#: ../../Whats-New.md:1159
 msgid "Sidebar tooltips now can go over sidebar bounds (by Belonit)"
 msgstr "现在侧边栏拓展工具条可以超出侧边栏边界（by Belonit）"
 
-#: ../../Whats-New.md:1149
+#: ../../Whats-New.md:1160
 msgid "Lifted stupidly small limit for tooltip character amount (by Belonit)"
 msgstr "解除了拓展工具条字符数量小得愚蠢的上限（by Belonit）"
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -269,7 +269,6 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->WarheadParticleAlphaImageIsLightFlash.Read(exINI, GameStrings::AudioVisual, "WarheadParticleAlphaImageIsLightFlash");
 	this->CombatLightDetailLevel.Read(exINI, GameStrings::AudioVisual, "CombatLightDetailLevel");
 	this->LightFlashAlphaImageDetailLevel.Read(exINI, GameStrings::AudioVisual, "LightFlashAlphaImageDetailLevel");
-
 	this->BuildingTypeSelectable.Read(exINI, GameStrings::General, "BuildingTypeSelectable");
 
 	this->ProneSpeed_Crawls.Read(exINI, GameStrings::General, "ProneSpeed.Crawls");
@@ -282,6 +281,9 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->AnimCraterDestroyTiberium.Read(exINI, GameStrings::General, "AnimCraterDestroyTiberium");
 
 	this->BerzerkTargeting.Read(exINI, GameStrings::CombatDamage, "BerzerkTargeting");
+
+	this->AttackMove_IgnoreWeaponCheck.Read(exINI, GameStrings::General, "AttackMove.IgnoreWeaponCheck");
+	this->AttackMove_StopWhenTargetAcquired.Read(exINI, GameStrings::General, "AttackMove.StopWhenTargetAcquired");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -521,6 +523,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->TintColorIronCurtain)
 		.Process(this->TintColorForceShield)
 		.Process(this->TintColorBerserk)
+		.Process(this->AttackMove_IgnoreWeaponCheck)
+		.Process(this->AttackMove_StopWhenTargetAcquired)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -230,6 +230,9 @@ public:
 
 		Valueable<AffectedHouse> BerzerkTargeting;
 
+		Valueable<bool> AttackMove_IgnoreWeaponCheck;
+		Nullable<bool> AttackMove_StopWhenTargetAcquired;
+		
 		// cache tint color
 		int TintColorIronCurtain;
 		int TintColorForceShield;
@@ -414,6 +417,9 @@ public:
 			, TintColorIronCurtain { 0 }
 			, TintColorForceShield { 0 }
 			, TintColorBerserk { 0 }
+
+			, AttackMove_IgnoreWeaponCheck { false }
+			, AttackMove_StopWhenTargetAcquired { }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -43,6 +43,11 @@ void TechnoExt::ExtData::OnEarlyUpdate()
 	this->ApplyMindControlRangeLimit();
 	this->UpdateRecountBurst();
 	this->UpdateRearmInEMPState();
+	
+	if (this->AttackMoveFollowerTempCount)
+	{
+		this->AttackMoveFollowerTempCount--;
+	}
 }
 
 void TechnoExt::ExtData::ApplyInterceptor()

--- a/src/Ext/Techno/Body.Update.cpp
+++ b/src/Ext/Techno/Body.Update.cpp
@@ -1372,7 +1372,7 @@ void TechnoExt::ExtData::ApplyMindControlRangeLimit()
 		auto const pCapturerExt = TechnoExt::ExtMap.Find(pCapturer)->TypeExtData;
 
 		if (pCapturerExt->MindControlRangeLimit.Get() > 0 &&
-			pThis->DistanceFrom(pCapturer) > pCapturerExt->MindControlRangeLimit.Get())
+			pCapturer->DistanceFrom(pThis) > pCapturerExt->MindControlRangeLimit.Get())
 		{
 			pCapturer->CaptureManager->FreeUnit(pThis);
 		}

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -652,6 +652,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->TintIntensityOwner)
 		.Process(this->TintIntensityAllies)
 		.Process(this->TintIntensityEnemies)
+		.Process(this->AttackMoveFollowerTempCount)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -82,6 +82,8 @@ public:
 		int TintIntensityAllies;
 		int TintIntensityEnemies;
 
+		int AttackMoveFollowerTempCount;
+
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, TypeExtData { nullptr }
 			, Shield {}
@@ -134,6 +136,7 @@ public:
 			, TintIntensityOwner { 0 }
 			, TintIntensityAllies { 0 }
 			, TintIntensityEnemies { 0 }
+			, AttackMoveFollowerTempCount { 0 }
 		{ }
 
 		void OnEarlyUpdate();

--- a/src/Ext/Techno/Hooks.Firing.cpp
+++ b/src/Ext/Techno/Hooks.Firing.cpp
@@ -1,4 +1,4 @@
-﻿#include "Body.h"
+#include "Body.h"
 
 #include <OverlayTypeClass.h>
 #include <ScenarioClass.h>

--- a/src/Ext/Techno/Hooks.TargetEvaluation.cpp
+++ b/src/Ext/Techno/Hooks.TargetEvaluation.cpp
@@ -187,10 +187,12 @@ DEFINE_HOOK(0x4DF3A0, FootClass_UpdateAttackMove_SelectNewTarget, 0x6)
 
 	const auto pExt = TechnoExt::ExtMap.Find(pThis);
 
-	if (pExt->TypeExtData->AttackMove_UpdateTarget.Get(RulesExt::Global()->AttackMove_UpdateTarget) && CheckAttackMoveCanResetTarget(pThis))
+	if (pExt->TypeExtData->AttackMove_UpdateTarget.Get(RulesExt::Global()->AttackMove_UpdateTarget)
+		&& CheckAttackMoveCanResetTarget(pThis))
 	{
 		pThis->Target = nullptr;
 		pThis->HaveAttackMoveTarget = false;
+		pExt->UpdateGattlingRateDownReset();
 	}
 
 	return 0;

--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -1,9 +1,11 @@
+#include <AircraftClass.h>
 #include "Body.h"
 
 #include <AircraftClass.h>
 #include <EventClass.h>
 #include <ScenarioClass.h>
 #include <TunnelLocomotionClass.h>
+#include <JumpjetLocomotionClass.h>
 #include <AlphaShapeClass.h>
 #include <TacticalClass.h>
 
@@ -14,6 +16,7 @@
 #include <Ext/WeaponType/Body.h>
 #include <Ext/TechnoType/Body.h>
 #include <Utilities/EnumFunctions.h>
+#include <Utilities/Helpers.Alex.h>
 #include <Utilities/AresHelper.h>
 #include <Utilities/AresFunctions.h>
 
@@ -1049,3 +1052,114 @@ DEFINE_HOOK(0x519FEC, InfantryClass_UpdatePosition_EngineerRepair, 0xA)
 	VocClass::PlayAt(BuildingTypeExt::ExtMap.Find(pTarget->Type)->BuildingRepairedSound.Get(RulesClass::Instance->BuildingRepairedSound), pTarget->GetCoords());
 	return SkipGameCode;
 }
+
+#pragma region AttackMove
+
+DEFINE_HOOK(0x4DF410, FootClass_UpdateAttackMove_TargetAcquired, 0x6)
+{
+	GET(FootClass* const, pThis, ESI);
+
+	auto const pType = pThis->GetTechnoType();
+	auto const pTypeExt = TechnoTypeExt::ExtMap.Find(pType);
+
+	if (pThis->IsCloseEnoughToAttack(pThis->Target)
+		&& pTypeExt->AttackMove_StopWhenTargetAcquired.Get(RulesExt::Global()->AttackMove_StopWhenTargetAcquired.Get(!pType->OpportunityFire)))
+	{
+		if (auto const pJumpjetLoco = locomotion_cast<JumpjetLocomotionClass*>(pThis->Locomotor))
+		{
+			auto const crd = pThis->GetCoords();
+			pJumpjetLoco->DestinationCoords.X = crd.X;
+			pJumpjetLoco->DestinationCoords.Y = crd.Y;
+			pJumpjetLoco->CurrentSpeed = 0;
+			pJumpjetLoco->MaxSpeed = 0;
+			pJumpjetLoco->State = JumpjetLocomotionClass::State::Hovering;
+			pThis->AbortMotion();
+		}
+		else
+		{
+			pThis->StopMoving();
+			pThis->AbortMotion();
+		}
+	}
+
+	if (pTypeExt->AttackMove_PursuitTarget)
+		pThis->SetDestination(pThis->Target, true);
+
+	return 0;
+}
+
+DEFINE_HOOK(0x711E90, TechnoTypeClass_CanAttackMove_IgnoreWeapon, 0x6)
+{
+	enum { SkipGameCode = 0x711E9A };
+	return RulesExt::Global()->AttackMove_IgnoreWeaponCheck ? SkipGameCode : 0;
+}
+
+DEFINE_HOOK(0x4DF3A6, FootClass_UpdateAttackMove_Follow, 0x6)
+{
+	enum { FuncRet = 0x4DF425 };
+
+	GET(FootClass* const, pThis, ESI);
+
+	auto const pTypeExt = TechnoExt::ExtMap.Find(pThis)->TypeExtData;
+
+	if (pTypeExt->AttackMove_Follow)
+	{
+		auto const& pTechnoVectors = Helpers::Alex::getCellSpreadItems(pThis->GetCoords(),
+			pThis->GetGuardRange(2) / Unsorted::LeptonsPerCell, pTypeExt->AttackMove_Follow_IncludeAir);
+
+		TechnoClass* pClosestTarget = nullptr;
+		int closestRange = 65536;
+
+		for (auto const pTechno : pTechnoVectors)
+		{
+			if ((pTechno->AbstractFlags & AbstractFlags::Foot) != AbstractFlags::None
+				&& pTechno != pThis && pTechno->Owner == pThis->Owner
+				&& pTechno->MegaMissionIsAttackMove())
+			{
+				auto const pTargetExt = TechnoExt::ExtMap.Find(pTechno);
+
+				// Check this to prevent the followed techno from being surrounded
+				if (pTargetExt->AttackMoveFollowerTempCount >= 6)
+					continue;
+
+				auto const pTargetTypeExt = pTargetExt->TypeExtData;
+
+				if (!pTargetTypeExt->AttackMove_Follow)
+				{
+					auto const dist = pTechno->DistanceFrom(pThis);
+
+					if (dist < closestRange)
+					{
+						pClosestTarget = pTechno;
+						closestRange = dist;
+					}
+				}
+			}
+		}
+
+		if (pClosestTarget)
+		{
+			auto const pTargetExt = TechnoExt::ExtMap.Find(pClosestTarget);
+			pTargetExt->AttackMoveFollowerTempCount += pThis->WhatAmI() == AbstractType::Infantry ? 1 : 3;
+			pThis->SetDestination(pClosestTarget, false);
+			pThis->SetArchiveTarget(pClosestTarget);
+			pThis->QueueMission(Mission::Area_Guard, true);
+		}
+		else
+		{
+			if (pThis->MegaTarget)
+				pThis->SetDestination(pThis->MegaTarget, false);
+			else // MegaDestination can be nullptr
+				pThis->SetDestination(pThis->MegaDestination, false);
+		}
+
+		pThis->ClearMegaMissionData();
+
+		R->EAX(pClosestTarget);
+		return FuncRet;
+	}
+
+	return 0;
+}
+
+#pragma endregion

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -696,6 +696,11 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->DebrisTypes_Limit.Read(exINI, pSection, "DebrisTypes.Limit");
 	this->DebrisMinimums.Read(exINI, pSection, "DebrisMinimums");
 
+	this->AttackMove_Follow.Read(exINI, pSection, "AttackMove.Follow");
+	this->AttackMove_Follow_IncludeAir.Read(exINI, pSection, "AttackMove.Follow.IncludeAir");
+	this->AttackMove_StopWhenTargetAcquired.Read(exINI, pSection, "AttackMove.StopWhenTargetAcquired");
+	this->AttackMove_PursuitTarget.Read(exINI, pSection, "AttackMove.PursuitTarget");
+
 	// Ares 0.2
 	this->RadarJamRadius.Read(exINI, pSection, "RadarJamRadius");
 
@@ -1290,6 +1295,11 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->DebrisMinimums)
 
 		.Process(this->EngineerRepairAmount)
+
+		.Process(this->AttackMove_Follow)
+		.Process(this->AttackMove_Follow_IncludeAir)
+		.Process(this->AttackMove_StopWhenTargetAcquired)
+		.Process(this->AttackMove_PursuitTarget)
 		;
 }
 void TechnoTypeExt::ExtData::LoadFromStream(PhobosStreamReader& Stm)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -383,6 +383,11 @@ public:
 
 		Valueable<int> EngineerRepairAmount;
 
+		Valueable<bool> AttackMove_Follow;
+		Valueable<bool> AttackMove_Follow_IncludeAir;
+		Nullable<bool> AttackMove_StopWhenTargetAcquired;
+		Valueable<bool> AttackMove_PursuitTarget;
+
 		ExtData(TechnoTypeClass* OwnerObject) : Extension<TechnoTypeClass>(OwnerObject)
 			, HealthBar_Hide { false }
 			, UIDescription {}
@@ -715,6 +720,11 @@ public:
 			, DebrisMinimums {}
 
 			, EngineerRepairAmount { 0 }
+
+			, AttackMove_Follow { false }
+			, AttackMove_Follow_IncludeAir { false }
+			, AttackMove_StopWhenTargetAcquired { }
+			, AttackMove_PursuitTarget { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Misc/Hooks.BugFixes.cpp
+++ b/src/Misc/Hooks.BugFixes.cpp
@@ -2250,3 +2250,15 @@ DEFINE_HOOK(0x489E47, DamageArea_RockerItemsFix2, 0x6)
 }
 
 #pragma region
+
+DEFINE_HOOK(0x71A7BC, TemporalClass_Update_DistCheck, 0x6)
+{
+	enum { SkipGameCode = 0x71A82C };
+
+	GET(TemporalClass*, pThis, ESI);
+	GET(TechnoClass*, pTarget, ECX);
+
+	// Vanilla check is incorrect for buildingtargets
+	R->EAX(pThis->Owner->DistanceFrom(pTarget));
+	return SkipGameCode;
+}


### PR DESCRIPTION

 2-94. 超时空保持距离计算bug修复
原本游戏中，这个距离计算方式和武器开火的计算方式不一致，这会导致明明保持距离大于武器射程，但开火之后无法正确冻结建筑目标的问题。
现在这个bug已经被修复了。
无ini，强制开启。
