### PR TITLE
统一雷达颜色修正

### DIFF
--- a/src/Ext/Bullet/Hooks.cpp
+++ b/src/Ext/Bullet/Hooks.cpp
@@ -23,6 +23,12 @@ DEFINE_HOOK(0x466556, BulletClass_Init, 0x6)
 			pExt->InitializeLaserTrails();
 	}
 
+	if (RulesExt::Global()->VHPScan_Enhanced)
+	{
+		if (auto pTargetExt = TechnoExt::ExtMap.Find(abstract_cast<TechnoClass*>(pThis->Target)))
+			pTargetExt->BulletsTargetingMe.AddItem(pThis);
+	}
+
 	return 0;
 }
 

--- a/src/Ext/Techno/Body.cpp
+++ b/src/Ext/Techno/Body.cpp
@@ -1211,6 +1211,7 @@ void TechnoExt::ExtData::Serialize(T& Stm)
 		.Process(this->AttackMoveFollowerTempCount)
 		.Process(this->UndergroundTracked)
 		.Process(this->SpecialTracked)
+		.Process(this->BulletsTargetingMe)
 		;
 }
 

--- a/src/Ext/Techno/Body.h
+++ b/src/Ext/Techno/Body.h
@@ -140,6 +140,8 @@ public:
 		bool UndergroundTracked;
 		bool SpecialTracked;
 
+		DynamicVectorClass<BulletClass*> BulletsTargetingMe;
+
 		ExtData(TechnoClass* OwnerObject) : Extension<TechnoClass>(OwnerObject)
 			, TypeExtData { nullptr }
 			, Shield {}
@@ -228,6 +230,7 @@ public:
 			, AttackMoveFollowerTempCount { 0 }
 			, UndergroundTracked { false }
 			, SpecialTracked { false }
+			, BulletsTargetingMe {}
 		{ }
 
 		void OnEarlyUpdate();

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -2095,7 +2095,7 @@ static inline void CheckVHPScanAndRetarget(TechnoClass* pThis)
 
 	const auto pTargetTechno = abstract_cast<TechnoClass*>(pThis->Target);
 
-	if (!pTargetTechno || pTargetTechno->EstimatedHealth > 0)
+	if (!pTargetTechno || pTargetTechno->EstimatedHealth > 0 || pThis->Owner->IsAlliedWith(pTargetTechno))
 		return;
 
 	pThis->SetTarget(nullptr);
@@ -2160,6 +2160,42 @@ DEFINE_HOOK(0x6F8721, TechnoClass_CanAutoTargetObject_VHPScanThreat, 0x7)
 	}
 
 	return 0;
+}
+
+DEFINE_HOOK(0x6F9F7B, TechnoClass_Update_EstimateHealth, 0x7)
+{
+	enum { SkipGameCode = 0x6F9F9F };
+
+	if (!RulesExt::Global()->VHPScan_Enhanced)
+		return 0;
+
+	GET(TechnoClass*, pThis, ESI);
+
+	if (pThis->EstimatedHealth < pThis->Health)
+	{
+		auto pBulletsTargetingMe = TechnoExt::ExtMap.Find(pThis)->BulletsTargetingMe;
+		bool shouldResetEstimateHealth = true;
+
+		for (int idx = 0; idx < pBulletsTargetingMe.Count; )
+		{
+			auto pBullet = pBulletsTargetingMe[idx];
+
+			if (VTable::Get(pBullet) != 0x7E46E4) // BulletClass::VTable
+			{
+				pBulletsTargetingMe.RemoveItem(idx);
+			}
+			else
+			{
+				shouldResetEstimateHealth = false;
+				break;
+			}
+		}
+
+		if (shouldResetEstimateHealth)
+			pThis->EstimatedHealth = pThis->Health;
+	}
+
+	return SkipGameCode;
 }
 
 #pragma endregion

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -1645,6 +1645,15 @@ DEFINE_HOOK(0x47C329, CellClass_GetRadarColor_UnifiedRadarColor, 0x7)
 	return 0;
 }
 
+DEFINE_HOOK(0x655E58, RadarClass_ProcessPoint_DrawOccupiable, 0x6)
+{
+	GET(TechnoClass*, pTechno, EBP);
+	auto pBuilding = abstract_cast<BuildingClass*>(pTechno);
+	R->CL(pTechno->Owner->Type->MultiplayPassive
+		&& (!RulesExt::Global()->UnifiedRadarColor || !pBuilding || !pBuilding->Type->CanBeOccupied));
+	return R->Origin() + 0x6;
+}
+
 #pragma endregion
 
 #pragma region UnifiedTechnoColor
@@ -1655,10 +1664,11 @@ DEFINE_HOOK(0x655F80, RadarClass_ProcessPoint_UnifiedRadarColor, 0x6)
 
 	GET_STACK(HouseClass*, pOwner, STACK_OFFSET(0x40, 0x4));
 
-	if (!Phobos::Config::UnifiedTechnoColor)
+	const auto pRulesExt = RulesExt::Global();
+
+	if (!pRulesExt->UnifiedRadarColor)
 		return 0;
 
-	const auto pRulesExt = RulesExt::Global();
 	int colorCode = 0;
 
 	if (pOwner->Type->MultiplayPassive)


### PR DESCRIPTION
现在启用该功能后，中立的可驻军建筑也会显示在地图上。
另，之前单位的雷达颜色开启的flag是错误的，现已修正。
以及改进了估计生命值的校准算法，现在当单位没有被抛射体瞄准时会校准自身的估计生命值。