### PR TITLE
混乱行为增强

### DIFF
--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -466,6 +466,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->InSequenceExtraRange.Read(exINI, GameStrings::CombatDamage, "InSequenceExtraRange");
 
+	this->EnhancedBerzerk.Read(exINI, GameStrings::CombatDamage, "EnhancedBerzerk");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -857,6 +859,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AdjacentWallDamage)
 		.Process(this->AISellCapturedBuilding)
 		.Process(this->InSequenceExtraRange)
+		.Process(this->EnhancedBerzerk)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -415,6 +415,8 @@ public:
 
 		Valueable<Leptons> InSequenceExtraRange;
 
+		Valueable<bool> EnhancedBerzerk;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, HarvesterDumpAmount { 0.0f }
@@ -763,6 +765,8 @@ public:
 			, AISellCapturedBuilding { true }
 
 			, InSequenceExtraRange { Leptons(0) }
+
+			, EnhancedBerzerk { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -2145,6 +2145,25 @@ DEFINE_HOOK(0x68758D, INIClass_ReadScenario_AfterLoadProgressMgrDraw, 0x5)
 
 #pragma endregion
 
+#pragma region BerzerkBehavior
+
+DEFINE_HOOK(0x701DAE, TechnoClass_ReceiveDamage_Berzerk, 0x6)
+{
+	enum { SkipQueueMission = 0x701DBA };
+
+	GET(TechnoClass*, pThis, ESI);
+
+	if (!RulesExt::Global()->EnhancedBerzerk)
+		return 0;
+	
+	pThis->SetDestination(0, false);
+	pThis->QueueMission(Mission::Area_Guard, false);
+
+	return SkipQueueMission;
+}
+
+#pragma endregion
+
 // TODO Self-made impl
 
 


### PR DESCRIPTION

 2-104. 混乱行为增强
原本游戏中，混乱的JJ在停下后才会再次寻找目标并前往攻击。
现在你可以让它们在受到影响时立刻停下，并前往攻击。
原本游戏中，混乱的单位被赋予的任务是Hunt，该任务会在全图索敌，有可能找到非常远的单位，导致单位直到混乱结束也不会攻击。
现在你可以把这个任务改为AreaGuard，单位只会在附近搜索目标。

[CombatDamage]
EnhancedBerzerk=false          ；布尔型，是否开启以上行为