### PR TITLE
修复一个AttackMove可能进入不正确的任务从而卡住的问题

### DIFF
--- a/src/Ext/Techno/Hooks.cpp
+++ b/src/Ext/Techno/Hooks.cpp
@@ -1301,6 +1301,12 @@ DEFINE_HOOK(0x4DF3A6, FootClass_UpdateAttackMove_Follow, 0x6)
 
 	GET(FootClass* const, pThis, ESI);
 
+	Mission mission = pThis->GetCurrentMission();
+
+	// Refresh mega mission if mission is somehow changed to incorrect missions.
+	if (mission != Mission::Attack && mission != Mission::Move)
+		pThis->ContinueMegaMission();
+
 	auto const pTypeExt = TechnoExt::ExtMap.Find(pThis)->TypeExtData;
 
 	if (pTypeExt->AttackMove_Follow || pTypeExt->AttackMove_Follow_IfMindControlIsFull && pThis->CaptureManager && pThis->CaptureManager->CannotControlAnyMore())


### PR DESCRIPTION
 2-99. AttackMove相关小问题修复
现在执行AttackMove的单位如果因为某些原因（比如EMP）进入了不正确的任务，那么会尝试恢复或退出AttackMove。
无ini，强制开启。