### PR TITLE
自动建筑增加右键启用

### DIFF
--- a/src/Ext/Sidebar/Body.cpp
+++ b/src/Ext/Sidebar/Body.cpp
@@ -8,6 +8,7 @@
 std::unique_ptr<SidebarExt::ExtData> SidebarExt::Data = nullptr;
 
 SHPStruct* SidebarExt::TabProducingProgress[4];
+SHPStruct* SidebarExt::AutoBuildingMark[2];
 
 void SidebarExt::Allocate(SidebarClass* pThis)
 {

--- a/src/Ext/Sidebar/Body.h
+++ b/src/Ext/Sidebar/Body.h
@@ -37,6 +37,7 @@ public:
 	static IStream* g_pStm;
 
 	static SHPStruct* TabProducingProgress[4];
+	static SHPStruct* AutoBuildingMark[2];
 
 	static void Allocate(SidebarClass* pThis);
 	static void Remove(SidebarClass* pThis);

--- a/src/Ext/Sidebar/Hooks.cpp
+++ b/src/Ext/Sidebar/Hooks.cpp
@@ -21,6 +21,12 @@ DEFINE_HOOK(0x6A593E, SidebarClass_InitForHouse_AdditionalFiles, 0x5)
 		SidebarExt::TabProducingProgress[i] = GameCreate<SHPReference>(filename);
 	}
 
+	for (int i = 0; i < 2; i++)
+	{
+		sprintf_s(filename, "tab%02dabm.shp", i);
+		SidebarExt::AutoBuildingMark[i] = GameCreate<SHPReference>(filename);
+	}
+
 	return 0;
 }
 
@@ -35,11 +41,27 @@ DEFINE_HOOK(0x6A5EA1, SidebarClass_UnloadShapes_AdditionalFiles, 0x5)
 		}
 	}
 
+	for (int i = 0; i < 2; i++)
+	{
+		if (SidebarExt::AutoBuildingMark[i])
+		{
+			GameDelete(SidebarExt::AutoBuildingMark[i]);
+			SidebarExt::AutoBuildingMark[i] = nullptr;
+		}
+	}
+
 	return 0;
 }
 
-DEFINE_HOOK(0x6A6EB1, SidebarClass_DrawIt_ProducingProgress, 0x6)
+namespace
 {
+	int drawnTimes = 0;
+}
+
+DEFINE_HOOK(0x6A6EB1, SidebarClass_DrawIt, 0x6)
+{
+	drawnTimes++;
+
 	if (Phobos::UI::ProducingProgress_Show)
 	{
 		const auto pPlayer = HouseClass::CurrentPlayer;
@@ -81,6 +103,89 @@ DEFINE_HOOK(0x6A6EB1, SidebarClass_DrawIt_ProducingProgress, 0x6)
 						&sidebarRect, BlitterFlags::bf_400, 0, 0, ZGradient::Ground, 1000, 0, 0, 0, 0, 0);
 				}
 			}
+		}
+	}
+
+	auto drawAutoBuildingMark = [&](int tabIndex)
+		{
+			if (auto pShp = SidebarExt::AutoBuildingMark[tabIndex])
+			{
+				drawnTimes %= pShp->Frames;
+				const auto pSideExt = SideExt::ExtMap.Find(SideClass::Array.GetItem(HouseClass::CurrentPlayer->SideIndex));
+				const int XOffset = pSideExt->Sidebar_GDIPositions ? 29 : 32;
+				const int XBase = (pSideExt->Sidebar_GDIPositions ? 26 : 20);
+				const int YBase = 197;
+				const auto position = Point2D { XBase + tabIndex * XOffset, YBase };
+				RectangleStruct sidebarRect = DSurface::Sidebar->GetRect();
+				DSurface::Sidebar->DrawSHP(FileSystem::ANIM_PAL, pShp, drawnTimes, &position,
+					&sidebarRect, BlitterFlags::bf_400, 0, 0, ZGradient::Ground, 1000, 0, 0, 0, 0, 0);
+			}
+		};
+
+	if (Phobos::Config::AutomaticPlacingBuilding)
+	{
+		drawAutoBuildingMark(0);
+	}
+
+	if (Phobos::Config::AutomaticPlacingCombatBuilding)
+	{
+		drawAutoBuildingMark(1);
+	}
+
+	return 0;
+}
+
+// Add right click for structure and combat tab button.
+DEFINE_HOOK(0x6A4CEE, SidebarClass_InitTabButtons_RightButton, 0x5)
+{
+	GET(ShapeButtonClass*, pButton, ECX);
+
+	new (pButton) ShapeButtonClass();
+
+	GET(int, leftCount, EDI);
+
+	if (leftCount >= 3)
+	{
+		pButton->Flags |= GadgetFlag::RightPress | GadgetFlag::RightRelease;
+	}
+
+	return R->Origin() + 0x5;
+}
+
+DEFINE_HOOK(0x6A7904, SidebarClass_Update_ToggleAutoBuilding, 0x5)
+{
+	GET(int, keyCode, EAX);
+
+	int clickedTabIdx = keyCode - ((int)WWKey::Button | (int)WWKey::Button_IsRightClick | 203);
+
+	// Right clicked on the tab button.
+	if (clickedTabIdx == 0 || clickedTabIdx == 1)
+	{
+		auto& sideBar = SidebarClass::Instance;
+
+		if (clickedTabIdx != sideBar.ActiveTabIndex)
+		{
+			auto& pClickedButton = SidebarClass::TabButtons[clickedTabIdx];
+			pClickedButton.MarkRedraw();
+			pClickedButton.IsPressed = false;
+			pClickedButton.IsOn = false;
+		}
+
+		if (clickedTabIdx == 0)
+		{
+			Phobos::Config::AutomaticPlacingBuilding = !Phobos::Config::AutomaticPlacingBuilding;
+		}
+		else// if (clickedTabIdx == 1)
+		{
+			Phobos::Config::AutomaticPlacingCombatBuilding = !Phobos::Config::AutomaticPlacingCombatBuilding;
+		}
+
+		const int tabIndex = SidebarClass::Instance.ActiveTabIndex;
+
+		if (!tabIndex || tabIndex == 1)
+		{
+			SidebarClass::Instance.SidebarBackgroundNeedsRedraw = true;
+			SidebarClass::Instance.RepaintSidebar(tabIndex);
 		}
 	}
 

--- a/整合包说明/更新改动说明.md
+++ b/整合包说明/更新改动说明.md
@@ -78,6 +78,7 @@
  > - `( 4 )` 修复 `Locomotor=AdvancedDrive` 的车辆在倾斜时的绘制错误
  > - `( 4 )` 修复 `Phobos-build-48+4_11` 的更新后，出现潜在的能导致游戏卡死甚至崩溃的寻路问题
  > - `( 4 )` 修复 `Phobos-build-48+4_10` 的更新后，使用 `UpdateInLimbo.NormalPassenger` 会导致运输机内步兵消失的问题
+ > - `( 4 )` 新增自动放置建筑的按钮和开启状态显示
 
 ### 2026.4.6  `Phobos-build-48+4_10` -> `Phobos-build-48+4_11`
 

--- a/整合包说明/额外功能说明.md
+++ b/整合包说明/额外功能说明.md
@@ -2659,6 +2659,7 @@ AutoBuilding.Gap=1                           ; 整数型，建筑自动放置时
 ```
 
 - 拥有快捷键功能，位于 [控制] 面板，可以分别控制科技界面和防御界面的建筑能否自动放置
+- 拥有按钮功能，右键点击建筑和防御面板的按钮可以开关相应的自动放置建筑功能
 - 只有 `AutoBuilding=yes` 的建筑会受到快捷键影响而被禁止自动放置，而 `AutoBuilding=no` 的建筑不会因此而能够自动放置。默认开启状态
 
 ```{note}
@@ -2667,6 +2668,7 @@ AutoBuilding.Gap=1                           ; 整数型，建筑自动放置时
 - 关于1个开关快捷键：
   - 开关快捷键默认名为 `Toggle Auto Building` ，可以在csf中添加名为 `TXT_AUTO_BUILD` 和 `TXT_AUTO_BUILD_DESC` 的项目来分别重写其在快捷键页面中的选项名称和详细说明
   - 开关快捷键默认名为 `Toggle Auto Building Combat` ，可以在csf中添加名为 `TXT_AUTO_BUILD_COMBAT` 和 `TXT_AUTO_BUILD_COMBAT_DESC` 的项目来分别重写其在快捷键页面中的选项名称和详细说明
+- 自动建筑启用时，会在相应面板的按钮处绘制 `tab0xabm.shp` （其中x为0和1）。该shp优先从 `sidec0x.mix` 中读取
 ```
 
 ---


### PR DESCRIPTION
可以右键建筑和防御页面的页面按钮开关相应的AutoBuilding。
启用状态下会在相应按钮上绘制tab%02dabm.shp（x填0或1），会循环绘制该shp的每一帧。这个shp可以在sidec0x.mix中对每个Side分别指定。