### PR TITLE
通过强制巡航避免触地

### DIFF
--- a/src/Ext/Bullet/Trajectories/ActualTrajectories/MissileTrajectory.cpp
+++ b/src/Ext/Bullet/Trajectories/ActualTrajectories/MissileTrajectory.cpp
@@ -1,4 +1,4 @@
-﻿#include "MissileTrajectory.h"
+#include "MissileTrajectory.h"
 
 #include <Ext/Bullet/Body.h>
 
@@ -23,7 +23,7 @@ void MissileTrajectoryType::Serialize(T& Stm)
 		.Process(this->CruiseUnableRange)
 		.Process(this->CruiseAltitude)
 		.Process(this->CruiseAlongLevel)
-		.Process(this->CruiseOnlyBeneathAltitude)
+		.Process(this->ForceCruiseToAvoidGround)
 		.Process(this->SuicideAboveRange)
 		.Process(this->SuicideShortOfROT)
 		;
@@ -94,7 +94,7 @@ void MissileTrajectoryType::Read(CCINIClass* const pINI, const char* pSection)
 	this->CruiseUnableRange = Leptons(Math::max(128, this->CruiseUnableRange.Get()));
 	this->CruiseAltitude.Read(exINI, pSection, "Trajectory.Missile.CruiseAltitude");
 	this->CruiseAlongLevel.Read(exINI, pSection, "Trajectory.Missile.CruiseAlongLevel");
-	this->CruiseOnlyBeneathAltitude.Read(exINI, pSection, "Trajectory.Missile.CruiseOnlyBeneathAltitude");
+	this->ForceCruiseToAvoidGround.Read(exINI, pSection, "Trajectory.Missile.ForceCruiseToAvoidGround");
 	this->SuicideAboveRange.Read(exINI, pSection, "Trajectory.Missile.SuicideAboveRange");
 	this->SuicideShortOfROT.Read(exINI, pSection, "Trajectory.Missile.SuicideShortOfROT");
 }
@@ -517,56 +517,41 @@ bool MissileTrajectory::StandardVelocityChange()
 			}
 		}
 
-		// If in the cruise phase, the steering target will be set at the fixed height
-		if (pType->CruiseEnable)
+		const int cruiseAltitudeTarget = this->GetCruiseAltitude();
+		const auto horizontal = BulletExt::Coord2Point(targetLocation - pBullet->Location);
+		const double horizontalDistance = horizontal.Magnitude();
+		
+		// Force cruise to zero if going to hit the ground.
+		if (pType->ForceCruiseToAvoidGround
+			&& pType->CruiseAlongLevel && pType->TurningSpeed > BulletExt::Epsilon
+			&& pBullet->Location.Z < cruiseAltitudeTarget - pType->CruiseAltitude) // going to hit the ground
 		{
-			const int cruiseAltitudeTarget = this->GetCruiseAltitude();
-			const auto horizontal = BulletExt::Coord2Point(targetLocation - pBullet->Location);
-			const double horizontalDistance = horizontal.Magnitude();
-			bool lastFrameCruise = this->CruiseEnable;
-
-			// If cruise is still enabled after altitude check, apply cruise logic
-			if (pType->CruiseOnlyBeneathAltitude && pBullet->Location.Z <= cruiseAltitudeTarget
-				|| horizontalDistance > pType->CruiseUnableRange.Get())
+			const double ratio = this->MovingSpeed / horizontalDistance;
+			targetLocation.X = pBullet->Location.X + static_cast<int>(horizontal.X * ratio);
+			targetLocation.Y = pBullet->Location.Y + static_cast<int>(horizontal.Y * ratio);
+			targetLocation.Z = cruiseAltitudeTarget - pType->CruiseAltitude;
+		}
+		else
+		{
+			if (this->CruiseEnable)
 			{
-				this->CruiseEnable = true;
 				// The distance is still long, continue cruising
-				const double ratio = this->MovingSpeed / horizontalDistance;
-				targetLocation.X = pBullet->Location.X + static_cast<int>(horizontal.X * ratio);
-				targetLocation.Y = pBullet->Location.Y + static_cast<int>(horizontal.Y * ratio);
+				if (horizontalDistance > pType->CruiseUnableRange.Get())
+				{
+					const double ratio = this->MovingSpeed / horizontalDistance;
+					targetLocation.X = pBullet->Location.X + static_cast<int>(horizontal.X * ratio);
+					targetLocation.Y = pBullet->Location.Y + static_cast<int>(horizontal.Y * ratio);
 
-				// Smooth curve for low turning speed projectile
-				targetLocation.Z = (cruiseAltitudeTarget + pBullet->Location.Z) / 2;
-			}
-			else
-			{
-				this->CruiseEnable = false;
-
-				if (lastFrameCruise)
+					// Smooth curve for low turning speed projectile
+					targetLocation.Z = (cruiseAltitudeTarget + pBullet->Location.Z) / 2;
+				}
+				else
+				{
+					this->CruiseEnable = false;
 					this->LastDotProduct = 0.0;
+				}
 			}
 		}
-		// if (this->CruiseEnable)
-		// {
-		// 	const auto horizontal = BulletExt::Coord2Point(targetLocation - pBullet->Location);
-		// 	const double horizontalDistance = horizontal.Magnitude();
-
-		// 	// The distance is still long, continue cruising
-		// 	if (horizontalDistance > pType->CruiseUnableRange.Get())
-		// 	{
-		// 		const double ratio = this->MovingSpeed / horizontalDistance;
-		// 		targetLocation.X = pBullet->Location.X + static_cast<int>(horizontal.X * ratio);
-		// 		targetLocation.Y = pBullet->Location.Y + static_cast<int>(horizontal.Y * ratio);
-
-		// 		// Smooth curve for low turning speed projectile
-		// 		targetLocation.Z = (this->GetCruiseAltitude() + pBullet->Location.Z) / 2;
-		// 	}
-		// 	else
-		// 	{
-		// 		this->CruiseEnable = false;
-		// 		this->LastDotProduct = 0.0;
-		// 	}
-		// }
 	}
 
 	// Calculate new speed

--- a/src/Ext/Bullet/Trajectories/ActualTrajectories/MissileTrajectory.cpp
+++ b/src/Ext/Bullet/Trajectories/ActualTrajectories/MissileTrajectory.cpp
@@ -23,6 +23,7 @@ void MissileTrajectoryType::Serialize(T& Stm)
 		.Process(this->CruiseUnableRange)
 		.Process(this->CruiseAltitude)
 		.Process(this->CruiseAlongLevel)
+		.Process(this->CruiseOnlyBeneathAltitude)
 		.Process(this->SuicideAboveRange)
 		.Process(this->SuicideShortOfROT)
 		;
@@ -93,6 +94,7 @@ void MissileTrajectoryType::Read(CCINIClass* const pINI, const char* pSection)
 	this->CruiseUnableRange = Leptons(Math::max(128, this->CruiseUnableRange.Get()));
 	this->CruiseAltitude.Read(exINI, pSection, "Trajectory.Missile.CruiseAltitude");
 	this->CruiseAlongLevel.Read(exINI, pSection, "Trajectory.Missile.CruiseAlongLevel");
+	this->CruiseOnlyBeneathAltitude.Read(exINI, pSection, "Trajectory.Missile.CruiseOnlyBeneathAltitude");
 	this->SuicideAboveRange.Read(exINI, pSection, "Trajectory.Missile.SuicideAboveRange");
 	this->SuicideShortOfROT.Read(exINI, pSection, "Trajectory.Missile.SuicideShortOfROT");
 }
@@ -516,27 +518,55 @@ bool MissileTrajectory::StandardVelocityChange()
 		}
 
 		// If in the cruise phase, the steering target will be set at the fixed height
-		if (this->CruiseEnable)
+		if (pType->CruiseEnable)
 		{
+			const int cruiseAltitudeTarget = this->GetCruiseAltitude();
 			const auto horizontal = BulletExt::Coord2Point(targetLocation - pBullet->Location);
 			const double horizontalDistance = horizontal.Magnitude();
+			bool lastFrameCruise = this->CruiseEnable;
 
-			// The distance is still long, continue cruising
-			if (horizontalDistance > pType->CruiseUnableRange.Get())
+			// If cruise is still enabled after altitude check, apply cruise logic
+			if (pType->CruiseOnlyBeneathAltitude && pBullet->Location.Z <= cruiseAltitudeTarget
+				|| horizontalDistance > pType->CruiseUnableRange.Get())
 			{
+				this->CruiseEnable = true;
+				// The distance is still long, continue cruising
 				const double ratio = this->MovingSpeed / horizontalDistance;
 				targetLocation.X = pBullet->Location.X + static_cast<int>(horizontal.X * ratio);
 				targetLocation.Y = pBullet->Location.Y + static_cast<int>(horizontal.Y * ratio);
 
 				// Smooth curve for low turning speed projectile
-				targetLocation.Z = (this->GetCruiseAltitude() + pBullet->Location.Z) / 2;
+				targetLocation.Z = (cruiseAltitudeTarget + pBullet->Location.Z) / 2;
 			}
 			else
 			{
 				this->CruiseEnable = false;
-				this->LastDotProduct = 0.0;
+
+				if (lastFrameCruise)
+					this->LastDotProduct = 0.0;
 			}
 		}
+		// if (this->CruiseEnable)
+		// {
+		// 	const auto horizontal = BulletExt::Coord2Point(targetLocation - pBullet->Location);
+		// 	const double horizontalDistance = horizontal.Magnitude();
+
+		// 	// The distance is still long, continue cruising
+		// 	if (horizontalDistance > pType->CruiseUnableRange.Get())
+		// 	{
+		// 		const double ratio = this->MovingSpeed / horizontalDistance;
+		// 		targetLocation.X = pBullet->Location.X + static_cast<int>(horizontal.X * ratio);
+		// 		targetLocation.Y = pBullet->Location.Y + static_cast<int>(horizontal.Y * ratio);
+
+		// 		// Smooth curve for low turning speed projectile
+		// 		targetLocation.Z = (this->GetCruiseAltitude() + pBullet->Location.Z) / 2;
+		// 	}
+		// 	else
+		// 	{
+		// 		this->CruiseEnable = false;
+		// 		this->LastDotProduct = 0.0;
+		// 	}
+		// }
 	}
 
 	// Calculate new speed

--- a/src/Ext/Bullet/Trajectories/ActualTrajectories/MissileTrajectory.h
+++ b/src/Ext/Bullet/Trajectories/ActualTrajectories/MissileTrajectory.h
@@ -20,6 +20,7 @@ public:
 		, CruiseUnableRange { Leptons(1280) }
 		, CruiseAltitude { 800 }
 		, CruiseAlongLevel { false }
+		, CruiseOnlyBeneathAltitude { false }
 		, SuicideAboveRange { -3.0 }
 		, SuicideShortOfROT { false }
 	{ }
@@ -36,6 +37,7 @@ public:
 	Valueable<Leptons> CruiseUnableRange;
 	Valueable<int> CruiseAltitude;
 	Valueable<bool> CruiseAlongLevel;
+	Valueable<bool> CruiseOnlyBeneathAltitude;
 	Valueable<double> SuicideAboveRange;
 	Valueable<bool> SuicideShortOfROT;
 

--- a/src/Ext/Bullet/Trajectories/ActualTrajectories/MissileTrajectory.h
+++ b/src/Ext/Bullet/Trajectories/ActualTrajectories/MissileTrajectory.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "../PhobosActualTrajectory.h"
 
@@ -20,7 +20,7 @@ public:
 		, CruiseUnableRange { Leptons(1280) }
 		, CruiseAltitude { 800 }
 		, CruiseAlongLevel { false }
-		, CruiseOnlyBeneathAltitude { false }
+		, ForceCruiseToAvoidGround { false }
 		, SuicideAboveRange { -3.0 }
 		, SuicideShortOfROT { false }
 	{ }
@@ -37,7 +37,7 @@ public:
 	Valueable<Leptons> CruiseUnableRange;
 	Valueable<int> CruiseAltitude;
 	Valueable<bool> CruiseAlongLevel;
-	Valueable<bool> CruiseOnlyBeneathAltitude;
+	Valueable<bool> ForceCruiseToAvoidGround;
 	Valueable<double> SuicideAboveRange;
 	Valueable<bool> SuicideShortOfROT;
 

--- a/整合包说明/更新改动说明.md
+++ b/整合包说明/更新改动说明.md
@@ -75,7 +75,7 @@
 
 ### 2026.??.??  `Phobos-build-48+4_11` -> `Phobos-build-48+4_12`
 
- > - `( 4 )` 新增 `Trajectory.Missile.CruiseOnlyBeneathAltitude` 选项，用于控制导弹巡航是否仅在高度低于 `CruiseAltitude` 时启用
+ > - `( 4 )` 新增 `Trajectory.Missile.ForceCruiseToAvoidGround` 选项，通过强制巡航避免触地
  > - `( 4 )` 修复 `Locomotor=AdvancedDrive` 的车辆在倾斜时的绘制错误
  > - `( 4 )` 修复 `Phobos-build-48+4_11` 的更新后，出现潜在的能导致游戏卡死甚至崩溃的寻路问题
  > - `( 4 )` 修复 `Phobos-build-48+4_10` 的更新后，使用 `UpdateInLimbo.NormalPassenger` 会导致运输机内步兵消失的问题

--- a/整合包说明/更新改动说明.md
+++ b/整合包说明/更新改动说明.md
@@ -75,7 +75,7 @@
 
 ### 2026.??.??  `Phobos-build-48+4_11` -> `Phobos-build-48+4_12`
 
- > - `( 4 )` 新增 `Trajectory.Missile.CruiseEnable_BeneathAltitudeOnly` 选项，用于控制导弹巡航是否仅在高度低于 `CruiseAltitude` 时启用
+ > - `( 4 )` 新增 `Trajectory.Missile.CruiseOnlyBeneathAltitude` 选项，用于控制导弹巡航是否仅在高度低于 `CruiseAltitude` 时启用
  > - `( 4 )` 修复 `Locomotor=AdvancedDrive` 的车辆在倾斜时的绘制错误
  > - `( 4 )` 修复 `Phobos-build-48+4_11` 的更新后，出现潜在的能导致游戏卡死甚至崩溃的寻路问题
  > - `( 4 )` 修复 `Phobos-build-48+4_10` 的更新后，使用 `UpdateInLimbo.NormalPassenger` 会导致运输机内步兵消失的问题

--- a/整合包说明/更新改动说明.md
+++ b/整合包说明/更新改动说明.md
@@ -75,6 +75,7 @@
 
 ### 2026.??.??  `Phobos-build-48+4_11` -> `Phobos-build-48+4_12`
 
+ > - `( 4 )` 新增 `Trajectory.Missile.CruiseEnable_BeneathAltitudeOnly` 选项，用于控制导弹巡航是否仅在高度低于 `CruiseAltitude` 时启用
  > - `( 4 )` 修复 `Locomotor=AdvancedDrive` 的车辆在倾斜时的绘制错误
  > - `( 4 )` 修复 `Phobos-build-48+4_11` 的更新后，出现潜在的能导致游戏卡死甚至崩溃的寻路问题
  > - `( 4 )` 修复 `Phobos-build-48+4_10` 的更新后，使用 `UpdateInLimbo.NormalPassenger` 会导致运输机内步兵消失的问题

--- a/整合包说明/额外功能说明.md
+++ b/整合包说明/额外功能说明.md
@@ -1800,7 +1800,7 @@ Trajectory.Missile.CruiseEnable=no           ; 布尔值，抛体在达到 `Traj
 Trajectory.Missile.CruiseUnableRange=5.0     ; 浮点型，距离目标多远时结束巡航阶段，不再保持巡航高度，并开始朝向目标前进，如果在达到 `Trajectory.Missile.PreAimCoord` 时已经小于该值，会跳过巡航阶段（如果此值过小，则可能导致抛体永久处在巡航状态）
 Trajectory.Missile.CruiseAltitude=800        ; 整数型，抛体的巡航高度
 Trajectory.Missile.CruiseAlongLevel=no       ; 布尔值，抛体的巡航高度是否根据地形进行计算
-Trajectory.Missile.CruiseOnlyBeneathAltitude=no ; 布尔值，是否仅在抛体高度低于 `Trajectory.Missile.CruiseAltitude` 时启用巡航，若高于则按非巡航方式运行
+Trajectory.Missile.ForceCruiseToAvoidGround=no ; 布尔值，是否在抛体将要触地时强制巡航以避免触地，可以在不启用 `Trajectory.Missile.CruiseEnable` 的情况下生效，必须启用 `Trajectory.Missile.CruiseAlongLevel` 才会生效
 Trajectory.Missile.SuicideAboveRange=-3.0    ; 浮点型，抛体本体在飞行距离达到该值后直接自爆，为0代表不因此自爆，当设置为负数时其绝对值代表初始距离的倍数
 Trajectory.Missile.SuicideShortOfROT=no      ; 布尔值，抛体本体是否在发现转向能力不足时自爆
 ```

--- a/整合包说明/额外功能说明.md
+++ b/整合包说明/额外功能说明.md
@@ -1800,6 +1800,7 @@ Trajectory.Missile.CruiseEnable=no           ; 布尔值，抛体在达到 `Traj
 Trajectory.Missile.CruiseUnableRange=5.0     ; 浮点型，距离目标多远时结束巡航阶段，不再保持巡航高度，并开始朝向目标前进，如果在达到 `Trajectory.Missile.PreAimCoord` 时已经小于该值，会跳过巡航阶段（如果此值过小，则可能导致抛体永久处在巡航状态）
 Trajectory.Missile.CruiseAltitude=800        ; 整数型，抛体的巡航高度
 Trajectory.Missile.CruiseAlongLevel=no       ; 布尔值，抛体的巡航高度是否根据地形进行计算
+Trajectory.Missile.CruiseEnable_BeneathAltitudeOnly=no ; 布尔值，是否仅在抛体高度低于 `Trajectory.Missile.CruiseAltitude` 时启用巡航，若高于则按非巡航方式运行
 Trajectory.Missile.SuicideAboveRange=-3.0    ; 浮点型，抛体本体在飞行距离达到该值后直接自爆，为0代表不因此自爆，当设置为负数时其绝对值代表初始距离的倍数
 Trajectory.Missile.SuicideShortOfROT=no      ; 布尔值，抛体本体是否在发现转向能力不足时自爆
 ```

--- a/整合包说明/额外功能说明.md
+++ b/整合包说明/额外功能说明.md
@@ -1800,7 +1800,7 @@ Trajectory.Missile.CruiseEnable=no           ; 布尔值，抛体在达到 `Traj
 Trajectory.Missile.CruiseUnableRange=5.0     ; 浮点型，距离目标多远时结束巡航阶段，不再保持巡航高度，并开始朝向目标前进，如果在达到 `Trajectory.Missile.PreAimCoord` 时已经小于该值，会跳过巡航阶段（如果此值过小，则可能导致抛体永久处在巡航状态）
 Trajectory.Missile.CruiseAltitude=800        ; 整数型，抛体的巡航高度
 Trajectory.Missile.CruiseAlongLevel=no       ; 布尔值，抛体的巡航高度是否根据地形进行计算
-Trajectory.Missile.CruiseEnable_BeneathAltitudeOnly=no ; 布尔值，是否仅在抛体高度低于 `Trajectory.Missile.CruiseAltitude` 时启用巡航，若高于则按非巡航方式运行
+Trajectory.Missile.CruiseOnlyBeneathAltitude=no ; 布尔值，是否仅在抛体高度低于 `Trajectory.Missile.CruiseAltitude` 时启用巡航，若高于则按非巡航方式运行
 Trajectory.Missile.SuicideAboveRange=-3.0    ; 浮点型，抛体本体在飞行距离达到该值后直接自爆，为0代表不因此自爆，当设置为负数时其绝对值代表初始距离的倍数
 Trajectory.Missile.SuicideShortOfROT=no      ; 布尔值，抛体本体是否在发现转向能力不足时自爆
 ```


### PR DESCRIPTION
Trajectory.Missile.ForceCruiseToAvoidGround=no ; 布尔值，是否在抛体将要触地时强制巡航以避免触地，可以在不启用 `Trajectory.Missile.CruiseEnable` 的情况下生效，必须启用 `Trajectory.Missile.CruiseAlongLevel` 才会生效

请帮忙看看这个小于号对不对
&& pBullet->Location.Z < cruiseAltitudeTarget - pType->CruiseAltitude) // going to hit the ground