### PR TITLE
自动攻击围墙

### DIFF
--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -305,6 +305,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->RallyPointForceMove.Read(exINI, GameStrings::General, "RallyPointForceMove");
 	this->RallyPointAreaGuard.Read(exINI, GameStrings::General, "RallyPointAreaGuard");
 	this->PlayerDestroyWalls.Read(exINI, GameStrings::General, "PlayerDestroyWalls");
+	this->AutoTargetWalls.Read(exINI, GameStrings::General, "AutoTargetWalls");
+	this->EndAutoTargetingIfFindWalls.Read(exINI, GameStrings::General, "EndAutoTargetingIfFindWalls");
 	this->DestroyOwnerlessWalls.Read(exINI, GameStrings::General, "DestroyOwnerlessWalls");
 	this->AIAngerOnAlly.Read(exINI, GameStrings::General, "AIAngerOnAlly");
 	this->FollowTargetSelf.Read(exINI, GameStrings::General, "FollowTargetSelf");
@@ -427,12 +429,10 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->BerzerkTargeting.Read(exINI, GameStrings::CombatDamage, "BerzerkTargeting");
 
-<<<<<<< DamageWall
-	this->DamageWallRecursivly.Read(exINI, GameStrings::CombatDamage, "DamageWallRecursivly");
-=======
 	this->AttackMove_IgnoreWeaponCheck.Read(exINI, GameStrings::General, "AttackMove.IgnoreWeaponCheck");
 	this->AttackMove_StopWhenTargetAcquired.Read(exINI, GameStrings::General, "AttackMove.StopWhenTargetAcquired");
->>>>>>> Mix-ECpack
+
+	this->DamageWallRecursivly.Read(exINI, GameStrings::CombatDamage, "DamageWallRecursivly");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -703,6 +703,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->RallyPointForceMove)
 		.Process(this->RallyPointAreaGuard)
 		.Process(this->PlayerDestroyWalls)
+		.Process(this->AutoTargetWalls)
+		.Process(this->EndAutoTargetingIfFindWalls)
 		.Process(this->DestroyOwnerlessWalls)
 		.Process(this->AIAngerOnAlly)
 		.Process(this->FollowTargetSelf)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -249,6 +249,8 @@ public:
 		Valueable<bool> RallyPointForceMove;
 		Valueable<bool> RallyPointAreaGuard;
 		Valueable<bool> PlayerDestroyWalls;
+		Valueable<int> AutoTargetWalls;
+		Valueable<bool> EndAutoTargetingIfFindWalls;
 		Valueable<bool> DestroyOwnerlessWalls;
 		Valueable<bool> AIAngerOnAlly;
 		Valueable<bool> FollowTargetSelf;
@@ -371,12 +373,10 @@ public:
 
 		Valueable<AffectedHouse> BerzerkTargeting;
 
-<<<<<<< DamageWall
-		Valueable<bool> DamageWallRecursivly;
-=======
 		Valueable<bool> AttackMove_IgnoreWeaponCheck;
 		Nullable<bool> AttackMove_StopWhenTargetAcquired;
->>>>>>> Mix-ECpack
+
+		Valueable<bool> DamageWallRecursivly;
 
 		// cache tint color
 		int TintColorIronCurtain;
@@ -587,6 +587,8 @@ public:
 			, RallyPointForceMove { false }
 			, RallyPointAreaGuard { false }
 			, PlayerDestroyWalls { false }
+			, AutoTargetWalls { 1 }
+			, EndAutoTargetingIfFindWalls { true }
 			, DestroyOwnerlessWalls { false }
 			, AIAngerOnAlly { true }
 			, FollowTargetSelf { false }

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -559,14 +559,21 @@ DEFINE_HOOK(0x6F8D21, TechnoClass_ScanToAttackWall_CheckWH, 0x6)
 {
 	GET(WarheadTypeClass*, pWH, ECX);
 
-	bool defaultValue = false;
+	bool result = pWH->Wall;
 
-	if (RulesExt::Global()->AutoTargetWalls > 0)
-		defaultValue = true;
-	else if (RulesExt::Global()->AutoTargetWalls < 0)
-		defaultValue = pWH->WallAbsoluteDestroyer;
+	if (result)
+	{
+		bool defaultValue = false;
 
-	R->AL(WarheadTypeExt::ExtMap.Find(pWH)->AutoTargetWalls.Get(defaultValue));
+		if (RulesExt::Global()->AutoTargetWalls > 0)
+			defaultValue = true;
+		else if (RulesExt::Global()->AutoTargetWalls < 0)
+			defaultValue = pWH->WallAbsoluteDestroyer;
+
+		result = WarheadTypeExt::ExtMap.Find(pWH)->AutoTargetWalls.Get(defaultValue);
+	}
+
+	R->AL(result);
 	return R->Origin() + 0x6;
 }
 

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -1,4 +1,4 @@
-﻿#include "Body.h"
+#include "Body.h"
 
 #include <EventClass.h>
 #include <SpawnManagerClass.h>
@@ -555,6 +555,21 @@ DEFINE_HOOK(0x6F8C18, TechnoClass_ScanToAttackWall_PlayerDestroyWall, 0x6)
 	return RulesExt::Global()->PlayerDestroyWalls ? SkipIsAIChecks : FuncRetZero;
 }
 
+DEFINE_HOOK(0x6F8D21, TechnoClass_ScanToAttackWall_CheckWH, 0x6)
+{
+	GET(WarheadTypeClass*, pWH, ECX);
+
+	bool defaultValue = false;
+
+	if (RulesExt::Global()->AutoTargetWalls > 0)
+		defaultValue = true;
+	else if (RulesExt::Global()->AutoTargetWalls < 0)
+		defaultValue = pWH->WallAbsoluteDestroyer;
+
+	R->AL(WarheadTypeExt::ExtMap.Find(pWH)->AutoTargetWalls.Get(defaultValue));
+	return R->Origin() + 0x6;
+}
+
 DEFINE_HOOK(0x6F8D32, TechnoClass_ScanToAttackWall_DestroyOwnerlessWalls, 0x9)
 {
 	enum { GoOtherChecks = 0x6F8D58, NotOkToFire = 0x6F8DE3 };
@@ -573,6 +588,27 @@ DEFINE_HOOK(0x6F8D32, TechnoClass_ScanToAttackWall_DestroyOwnerlessWalls, 0x9)
 	}
 
 	return GoOtherChecks;
+}
+
+DEFINE_HOOK(0x6F9B1B, TechnoClass_SelectAutoTarget_EndAutoTargetingIfFindWalls1, 0x5)
+{
+	enum { SkipGameCode = 0x6F9B37 };
+	return RulesExt::Global()->EndAutoTargetingIfFindWalls ? 0 : SkipGameCode;
+}
+
+DEFINE_HOOK(0x6F9B3E, TechnoClass_SelectAutoTarget_EndAutoTargetingIfFindWalls2, 0x6)
+{
+	enum { CheckNext = 0x6F9B44 , TargetTechno = 0x6F9DA1 , TargetWall = 0x6F9B55 };
+
+	GET(int, maxRange, ECX);
+	GET(int, currentRange, EDI);
+	GET_STACK(AbstractClass*, pBestTarget, STACK_OFFSET(0x6C, -0x4C));
+	GET_STACK(CellStruct, bestTargetCell, STACK_OFFSET(0x6C, -0x38));
+
+	if (currentRange > maxRange)
+		return RulesExt::Global()->EndAutoTargetingIfFindWalls || pBestTarget || bestTargetCell == CellStruct::Empty ? TargetTechno : TargetWall;
+
+	return CheckNext;
 }
 
 DEFINE_HOOK(0x6F9B64, TechnoClass_SelectAutoTarget_RecordAttackWall, 0x7)

--- a/src/Ext/WarheadType/Body.cpp
+++ b/src/Ext/WarheadType/Body.cpp
@@ -1,4 +1,4 @@
-﻿#include "Body.h"
+#include "Body.h"
 
 #include <BulletClass.h>
 #include <HouseClass.h>
@@ -323,6 +323,8 @@ void WarheadTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// AttachEffect
 	this->AttachEffects.LoadFromINI(pINI, pSection);
 
+	this->AutoTargetWalls.Read(exINI, pSection, "AutoTargetWalls");
+
 #ifdef LOCO_TEST_WARHEADS // Enable warheads parsing
 	this->InflictLocomotor.Read(exINI, pSection, "InflictLocomotor");
 	this->RemoveInflictedLocomotor.Read(exINI, pSection, "RemoveInflictedLocomotor");
@@ -603,6 +605,8 @@ void WarheadTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->ActivateWreckage)
 
 		.Process(this->AirstrikeTargets)
+
+		.Process(this->AutoTargetWalls)
 
 		// Ares tags
 		.Process(this->AffectsEnemies)

--- a/src/Ext/WarheadType/Body.h
+++ b/src/Ext/WarheadType/Body.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include <WarheadTypeClass.h>
 #include <SuperWeaponTypeClass.h>
 #include <Helpers/Macro.h>
@@ -208,6 +208,8 @@ public:
 
 		Valueable<double> AffectsAbovePercent;
 		Valueable<double> AffectsBelowPercent;
+
+		Nullable<bool> AutoTargetWalls;
 
 		// Ares tags
 		// http://ares-developers.github.io/Ares-docs/new/warheads/general.html
@@ -440,6 +442,8 @@ public:
 			, KillWeapon_OnFirer_AffectsHouses { AffectedHouse::All }
 			, KillWeapon_Affects { AffectedTarget::All }
 			, KillWeapon_OnFirer_Affects { AffectedTarget::All }
+
+			, AutoTargetWalls {}
 		{ }
 
 		void ApplyAttachmentTransform(HouseClass* pHouse, TechnoClass* pTarget);


### PR DESCRIPTION

 2-36. 自动攻击围墙
不言自明。
[General]                       ; 全局通用设置
PlayerDestroyWalls=false        ; 玩家单位是否自动攻击围墙。
AutoTargetWalls=1                ；整数，决定下面同名标签的默认值。大于0时，默认值为true，等于0时为false，小于0时为WallAbsoluteDestroyer的值。
EndAutoTargetingIfFindWalls=true           ；自动索敌中找到围墙时是否立刻停止索敌。
DestroyOwnerlessWalls=false     ; 自动攻击围墙的单位是否将所有非友军的围墙都作为目标，包括无所属方的和三家中立的。

[WarheadType]
AutoTargetWalls=true                ；该弹头是否会自动攻击围墙。Wall=no的弹头无视此选项。

注意：围墙实际上具有最低优先级（如果找到了单位就不会继续查找围墙）。原本游戏中自动索敌找到围墙时立刻停止索敌可能应该算是bug。
