### PR TITLE
更新集结点增强功能

### DIFF
--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -296,8 +296,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 	this->NonVehExplodeOnDestroy.Read(exINI, GameStrings::AudioVisual, "NonVehExplodeOnDestroy");
 	this->FireDeathWeaponOnCrushed.Read(exINI, GameStrings::CombatDamage, "FireDeathWeaponOnCrushed");
 	this->CrushBuildingOnAnyCell.Read(exINI, GameStrings::General, "CrushBuildingOnAnyCell");
-	this->RallyPointOnTechno.Read(exINI, GameStrings::General, "RallyPointOnTechno");
-	this->RallyPointForceMove.Read(exINI, GameStrings::General, "RallyPointForceMove");
+	this->RallyPointIgnoreReachability.Read(exINI, GameStrings::General, "RallyPointIgnoreReachability");
 	this->RallyPointAreaGuard.Read(exINI, GameStrings::General, "RallyPointAreaGuard");
 	this->PlayerDestroyWalls.Read(exINI, GameStrings::General, "PlayerDestroyWalls");
 	this->AutoTargetWalls.Read(exINI, GameStrings::General, "AutoTargetWalls");
@@ -725,8 +724,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->NonVehExplodeOnDestroy)
 		.Process(this->FireDeathWeaponOnCrushed)
 		.Process(this->CrushBuildingOnAnyCell)
-		.Process(this->RallyPointOnTechno)
-		.Process(this->RallyPointForceMove)
+		.Process(this->RallyPointIgnoreReachability)
 		.Process(this->RallyPointAreaGuard)
 		.Process(this->PlayerDestroyWalls)
 		.Process(this->AutoTargetWalls)

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -240,8 +240,7 @@ public:
 		Valueable<bool> NonVehExplodeOnDestroy;
 		Valueable<bool> FireDeathWeaponOnCrushed;
 		Valueable<bool> CrushBuildingOnAnyCell;
-		Valueable<bool> RallyPointOnTechno;
-		Valueable<bool> RallyPointForceMove;
+		Valueable<bool> RallyPointIgnoreReachability;
 		Valueable<bool> RallyPointAreaGuard;
 		Valueable<bool> PlayerDestroyWalls;
 		Valueable<int> AutoTargetWalls;
@@ -605,8 +604,7 @@ public:
 			, NonVehExplodeOnDestroy { false }
 			, FireDeathWeaponOnCrushed { false }
 			, CrushBuildingOnAnyCell { false }
-			, RallyPointOnTechno { false }
-			, RallyPointForceMove { false }
+			, RallyPointIgnoreReachability { false }
 			, RallyPointAreaGuard { false }
 			, PlayerDestroyWalls { false }
 			, AutoTargetWalls { 1 }

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -838,32 +838,42 @@ DEFINE_HOOK(0x44368D, BuildingClass_ObjectClickedAction_RallyPoint, 0x7)
 {
 	enum { OnTechno = 0x44363C };
 
-	return RulesExt::Global()->RallyPointOnTechno ? OnTechno : 0;
+	return RulesExt::Global()->RallyPointIgnoreReachability ? OnTechno : 0;
 }
 
 DEFINE_HOOK(0x4473F4, BuildingClass_MouseOverObject_JustHasRallyPoint, 0x6)
 {
-	enum { JustRally = 0x447413 };
+	enum { SkipFactoryCheck = 0x447413, SkipAllCheck = 0x44752C };
 
 	GET(BuildingClass* const, pThis, ESI);
 
-	return BuildingTypeExt::ExtMap.Find(pThis->Type)->JustHasRallyPoint ? JustRally : 0;
+	if (RulesExt::Global()->RallyPointIgnoreReachability)
+		return SkipAllCheck;
+	return BuildingTypeExt::ExtMap.Find(pThis->Type)->JustHasRallyPoint ? SkipFactoryCheck : 0;
 }
 
-DEFINE_HOOK(0x447413, BuildingClass_MouseOverObject_RallyPointForceMove, 0x5)
+DEFINE_HOOK(0x447643, BuildingClass_MouseOverCell_IgnoreReachability, 0x5)
 {
-	enum { AlwaysAlt = 0x44744E };
+	enum { SkipGameCode = 0x44774B };
 
-	return RulesExt::Global()->RallyPointForceMove ? AlwaysAlt : 0;
+	return RulesExt::Global()->RallyPointIgnoreReachability ? SkipGameCode : 0;
 }
 
-DEFINE_HOOK(0x70000E, TechnoClass_MouseOverObject_RallyPointForceMove, 0x5)
+DEFINE_HOOK(0x44398C, BuildingClass_SetRallyPoint_IgnoreReachability, 0x5)
+{
+	GET_STACK(CellStruct*, pTarget, STACK_OFFSET(0xA4, 0x4));
+	if (RulesExt::Global()->RallyPointIgnoreReachability)
+		R->EAX(MapClass::Instance.GetCellAt(*pTarget));
+	return 0;
+}
+
+DEFINE_HOOK(0x70000E, TechnoClass_MouseOverObject_RallyPointIgnoreReachability, 0x5)
 {
 	enum { AlwaysAlt = 0x700038 };
 
 	GET(TechnoClass* const, pThis, ESI);
 
-	if (pThis->WhatAmI() == AbstractType::Building && RulesExt::Global()->RallyPointForceMove)
+	if (pThis->WhatAmI() == AbstractType::Building && RulesExt::Global()->RallyPointIgnoreReachability)
 	{
 		auto const pType = static_cast<BuildingClass*>(pThis)->Type;
 		auto const pTypeExt = BuildingTypeExt::ExtMap.Find(pType);


### PR DESCRIPTION
把ontechno和forcemove都捏到一起了，现在会无视所有检查对任何位置都可以move。

[General]                                       ; 全局通用设置
RallyPointIgnoreReachability=no                 ; 布尔值，是否跳过所有对集结点的限制
