### PR TITLE
底边栏修改：选择建筑时，以“攻速增益”显示替换“速度增益”显示

### DIFF
--- a/src/Ext/Sidebar/SelectedButton/SelectedButtonClass.cpp
+++ b/src/Ext/Sidebar/SelectedButton/SelectedButtonClass.cpp
@@ -241,36 +241,69 @@ void SelectedNotButtonClass::DrawInfo() const
 			DSurface::Composite->DrawText(buffer, &location, COLOR_WHITE);
 		}
 	}
-	else // InfoIconS
+	else if (this->ID == 2) // InfoIconS
 	{
-		double mult = 1.0;
-
-		if (const auto pFoot = abstract_cast<FootClass*, true>(pTechno))
-			mult = pFoot->SpeedMultiplier * TechnoExt::ExtMap.Find(pFoot)->AE.SpeedMultiplier * (pFoot->HasAbility(Ability::Faster) ? RulesClass::Instance->VeteranSpeed : 1.0);
-
-		int frame = 10;
-
-		if (mult - 1.0 > 1e-10)
-			frame = mult > 2.0 ? 14 : 13;
-		else if (mult - 1.0 < -1e-10)
-			frame = mult < 0.5 ? 12 : 11;
-
-		RectangleStruct rect { 0, 0, this->X + this->Width, this->Y + this->Height };
-		DSurface::Composite->DrawSHP(pSideExt->SelectedInfo_Palette.GetOrDefaultConvert(FileSystem::ANIM_PAL),
-			pSHP, frame, &position, &rect, BlitterFlags::bf_400, 0, 0, ZGradient::Ground, 1000, 0, 0, 0, 0, 0);
-
-		if (this->Hovering)
+		auto const whatAmI = pTechno->WhatAmI();
+		
+		if (whatAmI == AbstractType::Building)
 		{
-			auto location = Point2D { this->X + this->Width + 10, this->Y - 3 };
-			wchar_t buffer[0x20];
-			swprintf_s(buffer, GeneralUtils::LoadStringUnlessMissing("TIP:SpeedMult", L"SpeedMult:%5.2f"), mult);
-			RectangleStruct drawRect = Drawing::GetTextDimensions(buffer, location, 0, 3, 2);
-			location += Point2D { 4, 1 };
-			drawRect.Width += 8;
-			ColorStruct color { 0, 0, 0 };
-			DSurface::Composite->FillRectTrans(&drawRect, &color, 40);
-			DSurface::Composite->DrawRect(&drawRect, COLOR_WHITE);
-			DSurface::Composite->DrawText(buffer, &location, COLOR_WHITE);
+			const auto mult = pExt->AE.ROFMultiplier * (pTechno->HasAbility(Ability::ROF) ? RulesClass::Instance->VeteranROF : 1.0);
+			int frame = 0;
+	
+			if (mult - 1.0 > 1e-10)
+				frame = mult > 2.0 ? 2 : 1;
+			else if (mult - 1.0 < -1e-10)
+				frame = mult < 0.5 ? 4 : 3;
+	
+			RectangleStruct rect { 0, 0, this->X + this->Width, this->Y + this->Height };
+			DSurface::Composite->DrawSHP(pSideExt->SelectedInfo_Palette.GetOrDefaultConvert(FileSystem::ANIM_PAL),
+				pSHP, frame, &position, &rect, BlitterFlags::bf_400, 0, 0, ZGradient::Ground, 1000, 0, 0, 0, 0, 0);
+	
+			if (this->Hovering)
+			{
+				auto location = Point2D { this->X + this->Width + 10, this->Y - 3 };
+				wchar_t buffer[0x20];
+				swprintf_s(buffer, GeneralUtils::LoadStringUnlessMissing("TIP:ROFMult", L"ROFMult:%5.2f"), mult);
+				RectangleStruct drawRect = Drawing::GetTextDimensions(buffer, location, 0, 3, 2);
+				location += Point2D { 4, 1 };
+				drawRect.Width += 8;
+				ColorStruct color { 0, 0, 0 };
+				DSurface::Composite->FillRectTrans(&drawRect, &color, 40);
+				DSurface::Composite->DrawRect(&drawRect, COLOR_WHITE);
+				DSurface::Composite->DrawText(buffer, &location, COLOR_WHITE);
+			}
+		}
+		else
+		{
+			double mult = 1.0;
+	
+			if (const auto pFoot = abstract_cast<FootClass*, true>(pTechno))
+				mult = pFoot->SpeedMultiplier * TechnoExt::ExtMap.Find(pFoot)->AE.SpeedMultiplier * (pFoot->HasAbility(Ability::Faster) ? RulesClass::Instance->VeteranSpeed : 1.0);
+	
+			int frame = 10;
+	
+			if (mult - 1.0 > 1e-10)
+				frame = mult > 2.0 ? 14 : 13;
+			else if (mult - 1.0 < -1e-10)
+				frame = mult < 0.5 ? 12 : 11;
+	
+			RectangleStruct rect { 0, 0, this->X + this->Width, this->Y + this->Height };
+			DSurface::Composite->DrawSHP(pSideExt->SelectedInfo_Palette.GetOrDefaultConvert(FileSystem::ANIM_PAL),
+				pSHP, frame, &position, &rect, BlitterFlags::bf_400, 0, 0, ZGradient::Ground, 1000, 0, 0, 0, 0, 0);
+	
+			if (this->Hovering)
+			{
+				auto location = Point2D { this->X + this->Width + 10, this->Y - 3 };
+				wchar_t buffer[0x20];
+				swprintf_s(buffer, GeneralUtils::LoadStringUnlessMissing("TIP:SpeedMult", L"SpeedMult:%5.2f"), mult);
+				RectangleStruct drawRect = Drawing::GetTextDimensions(buffer, location, 0, 3, 2);
+				location += Point2D { 4, 1 };
+				drawRect.Width += 8;
+				ColorStruct color { 0, 0, 0 };
+				DSurface::Composite->FillRectTrans(&drawRect, &color, 40);
+				DSurface::Composite->DrawRect(&drawRect, COLOR_WHITE);
+				DSurface::Composite->DrawText(buffer, &location, COLOR_WHITE);
+			}
 		}
 	}
 }

--- a/整合包说明/额外功能说明.md
+++ b/整合包说明/额外功能说明.md
@@ -2432,7 +2432,7 @@ UIDescription.HoveredInfo=                   ; CSF条目，鼠标悬浮在底部
 - 关于可本地化内容：
   - 可以在csf中添加名为 `Status:XXXX` 的项目来定义显示的文本，其中 XXXX 为状态名，包括：Sleep/Attack/Move/QueueMove/Retreat/Guard/Sticky/Enter/Capture/Eaten/Harvest/AreaGuard/Return/Stop/Ambush/Hunt/Unload/Sabotage/Construction/Selling/Repair/Rescue/Missile/Harmless/Open/Patrol/Paradrop/AttackMove/Wait/Produce/Deactive/Locomotor/FollowGuard/Unknown/None
   - 可以在csf中添加名为 `TIP:AggressiveStance` 和 `TIP:ManualReloadAmmo` 的项目来分别重写鼠标悬浮在两个大按钮上时的说明
-  - 可以在csf中添加名为 `TIP:PowerMult` 、`TIP:ArmorMult` 和 `TIP:SpeedMult` 的项目来分别重写鼠标悬浮在三个状态标上时的说明
+  - 可以在csf中添加名为 `TIP:PowerMult` 、`TIP:ArmorMult` 、`TIP:SpeedMult` 和 `TIP:ROFMult` 的项目来分别重写鼠标悬浮在状态标上时的说明
 - 关于1个开关快捷键：
   - 开关快捷键默认名为 `Selected technos display` ，可以在csf中添加名为 `TXT_SELECTED_INFO` 和 `TXT_SELECTED_INFO_DESC` 的项目来分别重写其在快捷键页面中的选项名称和详细说明
 - 关于1个展开快捷键：


### PR DESCRIPTION
当选择的目标为建筑时，将“速度增益（SpeedMult）”替换为“攻速增益（ROFMult）”。
攻速增益使用的图标暂时与攻击力增益相同。
ROFMult的值越小，攻速越快。
<img width="300" height="113" alt="de92c9e347d301b68f1fbdb8d5959283" src="https://github.com/user-attachments/assets/36070e2f-cdbe-494a-9846-f35d8759c1d7" />
