### PR TITLE
建筑节点距离限制

### DIFF
--- a/src/Ext/BuildingType/Body.cpp
+++ b/src/Ext/BuildingType/Body.cpp
@@ -1368,6 +1368,8 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 		}
 	}
 
+	this->Refinery_UseNormalActiveAnim.Read(exArtINI, pArtSection, "Refinery.UseNormalActiveAnim");
+
 	// Ares tag
 	this->SpyEffect_Custom.Read(exINI, pSection, "SpyEffect.Custom");
 	if (SuperWeaponTypeClass::Array.Count > 0)
@@ -1396,6 +1398,7 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 
 	this->Refinery_UseStorage.Read(exINI, pSection, "Refinery.UseStorage");
 	this->CloningFacility.Read(exINI, pSection, "CloningFacility");
+	this->AIBaseNormal.Read(exINI, pSection, "AIBaseNormal");
 
 	// PlacementPreview
 	{
@@ -1411,7 +1414,6 @@ void BuildingTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	// Art
 	this->IsAnimDelayedBurst.Read(exArtINI, pArtSection, "IsAnimDelayedBurst");
 	this->ZShapePointMove_OnBuildup.Read(exArtINI, pArtSection, "ZShapePointMove.OnBuildup");
-	this->Refinery_UseNormalActiveAnim.Read(exArtINI, pArtSection, "Refinery.UseNormalActiveAnim");
 }
 
 void BuildingTypeExt::ExtData::CompleteInitialization()
@@ -1503,6 +1505,7 @@ void BuildingTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->BunkerWallsDownSound)
 		.Process(this->BuildingRepairedSound)
 		.Process(this->Refinery_UseNormalActiveAnim)
+		.Process(this->AIBaseNormal)
 		;
 }
 

--- a/src/Ext/BuildingType/Body.h
+++ b/src/Ext/BuildingType/Body.h
@@ -121,6 +121,8 @@ public:
 
 		Valueable<bool> Refinery_UseNormalActiveAnim;
 
+		Nullable<bool> AIBaseNormal;
+
 		ExtData(BuildingTypeClass* OwnerObject) : Extension<BuildingTypeClass>(OwnerObject)
 			, PowersUp_Owner { AffectedHouse::Owner }
 			, PowersUp_Buildings {}
@@ -200,6 +202,7 @@ public:
 			, BunkerWallsDownSound {}
 			, BuildingRepairedSound {}
 			, Refinery_UseNormalActiveAnim { false }
+			, AIBaseNormal {}
 		{ }
 
 		// Ares 0.A functions

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -431,8 +431,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->DamageWallRecursivly.Read(exINI, GameStrings::CombatDamage, "DamageWallRecursivly");
 
-	this->AIAdjacentMax.Read(exINI, GameStrings::General, "AIAdjacentMax");
-	this->AIAdjacentMax_Campaign.Read(exINI, GameStrings::General, "AIAdjacentMax.Campaign");
+	this->AIAdjacentMax.Read(exINI, GameStrings::AI, "AIAdjacentMax");
+	this->AIAdjacentMax_Campaign.Read(exINI, GameStrings::AI, "AIAdjacentMax.Campaign");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -431,6 +431,9 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->DamageWallRecursivly.Read(exINI, GameStrings::CombatDamage, "DamageWallRecursivly");
 
+	this->AIAdjacentMax.Read(exINI, GameStrings::General, "AIAdjacentMax");
+	this->AIAdjacentMax_Campaign.Read(exINI, GameStrings::General, "AIAdjacentMax.Campaign");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -797,6 +800,8 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->TintColorBerserk)
 		.Process(this->AttackMove_IgnoreWeaponCheck)
 		.Process(this->AttackMove_StopWhenTargetAcquired)
+		.Process(this->AIAdjacentMax)
+		.Process(this->AIAdjacentMax_Campaign)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -378,6 +378,9 @@ public:
 
 		Valueable<bool> DamageWallRecursivly;
 
+		Valueable<int> AIAdjacentMax;
+		Nullable<int> AIAdjacentMax_Campaign;
+
 		// cache tint color
 		int TintColorIronCurtain;
 		int TintColorForceShield;
@@ -703,6 +706,9 @@ public:
 
 			, AttackMove_IgnoreWeaponCheck { false }
 			, AttackMove_StopWhenTargetAcquired { }
+
+			, AIAdjacentMax { -1 }
+			, AIAdjacentMax_Campaign {}
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -1,4 +1,4 @@
-﻿#include "Body.h"
+#include "Body.h"
 
 #include <EventClass.h>
 #include <SpawnManagerClass.h>
@@ -2185,6 +2185,48 @@ DEFINE_HOOK(0x7460EC, UnitClass_AStarAttempt_PathingTooFar, 0x5)
 }
 
 #pragma region
+
+#pragma region AIAdjacentMax
+
+DEFINE_HOOK_AGAIN(0x42EB6A, BaseClass_GetBaseNodeIndex_AIAdjacentMax, 0x8);
+DEFINE_HOOK(0x42EBA2, BaseClass_GetBaseNodeIndex_AIAdjacentMax, 0x8)
+{
+	GET(BaseClass*, pThis, ESI);
+	GET(int, nodeIdx, EDI);
+
+	bool isValid = reinterpret_cast<bool(__thiscall*)(BaseClass*, int)>(0x42E780)(pThis, nodeIdx);
+	int rangeLimit = SessionClass::Instance.IsCampaign() ? RulesExt::Global()->AIAdjacentMax_Campaign.Get(RulesExt::Global()->AIAdjacentMax) : RulesExt::Global()->AIAdjacentMax;
+
+	if (rangeLimit >= 0 && isValid)
+	{
+		auto node = pThis->BaseNodes[nodeIdx];
+		auto pOwner = pThis->Owner;
+		auto pBuildingType = BuildingTypeClass::Array[node.BuildingTypeIndex];
+		auto center = node.MapCoords + CellStruct { (short)(pBuildingType->GetFoundationWidth() / 2), (short)(pBuildingType->GetFoundationHeight(false) / 2) };
+		auto cellList = GeneralUtils::AdjacentCellsInRange(rangeLimit);
+		bool hasAdjacent = false;
+
+		for (auto cell : cellList)
+		{
+			CellStruct currentCell = cell + center;
+			auto pBuilding = MapClass::Instance.GetCellAt(currentCell)->GetBuilding();
+
+			if (pBuilding && pBuilding->Owner == pOwner)
+			{
+				hasAdjacent = true;
+				break;
+			}
+		}
+
+		isValid = hasAdjacent;
+	}
+
+	R->AL(isValid);
+	return R->Origin() + 0x8;
+}
+
+
+#pragma endregion
 
 // TODO Self-made impl
 

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -2210,8 +2210,10 @@ DEFINE_HOOK(0x42EBA2, BaseClass_GetBaseNodeIndex_AIAdjacentMax, 0x8)
 		{
 			CellStruct currentCell = cell + center;
 			auto pBuilding = MapClass::Instance.GetCellAt(currentCell)->GetBuilding();
+			auto pType = pBuilding->Type;
+			auto baseNormalDefault = (!pType->UndeploysInto || !pType->ResourceGatherer) && !pBuilding->IsStrange();
 
-			if (pBuilding && pBuilding->Owner == pOwner)
+			if (pBuilding && pBuilding->Owner == pOwner && BuildingTypeExt::ExtMap.Find(pType)->AIBaseNormal.Get(baseNormalDefault))
 			{
 				hasAdjacent = true;
 				break;

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -2210,10 +2210,14 @@ DEFINE_HOOK(0x42EBA2, BaseClass_GetBaseNodeIndex_AIAdjacentMax, 0x8)
 		{
 			CellStruct currentCell = cell + center;
 			auto pBuilding = MapClass::Instance.GetCellAt(currentCell)->GetBuilding();
+
+			if (!pBuilding)
+				continue;
+
 			auto pType = pBuilding->Type;
 			auto baseNormalDefault = (!pType->UndeploysInto || !pType->ResourceGatherer) && !pBuilding->IsStrange();
 
-			if (pBuilding && pBuilding->Owner == pOwner && BuildingTypeExt::ExtMap.Find(pType)->AIBaseNormal.Get(baseNormalDefault))
+			if (pBuilding->Owner == pOwner && BuildingTypeExt::ExtMap.Find(pType)->AIBaseNormal.Get(baseNormalDefault))
 			{
 				hasAdjacent = true;
 				break;


### PR DESCRIPTION

 2-98. 建筑节点距离限制
原本游戏中，AI可以无视距离往已有的建筑节点上建造建筑。
现在你可以限制一个范围，AI必须在节点附近这个范围内有它自己的建筑才能放置建筑。

[AI]
AIAdjacentMax=-1                          ；要求节点范围内有建筑的距离，单位格
AIAdjacentMax.Campaign=             ；战役模式下的上述范围，默认值为上一个flag的值