### PR TITLE
步兵抬手时给予额外射程

### DIFF
--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -461,6 +461,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->AdjacentWallDamage.Read(exINI, GameStrings::CombatDamage, "AdjacentWallDamage");
 
+	this->InSequenceExtraRange.Read(exINI, GameStrings::CombatDamage, "InSequenceExtraRange");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -850,6 +852,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->Parasite_GrappleAnim)
 		.Process(this->InfantryAutoDeploy)
 		.Process(this->AdjacentWallDamage)
+		.Process(this->InSequenceExtraRange)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -410,6 +410,8 @@ public:
 
 		Valueable<int> AdjacentWallDamage;
 
+		Valueable<Leptons> InSequenceExtraRange;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, HarvesterDumpAmount { 0.0f }
@@ -754,6 +756,8 @@ public:
 			, Parasite_GrappleAnim {}
 			, InfantryAutoDeploy { false }
 			, AdjacentWallDamage { 200 }
+
+			, InSequenceExtraRange { Leptons(0) }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Misc.cpp
+++ b/src/Ext/Techno/Hooks.Misc.cpp
@@ -290,7 +290,7 @@ DEFINE_HOOK(0x4D962B, FootClass_SetDestination_RecycleFLH, 0x5)
 	}
 	else if ((pDestination->AbstractFlags & AbstractFlags::Techno) != AbstractFlags::None
 		&& (((pDestination->AbstractFlags & AbstractFlags::Foot) != AbstractFlags::None)
-		? RulesExt::Global()->FollowTargetSelf.Get()
+			? RulesExt::Global()->FollowTargetSelf.Get() && locomotion_cast<JumpjetLocomotionClass*>((((FootClass*)pDestination))->Locomotor)
 		: (pThis->SendCommand(RadioCommand::QueryCanEnter, static_cast<BuildingClass*>(pDestination)) != RadioCommand::AnswerPositive)))
 	{
 		GET(CoordStruct*, pDestCrd, EAX);

--- a/src/Ext/Techno/Hooks.WeaponRange.cpp
+++ b/src/Ext/Techno/Hooks.WeaponRange.cpp
@@ -67,7 +67,17 @@ DEFINE_HOOK(0x6F7248, TechnoClass_InRange_WeaponRange, 0x6)
 	if (const auto keepRange = WeaponTypeExt::GetTechnoKeepRange(pWeapon, pThis, false))
 		range = keepRange;
 	else
+	{
 		range = WeaponTypeExt::GetRangeWithModifiers(pWeapon, pThis);
+
+		if (auto pInfantry = abstract_cast<InfantryClass*>(pThis))
+		{
+			auto sequence = pInfantry->SequenceAnim;
+
+			if (sequence == Sequence::FireFly || sequence == Sequence::FireUp || sequence == Sequence::FireProne || sequence == Sequence::DeployedFire || sequence == Sequence::SecondaryFire)
+				range += RulesExt::Global()->InSequenceExtraRange.Get();
+		}
+	}
 
 	R->EDI(range);
 


### PR DESCRIPTION

 2-99. 步兵抬手时给予额外射程
原本游戏中，由于步兵必须停下来播放完攻击序列才能攻击，导致具有较长抬手的步兵难以攻击正在逃离的敌人。
现在你可以通过以下设置让步兵在播放攻击序列时获得额外射程。

[CombatDamage]
InSequenceExtraRange=0.0            ；浮点型，单位：格，步兵处于攻击序列时获得的额外射程。

另：现在FollowTargetSelf只对jj目标生效了，因为对于其它目标没什么用。