### PR TITLE
AI索敌空军修复

### DIFF
--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -469,7 +469,7 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->EnhancedBerzerk.Read(exINI, GameStrings::CombatDamage, "EnhancedBerzerk");
 
-	this->AITargetingAirThroughATC.Read(exINI, GameStrings::General, "AITargetingAirThroughATC");
+	this->AIAirTargetingFix.Read(exINI, GameStrings::General, "AIAirTargetingFix");
 
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
@@ -864,7 +864,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AISellCapturedBuilding)
 		.Process(this->InSequenceExtraRange)
 		.Process(this->EnhancedBerzerk)
-		.Process(this->AITargetingAirThroughATC)
+		.Process(this->AIAirTargetingFix)
 		;
 }
 

--- a/src/Ext/Rules/Body.cpp
+++ b/src/Ext/Rules/Body.cpp
@@ -469,6 +469,8 @@ void RulesExt::ExtData::LoadBeforeTypeData(RulesClass* pThis, CCINIClass* pINI)
 
 	this->EnhancedBerzerk.Read(exINI, GameStrings::CombatDamage, "EnhancedBerzerk");
 
+	this->AITargetingAirThroughATC.Read(exINI, GameStrings::General, "AITargetingAirThroughATC");
+
 	// Section AITargetTypes
 	int itemsCount = pINI->GetKeyCount("AITargetTypes");
 	for (int i = 0; i < itemsCount; ++i)
@@ -862,6 +864,7 @@ void RulesExt::ExtData::Serialize(T& Stm)
 		.Process(this->AISellCapturedBuilding)
 		.Process(this->InSequenceExtraRange)
 		.Process(this->EnhancedBerzerk)
+		.Process(this->AITargetingAirThroughATC)
 		;
 }
 

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -418,7 +418,7 @@ public:
 
 		Valueable<bool> EnhancedBerzerk;
 
-		Valueable<bool> AITargetingAirThroughATC;
+		Valueable<bool> AIAirTargetingFix;
 
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
@@ -772,7 +772,7 @@ public:
 
 			, EnhancedBerzerk { false }
 
-			, AITargetingAirThroughATC { false }
+			, AIAirTargetingFix { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Rules/Body.h
+++ b/src/Ext/Rules/Body.h
@@ -418,6 +418,8 @@ public:
 
 		Valueable<bool> EnhancedBerzerk;
 
+		Valueable<bool> AITargetingAirThroughATC;
+
 		ExtData(RulesClass* OwnerObject) : Extension<RulesClass>(OwnerObject)
 			, Storage_TiberiumIndex { -1 }
 			, HarvesterDumpAmount { 0.0f }
@@ -769,6 +771,8 @@ public:
 			, InSequenceExtraRange { Leptons(0) }
 
 			, EnhancedBerzerk { false }
+
+			, AITargetingAirThroughATC { false }
 		{ }
 
 		virtual ~ExtData() = default;

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -2185,23 +2185,34 @@ DEFINE_HOOK(0x6F9C48, TechnoClass_SelectAutoTarget_FixAirSearching1, 0x5)
 {
 	if (!RulesExt::Global()->AITargetingAirThroughATC)
 		return 0;
-	R->EAX(AircraftTrackerClass::Instance.CurrentVector.Count);
-	return R->Origin() + 0x5;
+
+	return 0x6F9B8D;
 }
 
 DEFINE_HOOK(0x6F9B8D, TechnoClass_SelectAutoTarget_FixAirSearching2, 0x6)
 {
 	if (!RulesExt::Global()->AITargetingAirThroughATC)
 		return 0;
-	R->EAX(AircraftTrackerClass::Instance.CurrentVector.Items);
-	return R->Origin() + 0x6;
+
+	if (auto pTechno = AircraftTrackerClass::Instance.Get())
+	{
+		R->EDI(pTechno);
+		GET(TechnoClass*, pThis, ESI);
+		R->ECX(pThis->Owner);
+		return 0x6F9B9C;
+	}
+
+	return 0x6F9C56;
 }
 
 DEFINE_HOOK(0x6F9B7E, TechnoClass_SelectAutoTarget_FixAirSearching3, 0x5)
 {
 	if (!RulesExt::Global()->AITargetingAirThroughATC)
 		return 0;
-	R->EAX(AircraftTrackerClass::Instance.CurrentVector.Count);
+
+	GET(TechnoClass*, pThis, ESI);
+	AircraftTrackerClass::Instance.FillCurrentVector(pThis->GetCell(), 256);
+	R->EAX(114514);
 	return R->Origin() + 0x5;
 }
 

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -2181,39 +2181,29 @@ DEFINE_HOOK(0x701DAE, TechnoClass_ReceiveDamage_Berzerk, 0x6)
 
 #pragma region AITargetingAirThroughATC
 
-DEFINE_HOOK(0x6F9C48, TechnoClass_SelectAutoTarget_FixAirSearching1, 0x5)
+DEFINE_HOOK(0x6F9B7E, TechnoClass_SelectAutoTarget_FixAirSearching1, 0x5)
 {
-	if (!RulesExt::Global()->AITargetingAirThroughATC)
-		return 0;
-
-	return 0x6F9B8D;
+	return RulesExt::Global()->AITargetingAirThroughATC ? 0x6F9C56 : 0;
 }
 
-DEFINE_HOOK(0x6F9B8D, TechnoClass_SelectAutoTarget_FixAirSearching2, 0x6)
+DEFINE_HOOK(0x6F9D13, TechnoClass_SelectAutoTarget_FixAirSearching2, 0x7)
 {
+	enum { Ok = 0x6F9D13, NotOK = 0x6F9D93 };
+
 	if (!RulesExt::Global()->AITargetingAirThroughATC)
 		return 0;
 
-	if (auto pTechno = AircraftTrackerClass::Instance.Get())
-	{
-		R->EDI(pTechno);
-		GET(TechnoClass*, pThis, ESI);
-		R->ECX(pThis->Owner);
-		return 0x6F9B9C;
-	}
+	GET_STACK(int, canTargetRtti, STACK_OFFSET(0x6C, -0x58));
+	GET(TechnoClass*, pTarget, EDI);
 
-	return 0x6F9C56;
-}
+	bool canTarget = false;
 
-DEFINE_HOOK(0x6F9B7E, TechnoClass_SelectAutoTarget_FixAirSearching3, 0x5)
-{
-	if (!RulesExt::Global()->AITargetingAirThroughATC)
-		return 0;
+	if ((canTargetRtti & 4) != 0)
+		canTarget = pTarget->LastLayer != Layer::Underground;
+	else
+		canTarget = pTarget->LastLayer == Layer::Ground;
 
-	GET(TechnoClass*, pThis, ESI);
-	AircraftTrackerClass::Instance.FillCurrentVector(pThis->GetCell(), 256);
-	R->EAX(114514);
-	return R->Origin() + 0x5;
+	return canTarget ? Ok : NotOK;
 }
 
 #pragma endregion

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -2206,16 +2206,6 @@ DEFINE_HOOK(0x6F9D13, TechnoClass_SelectAutoTarget_AIAirTargetingFix2, 0x7)
 	return canTarget ? Ok : NotOK;
 }
 
-DEFINE_HOOK(0x6F9D93, TEST, 0x5)
-{
-	GET(int, nIdx, EBX);
-	GET_STACK(TechnoClass*, pTarget, STACK_OFFSET(0x6C, -0x4C));
-
-	if (nIdx == TechnoClass::Array.Count - 1 && pTarget && pTarget->IsInAir())
-		Debug::LogAndMessage("Find target %s\n", pTarget->GetTechnoType()->ID);
-	return 0;
-}
-
 #pragma endregion
 
 // TODO Self-made impl

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -1,4 +1,4 @@
-﻿#include "Body.h"
+#include "Body.h"
 
 #include <EventClass.h>
 #include <SpawnManagerClass.h>
@@ -2179,18 +2179,18 @@ DEFINE_HOOK(0x701DAE, TechnoClass_ReceiveDamage_Berzerk, 0x6)
 
 #pragma endregion
 
-#pragma region AITargetingAirThroughATC
+#pragma region AIAirTargetingFix
 
-DEFINE_HOOK(0x6F9B7E, TechnoClass_SelectAutoTarget_FixAirSearching1, 0x5)
+DEFINE_HOOK(0x6F9B7E, TechnoClass_SelectAutoTarget_AIAirTargetingFix1, 0x5)
 {
-	return RulesExt::Global()->AITargetingAirThroughATC ? 0x6F9C56 : 0;
+	return RulesExt::Global()->AIAirTargetingFix ? 0x6F9C56 : 0;
 }
 
-DEFINE_HOOK(0x6F9D13, TechnoClass_SelectAutoTarget_FixAirSearching2, 0x7)
+DEFINE_HOOK(0x6F9D13, TechnoClass_SelectAutoTarget_AIAirTargetingFix2, 0x7)
 {
-	enum { Ok = 0x6F9D13, NotOK = 0x6F9D93 };
+	enum { Ok = 0x6F9D1C, NotOK = 0x6F9D93 };
 
-	if (!RulesExt::Global()->AITargetingAirThroughATC)
+	if (!RulesExt::Global()->AIAirTargetingFix)
 		return 0;
 
 	GET_STACK(int, canTargetRtti, STACK_OFFSET(0x6C, -0x58));
@@ -2204,6 +2204,16 @@ DEFINE_HOOK(0x6F9D13, TechnoClass_SelectAutoTarget_FixAirSearching2, 0x7)
 		canTarget = pTarget->LastLayer == Layer::Ground;
 
 	return canTarget ? Ok : NotOK;
+}
+
+DEFINE_HOOK(0x6F9D93, TEST, 0x5)
+{
+	GET(int, nIdx, EBX);
+	GET_STACK(TechnoClass*, pTarget, STACK_OFFSET(0x6C, -0x4C));
+
+	if (nIdx == TechnoClass::Array.Count - 1 && pTarget && pTarget->IsInAir())
+		Debug::LogAndMessage("Find target %s\n", pTarget->GetTechnoType()->ID);
+	return 0;
 }
 
 #pragma endregion

--- a/src/Ext/Techno/Hooks.Others.cpp
+++ b/src/Ext/Techno/Hooks.Others.cpp
@@ -2179,6 +2179,34 @@ DEFINE_HOOK(0x701DAE, TechnoClass_ReceiveDamage_Berzerk, 0x6)
 
 #pragma endregion
 
+#pragma region AITargetingAirThroughATC
+
+DEFINE_HOOK(0x6F9C48, TechnoClass_SelectAutoTarget_FixAirSearching1, 0x5)
+{
+	if (!RulesExt::Global()->AITargetingAirThroughATC)
+		return 0;
+	R->EAX(AircraftTrackerClass::Instance.CurrentVector.Count);
+	return R->Origin() + 0x5;
+}
+
+DEFINE_HOOK(0x6F9B8D, TechnoClass_SelectAutoTarget_FixAirSearching2, 0x6)
+{
+	if (!RulesExt::Global()->AITargetingAirThroughATC)
+		return 0;
+	R->EAX(AircraftTrackerClass::Instance.CurrentVector.Items);
+	return R->Origin() + 0x6;
+}
+
+DEFINE_HOOK(0x6F9B7E, TechnoClass_SelectAutoTarget_FixAirSearching3, 0x5)
+{
+	if (!RulesExt::Global()->AITargetingAirThroughATC)
+		return 0;
+	R->EAX(AircraftTrackerClass::Instance.CurrentVector.Count);
+	return R->Origin() + 0x5;
+}
+
+#pragma endregion
+
 // TODO Self-made impl
 
 


### PR DESCRIPTION
 2-105. AI索敌空军修复
原本游戏中，AI的脚本索敌只会查找飞机数组和单位数组中处于地面的单位，所以JJ空军不会被选为目标。
现在你可以通过以下选项改变这一点了。

[General]
AIAirTargetingFix=false      ；是否查找JJ空军。